### PR TITLE
✅ add hex-color validator and add unit tests for the validation rules

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -9,13 +9,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+      - name: Test validators
+        working-directory: ./validation
+        run: php test.php
       - name: Validate line-colors.csv
         working-directory: ./validation
         run: php check.php
 
   deploy:
-    needs: [ validate ]
+    needs: [validate]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -307,7 +307,7 @@ vvo-db-regio,RB 31,db-regio-ag-nordost,8010089,#6ab023,#ffffff,,rectangle
 vvo-db-regio,RB 33,db-regio-ag-sudost,8010089,#ec7797,#ffffff,,rectangle
 vvo-db-regio,RB 71,db-regio-ag-sudost,8012959,#ad006f,#ffffff,,rectangle
 vvo-db-regio,RB 72,db-regio-ag-sudost,8010163,#9c321b,#ffffff,,rectangle
-vvo-db-regio,RE 15,db-regio-ag-nordost,8010177,#effd400,#000000,,rectangle
+vvo-db-regio,RE 15,db-regio-ag-nordost,8010177,#ffd400,#000000,,rectangle
 vvo-db-regio,RE 18,db-regio-ag-nordost,8010073,#ec7404,#ffffff,,rectangle
 vvo-db-regio,RE 19,db-regio-ag-sudost,8010085,#00895d,#ffffff,,rectangle
 vvo-db-regio,RE 50,db-regio-ag-sudost,8010085,#b60d1c,#ffffff,,rectangle
@@ -355,8 +355,8 @@ vvs-ssb-stadtbahn,U8,,8-vvs020-u8,#fed304,#000000,,rectangle
 vvs-ssb-stadtbahn,U9,,8-vvs020-u9,#bfb678,#000000,,rectangle
 zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,,rectangle
 zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,,rectangle
-zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,,#ffffff,rectangle
-zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,,#ffffff,rectangle
+zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,,rectangle
+zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,,rectangle
 zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangle
 zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
 zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,,rectangle

--- a/validation/check.php
+++ b/validation/check.php
@@ -30,22 +30,11 @@ foreach ($csv as $line) {
 echo "Checking that all shapes are valid and can be displayed on the website" . PHP_EOL;
 $i = 2;
 foreach ($csv as $line) {
-    if (!in_array($line["shape"], ["pill", "rectangle", "rectangle-rounded-corner"])) {
-        throw new Error("bad shape " . $line["shape"] . " in row $i");
-    }
+    valid_shape($line, $i);
     $i++;
 }
 
 echo "Checking that all colors are valid" . PHP_EOL;
-
-function valid_hex_color($line, $i, $key) {
-    $color = $line[$key];
-    
-    if (!(strlen($color) == 7 && ctype_xdigit(substr($color, 1)) && $color[0] === "#")) {
-        throw new Error("bad $key \"$color\" does not follow #<6 digit hex color> in row $i");
-    }
-}
-
 $i = 2;
 foreach ($csv as $line) {
     if ($line["borderColor"] != "") {

--- a/validation/check.php
+++ b/validation/check.php
@@ -36,6 +36,28 @@ foreach ($csv as $line) {
     $i++;
 }
 
+echo "Checking that all colors are valid" . PHP_EOL;
+
+function valid_hex_color($line, $i, $key) {
+    $color = $line[$key];
+    
+    if (!(strlen($color) == 7 && ctype_xdigit(substr($color, 1)) && $color[0] === "#")) {
+        throw new Error("bad $key \"$color\" does not follow #<6 digit hex color> in row $i");
+    }
+}
+
+$i = 2;
+foreach ($csv as $line) {
+    if ($line["borderColor"] != "") {
+        valid_hex_color($line, $i, "borderColor");
+    }
+
+    valid_hex_color($line, $i, "textColor");
+    valid_hex_color($line, $i, "backgroundColor");
+
+    $i++;
+}
+
 $sources = json_decode(file_get_contents("../sources.json"), true);
 $opSources = array_map(fn($op) => $op["shortOperatorName"], $sources);
 echo "Checking that operators are present in sources.json" . PHP_EOL;

--- a/validation/common.php
+++ b/validation/common.php
@@ -11,3 +11,18 @@ $linesByOperatorCode = array_reduce($csv, function ($result, $line) {
 
     return $result;
 }, []);
+
+
+function valid_shape($line, $i) {
+    if (!in_array($line["shape"], ["pill", "rectangle", "rectangle-rounded-corner"])) {
+        throw new Error("bad shape " . $line["shape"] . " in row $i");
+    }
+}
+
+function valid_hex_color($line, $i, $key) {
+    $color = $line[$key];
+    
+    if (!(strlen($color) == 7 && ctype_xdigit(substr($color, 1)) && $color[0] === "#")) {
+        throw new Error("bad $key \"$color\" does not follow #<6 digit hex color> in row $i");
+    }
+}

--- a/validation/test.php
+++ b/validation/test.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file tests whether the utility functions in common.php work as
+ * intended. For this, positive and negative test cases for all the checks are
+ * given. Instead of blowing up a large unit testing framework, two functions
+ * `test_ok` and `test_throws` are given which will check whether a given
+ * Callable will blow up or not.
+ */
+
+$positive_count = 0;
+function test_ok(string $name, callable $test_case) {
+    global $positive_count;
+    $positive_count++;
+
+    try {
+        $test_case();
+    } catch (Error $e) {
+        throw new Error("$name should not throw, but did.", previous: $e);
+    }
+}
+
+
+$negative_count = 0;
+/**
+ * This can only catch one error! Don't call `test_throws` with multiple
+ * validation calls as it might taint the test results!
+ */
+function test_throws(string $name, callable $test_case) {
+    global $negative_count;
+    $negative_count++;
+
+    $has_thrown = false;
+    try {
+        $test_case();
+    } catch (Error $e) {
+        $has_thrown = true;
+    } finally {
+        if (!$has_thrown) {
+            throw new Error("$name should have thrown, but did not.");
+        }
+    }
+}
+
+/**
+ * Loading testable functions from common.php.
+ */
+include_once "common.php";
+echo "Testing validation functions with synthetic data" . PHP_EOL;
+
+/**
+ * valid_shape
+ */
+test_ok("valid_shape for okay data", function () {
+    valid_shape(["shape" => "pill"], 1);
+    valid_shape(["shape" => "rectangle"], 2);
+    valid_shape(["shape" => "rectangle-rounded-corner"], 3);
+});
+test_throws("valid_shape for unknown data", function () {
+    valid_shape(["shape" => "bestagon"], 4);
+});
+test_throws("valid_shape for empty data", function () {
+    valid_shape(["shape" => ""], 5);
+});
+
+/**
+ * valid_hex_color
+ */
+test_ok("valid_hex_color for okay data", function () {
+    valid_hex_color(["test_key" => "#fff000"], 1, "test_key");
+    valid_hex_color(["test_key" => "#fff000"], 2, "test_key");
+});
+test_throws("valid_hex_color for non-hex data", function () {
+    valid_hex_color(["test_key" => "#ghijkl"], 3, "test_key");
+});
+test_throws("valid_hex_color for too short data", function () {
+    valid_hex_color(["test_key" => "#abc"], 4, "test_key");
+});
+test_throws("valid_hex_color for too long data", function () {
+    valid_hex_color(["test_key" => "#1234567"], 5, "test_key");
+});
+test_throws("valid_hex_color for empty data", function () {
+    valid_hex_color(["test_key" => ""], 6, "test_key");
+});
+test_throws("valid_hex_color when doesn't start with #", function () {
+    valid_hex_color(["test_key" => "abcdefg"], 5, "test_key");
+});
+
+/**
+ * End of file
+ */
+echo "...Tested $positive_count positive and $negative_count negative validation functions" . PHP_EOL;


### PR DESCRIPTION
This PR adds a validation rule for the color fields which should always be 6-digit hex codes with a # in front (inspired by https://github.com/Traewelling/line-colors/pull/40). Turns out there were even more cases where that wasn't set properly!

Since the validation rules are getting more and more complex, I've added a very barebones unit test framework which can cross-check if the rules are doing what we want them to. This turned out to be the larger part of this PR.

Hope it's alright for y'all and hopefully this can add to a better data quality overall.