### PR TITLE
add colours for moBiel (Stadtbahn Bielefeld)

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -30,6 +30,10 @@ kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,rectangle
 kvv-vbk,E,,8-kvv021-e,#fff,#000,rectangle
 kvv-vbk,NL1,,8-kvv021-nl1,#ed1c24,#ffffff,rectangle
 kvv-vbk,NL2,,8-kvv021-nl2,#0071bc,#ffffff,rectangle
+mobiel,1,mobiel-gmbh,8-owl031-1,#009fe0,#ffffff,rectangle
+mobiel,2,mobiel-gmbh,8-owl031-2,#008f36,#ffffff,rectangle
+mobiel,3,mobiel-gmbh,8-owl031-3,#ffed00,#00264f,rectangle
+mobiel,4,mobiel-gmbh,8-owl031-4,#e3001b,#ffffff,rectangle
 mvv-db-sbm,S1,db-regio-ag-s-bahn-munchen,4-800725-1,#1fbce6,#ffffff,pill
 mvv-db-sbm,S2,db-regio-ag-s-bahn-munchen,4-800725-2,#79b833,#ffffff,pill
 mvv-db-sbm,S20,db-regio-ag-s-bahn-munchen,4-800725-20,#f05972,#ffffff,pill

--- a/sources.json
+++ b/sources.json
@@ -97,6 +97,20 @@
         ]
     },
     {
+        "shortOperatorName": "mobiel",
+        "contributors": [
+            {
+                "github": "KiloBravoBFE"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan 2023",
+                "source": "https://www.mobiel.de/fileadmin/user_upload/Downloads/Netzplaene_Karten/schematischer_Netzplan_2023.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "mvv-db-sbm",
         "contributors": [
             {


### PR DESCRIPTION
Adds the 4 tram lines operated by moBiel.

In the official map a circular shape is used for all tram lines. This, however, is not the case in all other visualisations of the tram lines, where a rectangular version (see image) is used. Therefore, a rectangular shape appears more fitting in this case.


Colour Source (official map): https://www.mobiel.de/fileadmin/user_upload/Downloads/Netzplaene_Karten/schematischer_Netzplan_2023.pdf




(colours in the image are a bit off)
![20220603_143015](https://github.com/Traewelling/line-colors/assets/81705745/6a7f6ab8-ff91-48b1-83cb-2aefbaa3c5dd)