### PR TITLE
Add GABW and VAG

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -66,11 +66,11 @@ nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,rectangle
 nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,rectangle
 nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,rectangle
 nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,rectangle
-vag-stadtbahn,STR 1,,8-vag011-1,#e8001b,#ffffff,rectangle-rounded-corner
-vag-stadtbahn,STR 2,,8-vag011-2,#13a538,#ffffff,rectangle-rounded-corner
-vag-stadtbahn,STR 3,,8-vag011-3,#f59e00,#ffffff,rectangle-rounded-corner
-vag-stadtbahn,STR 4,,8-vag011-4,#ea5297,#ffffff,rectangle-rounded-corner
-vag-stadtbahn,STR 5,,8-vag011-5,#008bc5,#ffffff,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 1,,8-vag011-1,#e8001b,#ffffff,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 2,,8-vag011-2,#13a538,#ffffff,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 3,,8-vag011-3,#f59e00,#ffffff,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 4,,8-vag011-4,#ea5297,#ffffff,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 5,,8-vag011-5,#008bc5,#ffffff,rectangle-rounded-corner
 vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,pill
 vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,pill
 vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,pill

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,9 +1,9 @@
 shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,shape
-gabw,IRE1,go-ahead-baden-wurttemberg-gmbh,ire-1,#88c946,#ffffff,rectangle
-gabw,MEX13,go-ahead-baden-wurttemberg-gmbh,mex-13,#00b9f2,#ffffff,rectangle
-gabw,MEX16,go-ahead-baden-wurttemberg-gmbh,mex-16,#0073c0,#ffffff,rectangle
-gabw,RE8,go-ahead-baden-wurttemberg-gmbh,re-8,#b350a8,#ffffff,rectangle
-gabw,RE90,go-ahead-baden-wurttemberg-gmbh,re-90,#fd3083,#ffffff,rectangle
+gabw,IRE 1,go-ahead-baden-wurttemberg-gmbh,ire-1,#88c946,#ffffff,rectangle
+gabw,MEX 13,go-ahead-baden-wurttemberg-gmbh,mex-13,#00b9f2,#ffffff,rectangle
+gabw,MEX 16,go-ahead-baden-wurttemberg-gmbh,mex-16,#0073c0,#ffffff,rectangle
+gabw,RE 8,go-ahead-baden-wurttemberg-gmbh,re-8,#b350a8,#ffffff,rectangle
+gabw,RE 90,go-ahead-baden-wurttemberg-gmbh,re-90,#fd3083,#ffffff,rectangle
 gaby,RB86,go-ahead-bayern-gmbh,rb-86,#77aed2,#ffffff,rectangle
 gaby,RB87,go-ahead-bayern-gmbh,rb-87,#77aed2,#ffffff,rectangle
 gaby,RB89,go-ahead-bayern-gmbh,rb-89,#006da7,#ffffff,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -66,6 +66,11 @@ nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,rectangle
 nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,rectangle
 nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,rectangle
 nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,rectangle
+vag-stadtbahn,STR 1,,8-vag011-1,#e8001b,#ffffff,rectangle-rounded-corner
+vag-stadtbahn,STR 2,,8-vag011-2,#13a538,#ffffff,rectangle-rounded-corner
+vag-stadtbahn,STR 3,,8-vag011-3,#f59e00,#ffffff,rectangle-rounded-corner
+vag-stadtbahn,STR 4,,8-vag011-4,#ea5297,#ffffff,rectangle-rounded-corner
+vag-stadtbahn,STR 5,,8-vag011-5,#008bc5,#ffffff,rectangle-rounded-corner
 vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,pill
 vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,pill
 vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,pill

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -136,11 +136,6 @@ nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,,rectangle
 nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,,rectangle
 nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,,rectangle
 nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,,rectangle
-rvf-vag-stadtbahn,STR 1,,8-vag011-1,#e8001b,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 2,,8-vag011-2,#13a538,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 3,,8-vag011-3,#f59e00,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 4,,8-vag011-4,#ea5297,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 5,,8-vag011-5,#008bc5,#ffffff,,rectangle-rounded-corner
 neb-niederbarnimer-eisenbahn,RB12,neb-niederbarnimer-eisenbahn,rb-12,#a5027d,#ffffff,,rectangle
 neb-niederbarnimer-eisenbahn,RB25,neb-niederbarnimer-eisenbahn,rb-25,#007cb0,#ffffff,,rectangle
 neb-niederbarnimer-eisenbahn,RB26,neb-niederbarnimer-eisenbahn,rb-26,#009686,#ffffff,,rectangle
@@ -167,6 +162,11 @@ ooevv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1589920-5372014,#342980,#fffff
 ooevv-oebb,S4,osterreichische-bundesbahnen,4-81-4-1589920-5372014,#a4ba00,#ffffff,,rectangle-rounded-corner
 ooevv-stern-hafferl,S5,stern-hafferl-verkehrs-gmbh,4-810008-5,#e2007a,#ffffff,,rectangle-rounded-corner
 polregio,RB91,polregio,r-91,#eb7405,#ffffff,,rectangle
+rvf-vag-stadtbahn,STR 1,,8-vag011-1,#e8001b,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 2,,8-vag011-2,#13a538,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 3,,8-vag011-3,#f59e00,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 4,,8-vag011-4,#ea5297,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,STR 5,,8-vag011-5,#008bc5,#ffffff,,rectangle-rounded-corner
 svv-oebb,R3,osterreichische-bundesbahnen,r-3,#9dba3b,#ffffff,,rectangle-rounded-corner
 svv-oebb,R9,osterreichische-bundesbahnen,r-9,#dbbe2b,#ffffff,,rectangle-rounded-corner
 svv-oebb,R21,osterreichische-bundesbahnen,r-21,#42b3ca,#ffffff,,rectangle-rounded-corner

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,4 +1,9 @@
 shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,shape
+gabw,IRE1,go-ahead-baden-wurttemberg-gmbh,ire-1,#88c946,#ffffff,rectangle
+gabw,MEX13,go-ahead-baden-wurttemberg-gmbh,mex-13,#00b9f2,#ffffff,rectangle
+gabw,MEX16,go-ahead-baden-wurttemberg-gmbh,mex-16,#0073c0,#ffffff,rectangle
+gabw,RE8,go-ahead-baden-wurttemberg-gmbh,re-8,#b350a8,#ffffff,rectangle
+gabw,RE90,go-ahead-baden-wurttemberg-gmbh,re-90,#fd3083,#ffffff,rectangle
 gaby,RB86,go-ahead-bayern-gmbh,rb-86,#77aed2,#ffffff,rectangle
 gaby,RB87,go-ahead-bayern-gmbh,rb-87,#77aed2,#ffffff,rectangle
 gaby,RB89,go-ahead-bayern-gmbh,rb-89,#006da7,#ffffff,rectangle

--- a/sources.json
+++ b/sources.json
@@ -28,6 +28,20 @@
         ]
     },
     {
+        "shortOperatorName": "gabw",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Go-Ahead BW Netzplan",
+                "source": "https://www.go-ahead-bw.de/fileadmin/user_upload/content/unterwegs/liniennetz/GABW_Netz_A4_220315_pr.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "gaby",
         "contributors": [
             {
@@ -203,6 +217,20 @@
             {
                 "name": "NAH.SH Bahnlinienplan",
                 "source": "https://www.nah.sh/assets/2023/nahsh_bahnlinienSH_2023.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "rvf-vag-stadtbahn",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Linienfahrpläne",
+                "source": "https://www.vag-freiburg.de/fahrplan/linien-fahrplaene"
             }
         ]
     },


### PR DESCRIPTION
Added lines from Go Ahead Baden-Württemberg according to https://www.go-ahead-bw.de/fileadmin/user_upload/content/unterwegs/liniennetz/GABW_Netz_A4_220315_pr.pdf and Freiburgs VAG according to https://www.vag-freiburg.de/fahrplan/linien-fahrplaene