### PR TITLE
:lipstick: Add border style to website 

### DIFF
--- a/website/assets/js/custom-elements.js
+++ b/website/assets/js/custom-elements.js
@@ -21,13 +21,15 @@ function toggleDetails(event) {
             let template = document.getElementById("template-for-line-logo-" + shape);
             let templateContent = template.content;
 
-            const shadowRoot = this.attachShadow({mode: "open"});
+            const shadowRoot = this.attachShadow({ mode: "open" });
 
             const backgroundColor = this.getAttribute("backgroundColor");
             const textColor = this.getAttribute("textColor");
+            const borderColor = this.getAttribute("borderColor");
 
             let style = document.createElement("style");
-            style.textContent = `div { background-color: ${backgroundColor}; color: ${textColor}}; }`;
+            const borderStyle = borderColor ? `border: 0.1em solid ${borderColor};` : "";
+            style.textContent = `div { background-color: ${backgroundColor}; color: ${textColor}; ${borderStyle} }`;
 
             shadowRoot.appendChild(style);
 

--- a/website/index.php
+++ b/website/index.php
@@ -116,9 +116,10 @@ include_once "../validation/common.php";
 
                                 <dl>
                                     <?php foreach ($line as $key => $value): ?>
+                                        <?php if ($key === "borderColor" && $value === "") continue; ?>
                                         <dt><?= $key ?></dt>
-                                        <dd class="<?= in_array($key, ["backgroundColor", "textColor", "shape"]) ? "monospace" : "" ?>">
-                                            <?php if (in_array($key, ["backgroundColor", "textColor"])): ?>
+                                        <dd class="<?= in_array($key, ["backgroundColor", "textColor", "borderColor", "shape"]) ? "monospace" : "" ?>">
+                                            <?php if (in_array($key, ["backgroundColor", "textColor", "borderColor"])): ?>
                                                 <span class="color-preview"
                                                       style="background-color: <?= $value ?>"></span>
                                             <?php endif ?>


### PR DESCRIPTION
This PR:
* adds a border style to the website 
* only shows the borderColor property if not null
* and adds the color blip to the borderColor property when given

Looks like this in the website:

<img width="1016" alt="image" src="https://github.com/Traewelling/line-colors/assets/2796271/46924cbd-f05c-433f-b6f8-691947e239f3">
