### PR TITLE
add line-colors for VOR, OÖVV and SVV [AT]

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,4 +1,6 @@
 shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,shape
+brb,S4,bayerische-regiobahn,4-81-s4,#9762b2,#ffffff,pill
+brb,RE5,bayerische-regiobahn,brb-re5,#004080,#ffffff,rectangle
 gaby,RB86,go-ahead-bayern-gmbh,rb-86,#77aed2,#ffffff,rectangle
 gaby,RB87,go-ahead-bayern-gmbh,rb-87,#77aed2,#ffffff,rectangle
 gaby,RB89,go-ahead-bayern-gmbh,rb-89,#006da7,#ffffff,rectangle
@@ -61,6 +63,23 @@ nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,rectangle
 nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,rectangle
 nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,rectangle
 nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,rectangle
+ooevv-linz-linien,3,linz-linien-ag-strassenbahn-stadt-linz,8-810031-3,#a3238e,#ffffff,rectangle
+ooevv-linz-linien,4,linz-linien-ag-strassenbahn-stadt-linz,8-810031-4,#c40352,#ffffff,rectangle
+ooevv-oebb,S1,osterreichische-bundesbahnen,4-81-1-1589920-5372014,#ee7f00,#ffffff,rectangle-rounded-corner
+ooevv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1589920-5372014,#0098a1,#ffffff,rectangle-rounded-corner
+ooevv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1589920-5372014,#342980,#ffffff,rectangle-rounded-corner
+ooevv-oebb,S4,osterreichische-bundesbahnen,4-81-4-1589920-5372014,#a4ba00,#ffffff,rectangle-rounded-corner
+ooevv-stern-hafferl,S5,stern-hafferl-verkehrs-gmbh,4-810008-5,#e2007a,#ffffff,rectangle-rounded-corner
+sob,RB45,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-45,#6cc3d9,#ffffff,rectangle
+svv-oebb,R3,osterreichische-bundesbahnen,r-3,#9dba3b,#ffffff,rectangle-rounded-corner
+svv-oebb,R9,osterreichische-bundesbahnen,r-9,#dbbe2b,#ffffff,rectangle-rounded-corner
+svv-oebb,R21,osterreichische-bundesbahnen,r-21,#42b3ca,#ffffff,rectangle-rounded-corner
+svv-oebb,REX3,osterreichische-bundesbahnen,rex-3,#78c257,#ffffff,rectangle-rounded-corner
+svv-oebb,REX21,osterreichische-bundesbahnen,rex-21,#f6861f,#ffffff,rectangle-rounded-corner
+svv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1451275-5318936,#28ab48,#ffffff,rectangle-rounded-corner
+svv-slb,R33,salzburger-lokalbahnen,,#b93146,#ffffff,rectangle-rounded-corner
+svv-slb,S1,salzburger-lokalbahnen,4-810007-1,#b4193c,#ffffff,rectangle-rounded-corner
+svv-slb,S11,salzburger-lokalbahnen,4-810007-11,#b4193c,#ffffff,rectangle-rounded-corner
 vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,pill
 vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,pill
 vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,pill
@@ -77,6 +96,22 @@ vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,pill
 vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,pill
 vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,pill
 vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,pill
+vor-oebb,S1,osterreichische-bundesbahnen,4-81-1-1821578-5360392,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S2,osterreichische-bundesbahnen,4-81-2-1821578-5360392,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S3,osterreichische-bundesbahnen,4-81-3-1821578-5360392,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S4,osterreichische-bundesbahnen,4-81-4-1821578-5360392,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S7,osterreichische-bundesbahnen,4-81-7-1822664-5362609,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S40,osterreichische-bundesbahnen,4-81-40,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S45,osterreichische-bundesbahnen,4-81-45,#c8d200,#ffffff,rectangle-rounded-corner
+vor-oebb,S50,osterreichische-bundesbahnen,4-81-50-1817428-5361639,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S60,osterreichische-bundesbahnen,4-81-60,#0097d5,#ffffff,rectangle-rounded-corner
+vor-oebb,S80,osterreichische-bundesbahnen,4-81-80,#0097d5,#ffffff,rectangle-rounded-corner
+vor-wl,18,wiener-linien,8-810009-18,#c00808,#ffffff,rectangle
+vor-wl,U1,wiener-linien,7-810009-1,#e3000f,#ffffff,rectangle
+vor-wl,U2,wiener-linien,7-810009-2,#a862a4,#ffffff,rectangle
+vor-wl,U3,wiener-linien,7-810009-3,#ef7c00,#ffffff,rectangle
+vor-wl,U4,wiener-linien,7-810009-4,#00963f,#ffffff,rectangle
+vor-wl,U6,wiener-linien,7-810009-6,#9d6830,#ffffff,rectangle
 vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,rectangle-rounded-corner
 vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,rectangle-rounded-corner
 vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,rectangle-rounded-corner
@@ -124,3 +159,4 @@ vvs-ssb-stadtbahn,U6,,8-vvs020-u6,#ed028c,#ffffff,rectangle
 vvs-ssb-stadtbahn,U7,,8-vvs020-u7,#0ab38d,#ffffff,rectangle
 vvs-ssb-stadtbahn,U8,,8-vvs020-u8,#fed304,#000000,rectangle
 vvs-ssb-stadtbahn,U9,,8-vvs020-u9,#bfb678,#000000,rectangle
+vvt-oebb,S8,osterreichische-bundesbahnen,4-81-8-1341673-5283199,#25aae1,#ffffff,rectangle-rounded-corner

--- a/sources.json
+++ b/sources.json
@@ -128,6 +128,76 @@
         ]
     },
     {
+        "shortOperatorName": "ooevv-linz-linien",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan Linz AG Linien",
+                "source": "https://www.linzag.at/media/dokumente/linien_1/infomaterial_1/linien-linienfahrplan.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "ooevv-oebb",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan OÖVV",
+                "source": "https://www.oebb.at/dam/jcr:562c11c9-4da3-4253-8623-28601d77e346/liniennetz_ooe.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "ooevv-stern-hafferl",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan OÖVV",
+                "source": "https://www.oebb.at/dam/jcr:562c11c9-4da3-4253-8623-28601d77e346/liniennetz_ooe.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "svv-oebb",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan SVV",
+                "source": "https://salzburg-verkehr.at/download/bahnnetz-land-salzburg/?wpdmdl=32234&refresh=6501827b0c3a01694597755"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "svv-slb",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan SVV",
+                "source": "https://salzburg-verkehr.at/download/bahnnetz-land-salzburg/?wpdmdl=32234&refresh=6501827b0c3a01694597755"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "vbb-db-sbahn",
         "contributors": [
             {
@@ -138,6 +208,34 @@
             {
                 "name": "Netzplan S-Bahn Berlin",
                 "source": "https://sbahn.berlin/liniennetz/"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "vor-oebb",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan VOR",
+                "source": "https://www.vor.at/fileadmin/CONTENT/Downloads/Plaene/Bahnnetz_Plaene/Bahnnetz_Wien_NOE_BGLD_2023.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "vor-wl",
+        "contributors": [
+            {
+                "github": "rnewhost"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan Wiener Linien",
+                "source": "https://www.wienerlinien.at/media/files/2016/gesamtnetzplan_wien_176236.pdf"
             }
         ]
     },


### PR DESCRIPTION
Adds the line colours for all available tram, subway, suburban and regional lines in the VOR (Verkehrsverbund Ostregion), OÖVV (Öberösterreichischer Verkehrsverbund) und SVV (Salzburger Verkehrsverbund).

Line-colors can be found here:
vor-oebb: https://www.vor.at/fileadmin/CONTENT/Downloads/Plaene/Bahnnetz_Plaene/Bahnnetz_Wien_NOE_BGLD_2023.pdf
vor-wl: https://www.wienerlinien.at/media/files/2016/gesamtnetzplan_wien_176236.pdf
ooevv-oebb & ooebb-stern-hafferl: https://www.oebb.at/dam/jcr:562c11c9-4da3-4253-8623-28601d77e346/liniennetz_ooe.pdf
ooevv-linz-linien: https://www.linzag.at/media/dokumente/linien_1/infomaterial_1/linien-linienfahrplan.pdf
svv: https://salzburg-verkehr.at/download/bahnnetz-land-salzburg/?wpdmdl=32234&refresh=6501827b0c3a01694597755
svv lines S4, RB45 und RE5: https://www.mvg.de/dam/jcr:de41cb75-e77c-489c-b8c9-429b0111fc02/Bahnland-Bayern-Liniennetzplan.pdf