### PR TITLE
Added missing AVG colours & S-Bahn Rhein-Neckar

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -25,12 +25,20 @@ kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-
 kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
 kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner
 kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,,rectangle-rounded-corner
+kvv-avg,S6,albtal-verkehrs-gesellschaft-mbh,4-a6s6-6,#282268,#ffffff,,rectangle-rounded-corner
 kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,,rectangle-rounded-corner
 kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,,rectangle-rounded-corner
 kvv-avg,S11,albtal-verkehrs-gesellschaft-mbh,4-a6s11-11,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S12,albtal-verkehrs-gesellschaft-mbh,4-a6s12-12,#00a76d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S31,albtal-verkehrs-gesellschaft-mbh,4-a6s31-31,#00a99d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S32,albtal-verkehrs-gesellschaft-mbh,4-a6s32-32,#00a99d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S41,albtal-verkehrs-gesellschaft-mbh,4-a6s41-41,#bed730,#ffffff,,rectangle-rounded-corner
+kvv-avg,S42,albtal-verkehrs-gesellschaft-mbh,4-a6s42-42,#0097bb,#ffffff,,rectangle-rounded-corner
 kvv-avg,S51,albtal-verkehrs-gesellschaft-mbh,4-a6s51-51,#f69795,#ffffff,,rectangle-rounded-corner
 kvv-avg,S52,albtal-verkehrs-gesellschaft-mbh,4-a6s52-52,#f69795,#ffffff,,rectangle-rounded-corner
+kvv-avg,S71,albtal-verkehrs-gesellschaft-mbh,4-a6s71-71,#fff200,#000000,,rectangle-rounded-corner
+kvv-avg,S81,albtal-verkehrs-gesellschaft-mbh,4-a6s81-81,#6e692a,#ffffff,,rectangle-rounded-corner
+kvv-avg,S FEX,albtal-verkehrs-gesellschaft-mbh,4-a6s1-fex,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#fff,#000,,rectangle-rounded-corner
 kvv-vbk,1,,8-kvv021-1,#ed1c24,#ffffff,,rectangle
 kvv-vbk,2,,8-kvv021-2,#0071bc,#ffffff,,rectangle
@@ -136,6 +144,21 @@ vor-wl,U2,wiener-linien,7-810009-2,#a862a4,#ffffff,,rectangle
 vor-wl,U3,wiener-linien,7-810009-3,#ef7c00,#ffffff,,rectangle
 vor-wl,U4,wiener-linien,7-810009-4,#00963f,#ffffff,,rectangle
 vor-wl,U6,wiener-linien,7-810009-6,#9d6830,#ffffff,,rectangle
+vrn-sbahn-rn,RE5,db-regio-ag-mitte,re-5,#f68a25,#ffffff,,pill
+vrn-sbahn-rn,RE9,db-regio-ag-mitte,re-9,#73c82c,#ffffff,,pill
+vrn-sbahn-rn,S1,db-regio-ag-mitte,4-801539-1,#ed1c24,#ffffff,,pill
+vrn-sbahn-rn,S2,db-regio-ag-mitte,4-801539-2,#1575c5,#ffffff,,pill
+vrn-sbahn-rn,S3,db-regio-ag-mitte,4-801539-3,#fddd04,#231f20,,pill
+vrn-sbahn-rn,S4,db-regio-ag-mitte,4-801539-4,#00a650,#ffffff,,pill
+vrn-sbahn-rn,S5,db-regio-ag-mitte,4-801518-5,#f68a25,#ffffff,,pill
+vrn-sbahn-rn,S6,db-regio-ag-mitte,4-801518-6,#40c1f3,#ffffff,,pill
+vrn-sbahn-rn,S7,db-regio-ag-mitte,4-801539-7,#ffffff,#ef249c,#ef249c,pill
+vrn-sbahn-rn,S8,db-regio-ag-mitte,4-801518-8,#a25bad,#ffffff,,pill
+vrn-sbahn-rn,S9,db-regio-ag-mitte,4-801518-9,#73c82c,#ffffff,,pill
+vrn-sbahn-rn,S33,db-regio-ag-mitte,4-801539-33,#833aa1,#ffffff,,pill
+vrn-sbahn-rn,S39,db-regio-ag-mitte,4-801539-39,#ffffff,#bf5810,#bf5810,pill
+vrn-sbahn-rn,S44,db-regio-ag-mitte,4-801539-44,#ffffff,#00a650,#00a650,pill
+vrn-sbahn-rn,S51,db-regio-ag-mitte,4-801518-51,#f68a25,#ffffff,,pill
 vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner

--- a/sources.json
+++ b/sources.json
@@ -281,6 +281,20 @@
             }
         ]
     },
+        {
+        "shortOperatorName": "vrn-sbahn-rn",
+        "contributors": [
+            {
+                "github": "metrophil"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetz S-Bahn Rhein-Neckar",
+                "source": "https://www.s-bahn-rheinneckar.de/fahrplan/streckenfpl"
+            }
+        ]
+    },
     {
         "shortOperatorName": "vrs-stadtbahn",
         "contributors": [


### PR DESCRIPTION
Colours for AVG lines S31, S32, S41, S42, S6, S71, S81 and S FEX from https://www.kvv.de/fileadmin/user_upload/kvv/Dateien/Fahrplaene_Netzplaene/Schiene/2023/KVV-Liniennetzplan_Karlsruhe-Heilbronn.pdf

Colours for S-Bahn Rhein-Neckar lines including "Sprinter-S-Bahn" RE5 & RE9 from https://www.s-bahn-rheinneckar.de/fahrplan/streckenfpl