### PR TITLE
Add colors for VVO and ZVON rail and tram lines

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -193,15 +193,6 @@ vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,,pill
 vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,,pill
 vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,,pill
 vvo-db-sbd,S 8,db-regio-ag-sudost,8010006,#2d92ad,#ffffff,,pill
-vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,,rectangle
-vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,,rectangle
-vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,,rectangle
-vvs-db-sbs,S3,db-regio-ag-s-bahn-stuttgart,4-800643-3,#f36e31,#ffffff,,rectangle
-vvs-db-sbs,S4,db-regio-ag-s-bahn-stuttgart,4-800643-4,#0166b3,#ffffff,,rectangle
-vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle
-vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle
-vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle
-vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle
 vvo-tram,1,,8-voe011-1,#e30018,#ffffff,,rectangle-rounded-corner
 vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,,rectangle-rounded-corner
 vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,,rectangle-rounded-corner
@@ -215,6 +206,15 @@ vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner
 vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner
 vvo-tram,13,,8-voe011-13,#fdc300,#000000,,rectangle-rounded-corner
 vvo-tram,20,,8-voe011-20,#000000,#ffffff,,rectangle-rounded-corner
+vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,,rectangle
+vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,,rectangle
+vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,,rectangle
+vvs-db-sbs,S3,db-regio-ag-s-bahn-stuttgart,4-800643-3,#f36e31,#ffffff,,rectangle
+vvs-db-sbs,S4,db-regio-ag-s-bahn-stuttgart,4-800643-4,#0166b3,#ffffff,,rectangle
+vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle
+vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle
+vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle
+vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle
 vvs-ssb-stadtbahn,U1,,8-vvs020-u1,#cd9c72,#000000,,rectangle
 vvs-ssb-stadtbahn,U11,,8-vvs020-u11,#939598,#ffffff,,rectangle
 vvs-ssb-stadtbahn,U12,,8-vvs020-u12,#85bbe5,#000000,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -114,8 +114,6 @@ vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,,pill
 vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,,pill
 vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,,pill
 vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,,pill
-vms-mrb,RB 30,mitteldeutsche-regiobahn,8010397,#ed9126,#ffffff,,rectangle
-vms-mrb,RE 3,mitteldeutsche-regiobahn,8010085,#0093d4,#ffffff,,rectangle
 vgn-db-sbn,S 1,db-regio-ag-bayern,4-800721-1,#92292e,#ffffff,,rectangle
 vgn-db-sbn,S 2,db-regio-ag-bayern,4-800721-2,#4dbd38,#ffffff,,rectangle
 vgn-db-sbn,S 3,db-regio-ag-bayern,4-800721-3,#f1471d,#ffffff,,rectangle
@@ -130,6 +128,8 @@ vgn-vag-tram,8,,8-vanstr-8,#32bdf2,#ffffff,,rectangle
 vgn-vag-ubahn,U 1,,7-vanuba-1,#1c62aa,#ffffff,,rectangle
 vgn-vag-ubahn,U 2,,7-vanuba-2,#ed1c24,#ffffff,,rectangle
 vgn-vag-ubahn,U 3,,7-vanuba-3,#4dc2bb,#ffffff,,rectangle
+vms-mrb,RB 30,mitteldeutsche-regiobahn,8010397,#ed9126,#ffffff,,rectangle
+vms-mrb,RE 3,mitteldeutsche-regiobahn,8010085,#0093d4,#ffffff,,rectangle
 vor-oebb,S1,osterreichische-bundesbahnen,4-81-1-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S2,osterreichische-bundesbahnen,4-81-2-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S3,osterreichische-bundesbahnen,4-81-3-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -111,6 +111,19 @@ vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,pill
 vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,pill
 vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,pill
 vvo-db-sbd,S 8,db-regio-ag-sudost,8010006,#2d92ad,#ffffff,pill
+vvo-tram,1,,8-voe011-1,#e30018,#ffffff,rectangle-rounded-corner
+vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,rectangle-rounded-corner
+vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,rectangle-rounded-corner
+vvo-tram,4,,8-voe011-4,#c9061a,#ffffff,rectangle-rounded-corner
+vvo-tram,6,,8-voe011-6,#ffdd00,#000000,rectangle-rounded-corner
+vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,rectangle-rounded-corner
+vvo-tram,8,,8-voe011-8,#229133,#ffffff,rectangle-rounded-corner
+vvo-tram,9,,8-voe011-9,#93c355,#ffffff,rectangle-rounded-corner
+vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,rectangle-rounded-corner
+vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,rectangle-rounded-corner
+vvo-tram,12,,8-voe011-12,#006b42,#ffffff,rectangle-rounded-corner
+vvo-tram,13,,8-voe011-13,#fdc300,#000000,rectangle-rounded-corner
+vvo-tram,20,,8-voe011-20,#000000,#ffffff,rectangle-rounded-corner
 vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,rectangle
 vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,rectangle
 vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,143 +1,143 @@
-shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,shape
-gaby,RB86,go-ahead-bayern-gmbh,rb-86,#77aed2,#ffffff,rectangle
-gaby,RB87,go-ahead-bayern-gmbh,rb-87,#77aed2,#ffffff,rectangle
-gaby,RB89,go-ahead-bayern-gmbh,rb-89,#006da7,#ffffff,rectangle
-gaby,RB92,go-ahead-bayern-gmbh,rb-92,#f28f8e,#ffffff,rectangle
-gaby,RE72,go-ahead-bayern-gmbh,re-72,#ef7c00,#ffffff,rectangle
-gaby,RE80,go-ahead-bayern-gmbh,re-80,#006da7,#ffffff,rectangle
-gaby,RE89,go-ahead-bayern-gmbh,re-89,#006da7,#ffffff,rectangle
-gaby,RE9,go-ahead-bayern-gmbh,re-9,#006da7,#ffffff,rectangle
-gaby,RE96,go-ahead-bayern-gmbh,re-96,#f9b000,#ffffff,rectangle
-kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,rectangle-rounded-corner
-kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,rectangle-rounded-corner
-kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,rectangle-rounded-corner
-kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,rectangle-rounded-corner
-kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,rectangle-rounded-corner
-kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,rectangle-rounded-corner
-kvv-avg,S11,albtal-verkehrs-gesellschaft-mbh,4-a6s11-11,#00a76d,#ffffff,rectangle-rounded-corner
-kvv-avg,S12,albtal-verkehrs-gesellschaft-mbh,4-a6s12-12,#00a76d,#ffffff,rectangle-rounded-corner
-kvv-avg,S51,albtal-verkehrs-gesellschaft-mbh,4-a6s51-51,#f69795,#ffffff,rectangle-rounded-corner
-kvv-avg,S52,albtal-verkehrs-gesellschaft-mbh,4-a6s52-52,#f69795,#ffffff,rectangle-rounded-corner
-kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#fff,#000,rectangle-rounded-corner
-kvv-vbk,1,,8-kvv021-1,#ed1c24,#ffffff,rectangle
-kvv-vbk,2,,8-kvv021-2,#0071bc,#ffffff,rectangle
-kvv-vbk,3,,8-kvv021-3,#947139,#ffffff,rectangle
-kvv-vbk,4,,8-kvv021-4,#ffcb04,#000000,rectangle
-kvv-vbk,5,,8-kvv021-5,#00c0f3,#ffffff,rectangle
-kvv-vbk,16,,8-kvv021-16,#660000,#ffffff,rectangle
-kvv-vbk,17,,8-kvv021-17,#660000,#ffffff,rectangle
-kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,rectangle
-kvv-vbk,E,,8-kvv021-e,#fff,#000,rectangle
-kvv-vbk,NL1,,8-kvv021-nl1,#ed1c24,#ffffff,rectangle
-kvv-vbk,NL2,,8-kvv021-nl2,#0071bc,#ffffff,rectangle
-mvv-db-sbm,S1,db-regio-ag-s-bahn-munchen,4-800725-1,#1fbce6,#ffffff,pill
-mvv-db-sbm,S2,db-regio-ag-s-bahn-munchen,4-800725-2,#79b833,#ffffff,pill
-mvv-db-sbm,S20,db-regio-ag-s-bahn-munchen,4-800725-20,#f05972,#ffffff,pill
-mvv-db-sbm,S3,db-regio-ag-s-bahn-munchen,4-800725-3,#962a85,#ffffff,pill
-mvv-db-sbm,S4,db-regio-ag-s-bahn-munchen,4-800725-4,#e41f28,#ffffff,pill
-mvv-db-sbm,S6,db-regio-ag-s-bahn-munchen,4-800725-6,#008f5c,#ffffff,pill
-mvv-db-sbm,S7,db-regio-ag-s-bahn-munchen,4-800725-7,#8a372f,#ffffff,pill
-mvv-db-sbm,S8,db-regio-ag-s-bahn-munchen,4-800725-8,#2d2b29,#ffcd01,pill
-nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,rectangle
-nah-sh,RB 61,nordbahn-eisenbahngesellschaft,nbe-rb61,#174094,#ffffff,rectangle
-nah-sh,RB 62,db-regio-ag-nord,rb-62,#00aeca,#000000,rectangle
-nah-sh,RB 63,nordbahn-eisenbahngesellschaft,nbe-rb63,#ffdc00,#000000,rectangle
-nah-sh,RB 64,db-regio-ag-nord,rb-64,#c2d0eb,#000000,rectangle
-nah-sh,RB 65,norddeutsche-eisenbahn-gesellschaft,neg-rb65,#dedd00,#000000,rectangle
-nah-sh,RB 66,norddeutsche-eisenbahn-gesellschaft,neg-rb66,#798e0e,#ffffff,rectangle
-nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,rectangle
-nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,rectangle
-nah-sh,RB 71,nordbahn-eisenbahngesellschaft,nbe-rb71,#008bd2,#ffffff,rectangle
-nah-sh,RE 72,db-regio-ag-nord,re-72,#adce6d,#000000,rectangle
-nah-sh,RB 73,db-regio-ag-nord,rb-73,#008c57,#ffffff,rectangle
-nah-sh,RE 74,db-regio-ag-nord,re-74,#0069b4,#ffffff,rectangle
-nah-sh,RB 75,db-regio-ag-nord,rb-75,#ba731a,#ffffff,rectangle
-nah-sh,RB 76,erixx,erx-rb76,#ffdc00,#000000,rectangle
-nah-sh,RE 8,db-regio-ag-nord,re-8,#a3d9f0,#000000,rectangle
-nah-sh,RE 80,db-regio-ag-nord,re-80,#d9338a,#ffffff,rectangle
-nah-sh,RB 81,db-regio-ag-nord,rb-81,#798e0e,#ffffff,rectangle
-nah-sh,RB 82,nordbahn-eisenbahngesellschaft,nbe-rb82,#9c9c9c,#ffffff,rectangle
-nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,rectangle
-nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,rectangle
-nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,rectangle
-nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,rectangle
-vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,pill
-vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,pill
-vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,pill
-vbb-db-sbahn,S26,s-bahn-berlin,4-08-26,#047939,#ffffff,pill
-vbb-db-sbahn,S3,s-bahn-berlin,4-08-3,#026597,#ffffff,pill
-vbb-db-sbahn,S41,s-bahn-berlin,4-08-41,#aa3c1f,#ffffff,pill
-vbb-db-sbahn,S42,s-bahn-berlin,4-08-42,#ba622d,#ffffff,pill
-vbb-db-sbahn,S45,s-bahn-berlin,4-08-45,#aa3c1f,#ffffff,pill
-vbb-db-sbahn,S46,s-bahn-berlin,4-08-46,#ca8539,#ffffff,pill
-vbb-db-sbahn,S47,s-bahn-berlin,4-08-47,#ca8539,#ffffff,pill
-vbb-db-sbahn,S5,s-bahn-berlin,4-08-5,#ea561c,#ffffff,pill
-vbb-db-sbahn,S7,s-bahn-berlin,4-08-7,#764d9a,#ffffff,pill
-vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,pill
-vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,pill
-vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,pill
-vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,pill
-vms-mrb,RB 30,mitteldeutsche-regiobahn,8010397,#ed9126,#ffffff,rectangle
-vms-mrb,RE 3,mitteldeutsche-regiobahn,8010085,#0093d4,#ffffff,rectangle
-vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,5,,8-vrs001-5,#a69dc8,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,12,,8-vrs001-12,#98c01e,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,13,,8-vrs001-13,#aa8567,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,15,,8-vrs001-15,#5aad31,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,16,,8-vrs001-16,#07ada5,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,17,,8-vrs001-17,#1e93d1,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,18,,8-vrs001-18,#85d1f5,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,61,stadtwerke-bonn,8-s3-61,#9ab831,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,62,stadtwerke-bonn,8-s3-62,#65a53b,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,63,stadtwerke-bonn,8-s3-63,#8bccf3,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,65,stadtwerke-bonn,8-s3-65,#c6cc2a,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,66,stadtwerke-bonn,8-s3-66,#d4417d,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,67,stadtwerke-bonn,8-s3-67,#e7a8c4,#ffffff,rectangle-rounded-corner
-vrs-stadtbahn,68,stadtwerke-bonn,8-s3-68,#cbaece,#ffffff,rectangle-rounded-corner
-vvo-db-regio,RB U28,db-regio-ag-sudost,5400003,#014d6f,#ffffff,pill
-vvo-db-regio,RB 31,db-regio-ag-nordost,8010089,#6ab023,#ffffff,rectangle
-vvo-db-regio,RB 33,db-regio-ag-sudost,8010089,#ec7797,#ffffff,rectangle
-vvo-db-regio,RB 71,db-regio-ag-sudost,8012959,#ad006f,#ffffff,rectangle
-vvo-db-regio,RB 72,db-regio-ag-sudost,8010163,#9c321b,#ffffff,rectangle
-vvo-db-regio,RE 15,db-regio-ag-nordost,8010177,#effd400,#000000,rectangle
-vvo-db-regio,RE 18,db-regio-ag-nordost,8010073,#ec7404,#ffffff,rectangle
-vvo-db-regio,RE 19,db-regio-ag-sudost,8010085,#00895d,#ffffff,rectangle
-vvo-db-regio,RE 50,db-regio-ag-sudost,8010085,#b60d1c,#ffffff,rectangle
-vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,pill
-vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,pill
-vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,pill
-vvo-db-sbd,S 8,db-regio-ag-sudost,8010006,#2d92ad,#ffffff,pill
-vvo-tram,1,,8-voe011-1,#e30018,#ffffff,rectangle-rounded-corner
-vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,rectangle-rounded-corner
-vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,rectangle-rounded-corner
-vvo-tram,4,,8-voe011-4,#c9061a,#ffffff,rectangle-rounded-corner
-vvo-tram,6,,8-voe011-6,#ffdd00,#000000,rectangle-rounded-corner
-vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,rectangle-rounded-corner
-vvo-tram,8,,8-voe011-8,#229133,#ffffff,rectangle-rounded-corner
-vvo-tram,9,,8-voe011-9,#93c355,#ffffff,rectangle-rounded-corner
-vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,rectangle-rounded-corner
-vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,rectangle-rounded-corner
-vvo-tram,12,,8-voe011-12,#006b42,#ffffff,rectangle-rounded-corner
-vvo-tram,13,,8-voe011-13,#fdc300,#000000,rectangle-rounded-corner
-vvo-tram,20,,8-voe011-20,#000000,#ffffff,rectangle-rounded-corner
-vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,rectangle
-vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,rectangle
-vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,rectangle
-vvs-db-sbs,S3,db-regio-ag-s-bahn-stuttgart,4-800643-3,#f36e31,#ffffff,rectangle
-vvs-db-sbs,S4,db-regio-ag-s-bahn-stuttgart,4-800643-4,#0166b3,#ffffff,rectangle
-vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,rectangle
-vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,rectangle
-vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,rectangle
-vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,rectangle
-zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,rectangle
-zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,rectangle
-zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,rectangle
-zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,rectangle
-zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,rectangle
-zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,rectangle
-zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,rectangle
-zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,rectangle
+shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,borderColor,shape
+gaby,RB86,go-ahead-bayern-gmbh,rb-86,#77aed2,#ffffff,,rectangle
+gaby,RB87,go-ahead-bayern-gmbh,rb-87,#77aed2,#ffffff,,rectangle
+gaby,RB89,go-ahead-bayern-gmbh,rb-89,#006da7,#ffffff,,rectangle
+gaby,RB92,go-ahead-bayern-gmbh,rb-92,#f28f8e,#ffffff,,rectangle
+gaby,RE72,go-ahead-bayern-gmbh,re-72,#ef7c00,#ffffff,,rectangle
+gaby,RE80,go-ahead-bayern-gmbh,re-80,#006da7,#ffffff,,rectangle
+gaby,RE89,go-ahead-bayern-gmbh,re-89,#006da7,#ffffff,,rectangle
+gaby,RE9,go-ahead-bayern-gmbh,re-9,#006da7,#ffffff,,rectangle
+gaby,RE96,go-ahead-bayern-gmbh,re-96,#f9b000,#ffffff,,rectangle
+kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
+kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner
+kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,,rectangle-rounded-corner
+kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,,rectangle-rounded-corner
+kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,,rectangle-rounded-corner
+kvv-avg,S11,albtal-verkehrs-gesellschaft-mbh,4-a6s11-11,#00a76d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S12,albtal-verkehrs-gesellschaft-mbh,4-a6s12-12,#00a76d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S51,albtal-verkehrs-gesellschaft-mbh,4-a6s51-51,#f69795,#ffffff,,rectangle-rounded-corner
+kvv-avg,S52,albtal-verkehrs-gesellschaft-mbh,4-a6s52-52,#f69795,#ffffff,,rectangle-rounded-corner
+kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#fff,#000,,rectangle-rounded-corner
+kvv-vbk,1,,8-kvv021-1,#ed1c24,#ffffff,,rectangle
+kvv-vbk,2,,8-kvv021-2,#0071bc,#ffffff,,rectangle
+kvv-vbk,3,,8-kvv021-3,#947139,#ffffff,,rectangle
+kvv-vbk,4,,8-kvv021-4,#ffcb04,#000000,,rectangle
+kvv-vbk,5,,8-kvv021-5,#00c0f3,#ffffff,,rectangle
+kvv-vbk,16,,8-kvv021-16,#660000,#ffffff,,rectangle
+kvv-vbk,17,,8-kvv021-17,#660000,#ffffff,,rectangle
+kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,,rectangle
+kvv-vbk,E,,8-kvv021-e,#fff,#000,,rectangle
+kvv-vbk,NL1,,8-kvv021-nl1,#ed1c24,#ffffff,,rectangle
+kvv-vbk,NL2,,8-kvv021-nl2,#0071bc,#ffffff,,rectangle
+mvv-db-sbm,S1,db-regio-ag-s-bahn-munchen,4-800725-1,#1fbce6,#ffffff,,pill
+mvv-db-sbm,S2,db-regio-ag-s-bahn-munchen,4-800725-2,#79b833,#ffffff,,pill
+mvv-db-sbm,S20,db-regio-ag-s-bahn-munchen,4-800725-20,#f05972,#ffffff,,pill
+mvv-db-sbm,S3,db-regio-ag-s-bahn-munchen,4-800725-3,#962a85,#ffffff,,pill
+mvv-db-sbm,S4,db-regio-ag-s-bahn-munchen,4-800725-4,#e41f28,#ffffff,,pill
+mvv-db-sbm,S6,db-regio-ag-s-bahn-munchen,4-800725-6,#008f5c,#ffffff,,pill
+mvv-db-sbm,S7,db-regio-ag-s-bahn-munchen,4-800725-7,#8a372f,#ffffff,,pill
+mvv-db-sbm,S8,db-regio-ag-s-bahn-munchen,4-800725-8,#2d2b29,#ffcd01,,pill
+nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,,rectangle
+nah-sh,RB 61,nordbahn-eisenbahngesellschaft,nbe-rb61,#174094,#ffffff,,rectangle
+nah-sh,RB 62,db-regio-ag-nord,rb-62,#00aeca,#000000,,rectangle
+nah-sh,RB 63,nordbahn-eisenbahngesellschaft,nbe-rb63,#ffdc00,#000000,,rectangle
+nah-sh,RB 64,db-regio-ag-nord,rb-64,#c2d0eb,#000000,,rectangle
+nah-sh,RB 65,norddeutsche-eisenbahn-gesellschaft,neg-rb65,#dedd00,#000000,,rectangle
+nah-sh,RB 66,norddeutsche-eisenbahn-gesellschaft,neg-rb66,#798e0e,#ffffff,,rectangle
+nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,,rectangle
+nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,,rectangle
+nah-sh,RB 71,nordbahn-eisenbahngesellschaft,nbe-rb71,#008bd2,#ffffff,,rectangle
+nah-sh,RE 72,db-regio-ag-nord,re-72,#adce6d,#000000,,rectangle
+nah-sh,RB 73,db-regio-ag-nord,rb-73,#008c57,#ffffff,,rectangle
+nah-sh,RE 74,db-regio-ag-nord,re-74,#0069b4,#ffffff,,rectangle
+nah-sh,RB 75,db-regio-ag-nord,rb-75,#ba731a,#ffffff,,rectangle
+nah-sh,RB 76,erixx,erx-rb76,#ffdc00,#000000,,rectangle
+nah-sh,RE 8,db-regio-ag-nord,re-8,#a3d9f0,#000000,,rectangle
+nah-sh,RE 80,db-regio-ag-nord,re-80,#d9338a,#ffffff,,rectangle
+nah-sh,RB 81,db-regio-ag-nord,rb-81,#798e0e,#ffffff,,rectangle
+nah-sh,RB 82,nordbahn-eisenbahngesellschaft,nbe-rb82,#9c9c9c,#ffffff,,rectangle
+nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,,rectangle
+nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,,rectangle
+nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,,rectangle
+nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,,rectangle
+vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,,pill
+vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,,pill
+vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,,pill
+vbb-db-sbahn,S26,s-bahn-berlin,4-08-26,#047939,#ffffff,,pill
+vbb-db-sbahn,S3,s-bahn-berlin,4-08-3,#026597,#ffffff,,pill
+vbb-db-sbahn,S41,s-bahn-berlin,4-08-41,#aa3c1f,#ffffff,,pill
+vbb-db-sbahn,S42,s-bahn-berlin,4-08-42,#ba622d,#ffffff,,pill
+vbb-db-sbahn,S45,s-bahn-berlin,4-08-45,#aa3c1f,#ffffff,,pill
+vbb-db-sbahn,S46,s-bahn-berlin,4-08-46,#ca8539,#ffffff,,pill
+vbb-db-sbahn,S47,s-bahn-berlin,4-08-47,#ca8539,#ffffff,,pill
+vbb-db-sbahn,S5,s-bahn-berlin,4-08-5,#ea561c,#ffffff,,pill
+vbb-db-sbahn,S7,s-bahn-berlin,4-08-7,#764d9a,#ffffff,,pill
+vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,,pill
+vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,,pill
+vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,,pill
+vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,,pill
+vms-mrb,RB 30,mitteldeutsche-regiobahn,8010397,#ed9126,#ffffff,,rectangle
+vms-mrb,RE 3,mitteldeutsche-regiobahn,8010085,#0093d4,#ffffff,,rectangle
+vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,5,,8-vrs001-5,#a69dc8,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,12,,8-vrs001-12,#98c01e,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,13,,8-vrs001-13,#aa8567,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,15,,8-vrs001-15,#5aad31,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,16,,8-vrs001-16,#07ada5,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,17,,8-vrs001-17,#1e93d1,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,18,,8-vrs001-18,#85d1f5,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,61,stadtwerke-bonn,8-s3-61,#9ab831,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,62,stadtwerke-bonn,8-s3-62,#65a53b,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,63,stadtwerke-bonn,8-s3-63,#8bccf3,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,65,stadtwerke-bonn,8-s3-65,#c6cc2a,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,66,stadtwerke-bonn,8-s3-66,#d4417d,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,67,stadtwerke-bonn,8-s3-67,#e7a8c4,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,68,stadtwerke-bonn,8-s3-68,#cbaece,#ffffff,,rectangle-rounded-corner
+vvo-db-regio,RB U28,db-regio-ag-sudost,5400003,#014d6f,#ffffff,,pill
+vvo-db-regio,RB 31,db-regio-ag-nordost,8010089,#6ab023,#ffffff,,rectangle
+vvo-db-regio,RB 33,db-regio-ag-sudost,8010089,#ec7797,#ffffff,,rectangle
+vvo-db-regio,RB 71,db-regio-ag-sudost,8012959,#ad006f,#ffffff,,rectangle
+vvo-db-regio,RB 72,db-regio-ag-sudost,8010163,#9c321b,#ffffff,,rectangle
+vvo-db-regio,RE 15,db-regio-ag-nordost,8010177,#effd400,#000000,,rectangle
+vvo-db-regio,RE 18,db-regio-ag-nordost,8010073,#ec7404,#ffffff,,rectangle
+vvo-db-regio,RE 19,db-regio-ag-sudost,8010085,#00895d,#ffffff,,rectangle
+vvo-db-regio,RE 50,db-regio-ag-sudost,8010085,#b60d1c,#ffffff,,rectangle
+vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,,pill
+vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,,pill
+vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,,pill
+vvo-db-sbd,S 8,db-regio-ag-sudost,8010006,#2d92ad,#ffffff,,pill
+vvo-tram,1,,8-voe011-1,#e30018,#ffffff,,rectangle-rounded-corner
+vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,,rectangle-rounded-corner
+vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,,rectangle-rounded-corner
+vvo-tram,4,,8-voe011-4,#c9061a,#ffffff,,rectangle-rounded-corner
+vvo-tram,6,,8-voe011-6,#ffdd00,#000000,,rectangle-rounded-corner
+vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,,rectangle-rounded-corner
+vvo-tram,8,,8-voe011-8,#229133,#ffffff,,rectangle-rounded-corner
+vvo-tram,9,,8-voe011-9,#93c355,#ffffff,,rectangle-rounded-corner
+vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,,rectangle-rounded-corner
+vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner
+vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner
+vvo-tram,13,,8-voe011-13,#fdc300,#000000,,rectangle-rounded-corner
+vvo-tram,20,,8-voe011-20,#000000,#ffffff,,rectangle-rounded-corner
+vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,,rectangle
+vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,,rectangle
+vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,,rectangle
+vvs-db-sbs,S3,db-regio-ag-s-bahn-stuttgart,4-800643-3,#f36e31,#ffffff,,rectangle
+vvs-db-sbs,S4,db-regio-ag-s-bahn-stuttgart,4-800643-4,#0166b3,#ffffff,,rectangle
+vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle
+vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle
+vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle
+vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle
+zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,,rectangle
+zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,,rectangle
+zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,,rectangle
+zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,,rectangle
+zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangle
+zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
+zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,,rectangle
+zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -77,6 +77,8 @@ vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,pill
 vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,pill
 vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,pill
 vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,pill
+vms-mrb,RB 30,mitteldeutsche-regiobahn,8010397,#ed9126,#ffffff,rectangle
+vms-mrb,RE 3,mitteldeutsche-regiobahn,8010085,#0093d4,#ffffff,rectangle
 vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,rectangle-rounded-corner
 vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,rectangle-rounded-corner
 vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,rectangle-rounded-corner
@@ -96,9 +98,19 @@ vrs-stadtbahn,65,stadtwerke-bonn,8-s3-65,#c6cc2a,#ffffff,rectangle-rounded-corne
 vrs-stadtbahn,66,stadtwerke-bonn,8-s3-66,#d4417d,#ffffff,rectangle-rounded-corner
 vrs-stadtbahn,67,stadtwerke-bonn,8-s3-67,#e7a8c4,#ffffff,rectangle-rounded-corner
 vrs-stadtbahn,68,stadtwerke-bonn,8-s3-68,#cbaece,#ffffff,rectangle-rounded-corner
+vvo-db-regio,RB U28,db-regio-ag-sudost,5400003,#014d6f,#ffffff,pill
+vvo-db-regio,RB 31,db-regio-ag-nordost,8010089,#6ab023,#ffffff,rectangle
+vvo-db-regio,RB 33,db-regio-ag-sudost,8010089,#ec7797,#ffffff,rectangle
+vvo-db-regio,RB 71,db-regio-ag-sudost,8012959,#ad006f,#ffffff,rectangle
+vvo-db-regio,RB 72,db-regio-ag-sudost,8010163,#9c321b,#ffffff,rectangle
+vvo-db-regio,RE 15,db-regio-ag-nordost,8010177,#effd400,#000000,rectangle
+vvo-db-regio,RE 18,db-regio-ag-nordost,8010073,#ec7404,#ffffff,rectangle
+vvo-db-regio,RE 19,db-regio-ag-sudost,8010085,#00895d,#ffffff,rectangle
+vvo-db-regio,RE 50,db-regio-ag-sudost,8010085,#b60d1c,#ffffff,rectangle
 vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,pill
 vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,pill
 vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,pill
+vvo-db-sbd,S 8,db-regio-ag-sudost,8010006,#2d92ad,#ffffff,pill
 vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,rectangle
 vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,rectangle
 vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,rectangle
@@ -108,3 +120,11 @@ vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,rectangle
 vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,rectangle
 vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,rectangle
 vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,rectangle
+zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,rectangle
+zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,rectangle
+zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,rectangle
+zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,rectangle
+zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,rectangle
+zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,rectangle
+zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,rectangle
+zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,rectangle

--- a/sources.json
+++ b/sources.json
@@ -254,6 +254,20 @@
         ]
     },
     {
+        "shortOperatorName": "vms-mrb",
+        "contributors": [
+            {
+                "github": "hoolycrash"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan",
+                "source": "https://download.transdev.de/transdev/uploads/mdr/media_document/26/original.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "vor-oebb",
         "contributors": [
             {
@@ -310,6 +324,20 @@
         ]
     },
     {
+        "shortOperatorName": "vvo-db-regio",
+        "contributors": [
+            {
+                "github": "hoolycrash"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan",
+                "source": "https://assets.static-bahn.de/dam/jcr:6780b540-43a7-4c03-8e02-2d64231667c1/Streckennetz%20DB%20Regio%20rund%20um%20Dresden_.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "vvo-db-sbd",
         "contributors": [
             {
@@ -338,6 +366,20 @@
         ]
     },
     {
+        "shortOperatorName": "vvo-tram",
+        "contributors": [
+            {
+                "github": "hoolycrash"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan",
+                "source": "https://www.dvb.de/-/media/files/liniennetz/2023-09-04/dvblnp040923bauwebpdf.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "vvs-ssb-stadtbahn",
         "contributors": [
             {
@@ -348,6 +390,34 @@
             {
                 "name": "Netzplan Stadtbahn Stuttgart",
                 "source": "https://download.vvs.de/Stadtbahn_Liniennetz.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "zvon-odeg",
+        "contributors": [
+            {
+                "github": "hoolycrash"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan",
+                "source": "https://www.vvo-online.de/doc/VVO-Liniennetzplan-SPNV-Sachsen.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "zvon-tl",
+        "contributors": [
+            {
+                "github": "hoolycrash"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan",
+                "source": "https://www.vvo-online.de/doc/VVO-Liniennetzplan-SPNV-Sachsen.pdf"
             }
         ]
     }


### PR DESCRIPTION
Added lines operated by DB Regio Nordost, DB Regio Südost, Trilex, Odeg and MRB.
Added DVB Trams

Sources:
DB Regio Südost: https://assets.static-bahn.de/dam/jcr:6780b540-43a7-4c03-8e02-2d64231667c1/Streckennetz%20DB%20Regio%20rund%20um%20Dresden_.pdf

MRB: https://download.transdev.de/transdev/uploads/mdr/media_document/26/original.pdf

DVB: https://www.dvb.de/-/media/files/liniennetz/2023-09-04/dvblnp040923bauwebpdf.pdf

Others: https://www.vvo-online.de/doc/VVO-Liniennetzplan-SPNV-Sachsen.pdf