### PR TITLE
Add Leipziger Verkehrsbetriebe (LVB) Trams + Bus

### DIFF
--- a/hafas-operators.csv
+++ b/hafas-operators.csv
@@ -532,3 +532,4 @@ zugerbergbahn,Zugerbergbahn
 zugerland-verkehrsbetriebe,Zugerland Verkehrsbetriebe
 zugersee,Zugersee
 zurichsee,Zürichsee
+zweckverband-fur-den-nahverkehrsraum-leipzig, Zweckverband für den Nahverkehrsraum Leipzig

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -350,3 +350,46 @@ zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangl
 zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
 zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,,rectangle
 zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,,rectangle
+zvnl-bus,60,,5-naslvb-60,#a61580,#ffffff,,pill
+zvnl-bus,65,,5-naslvb-65,#a61580,#ffffff,,pill
+zvnl-bus,70,,5-naslvb-70,#a61580,#ffffff,,pill
+zvnl-bus,72,,5-naslvb-72,#a61580,#ffffff,,pill
+zvnl-bus,73,,5-naslvb-73,#a61580,#ffffff,,pill
+zvnl-bus,74,,5-naslvb-74,#a61580,#ffffff,,pill
+zvnl-bus,80,,5-naslvb-80,#a61580,#ffffff,,pill
+zvnl-bus,81,,5-naslvb-81,#a61580,#ffffff,,pill
+zvnl-bus,82,,5-naslvb-82,#a61580,#ffffff,,pill
+zvnl-bus,89,,5-naslvb-89,#a61580,#ffffff,,pill
+zvnl-bus,90,,5-naslvb-90,#a61580,#ffffff,,pill
+zvnl-bus,N1,,5-naslvb-n1,#f5a522,#000000,,pill
+zvnl-bus,N2,,5-naslvb-n2,#fee38e,#000000,,pill
+zvnl-bus,N3,,5-naslvb-n3,#fed92bD,#000000,,pill
+zvnl-bus,N4,,5-naslvb-n4,#fed92b,#000000,,pill
+zvnl-bus,N5,,5-naslvb-n5,#f5a522,#000000,,pill
+zvnl-bus,N6,,5-naslvb-n6,#fed92b,#000000,,pill
+zvnl-bus,N7,,5-naslvb-n7,#fee38e,#000000,,pill
+zvnl-bus,N8,,5-naslvb-n8,#f5a522,#000000,,pill
+zvnl-bus,N9,,5-naslvb-n9,#fed92b,#000000,,pill
+zvnl-bus,N60,,5-naslvb-n60,#a61580,#000000,,pill
+zvnl-bus,SEV1,,5-naslvb-sev1,#ee8322,#ffffff,,pill
+zvnl-bus,SEV2,,5-naslvb-sev2,#ee8322,#ffffff,,pill
+zvnl-tram,1,,8-naslvt-1,#67b337,#ffffff,,rectangle
+zvnl-tram,2,,8-naslvt-2,#fecb29,#000000,,rectangle
+zvnl-tram,3,,8-naslvt-3,#67b337,#ffffff,,rectangle
+zvnl-tram,4,,8-naslvt-4,#233b8d,#ffffff,,rectangle
+zvnl-tram,7,,8-naslvt-7,#233b8d,#ffffff,,rectangle
+zvnl-tram,8,,8-naslvt-8,#fecb29,#000000,,rectangle
+zvnl-tram,9,,8-naslvt-9,#fecb29,#000000,,rectangle
+zvnl-tram,10,,8-naslvt-10,#e1001e,#ffffff,,rectangle
+zvnl-tram,11,,8-naslvt-11,#e1001e,#ffffff,,rectangle
+zvnl-tram,12,,8-naslvt-12,#233b8d,#ffffff,,rectangle
+zvnl-tram,14,,8-naslvt-14,#18a0e1,#ffffff,,rectangle
+zvnl-tram,15,,8-naslvt-15,#233b8d,#ffffff,,rectangle
+zvnl-tram,16,,8-naslvt-16,#e1001e,#ffffff,,rectangle
+zvnl-tram,34,,8-naslvt-34,#ee8322,#ffffff,,rectangle
+zvnl-tram,38,,8-naslvt-38,#e8591d,#ffffff,,rectangle
+zvnl-tram,39,,8-naslvt-39,#ee8322,#ffffff,,rectangle
+zvnl-tram,50,,8-naslvt-50,#ffffff,#000000,#000000,rectangle
+zvnl-tram,56,,8-naslvt-56,#ffffff,#000000,#000000,rectangle
+zvnl-tram,N10,,8-naslvt-n10,#e1001e,#ffffff,,rectangle
+zvnl-tram,N17,,8-naslvt-n17,#67b337,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -374,7 +374,7 @@ zvnl-bus,89,,5-naslvb-89,#a61580,#ffffff,,pill
 zvnl-bus,90,,5-naslvb-90,#a61580,#ffffff,,pill
 zvnl-bus,N1,,5-naslvb-n1,#f5a522,#000000,,pill
 zvnl-bus,N2,,5-naslvb-n2,#fee38e,#000000,,pill
-zvnl-bus,N3,,5-naslvb-n3,#fed92bD,#000000,,pill
+zvnl-bus,N3,,5-naslvb-n3,#fed92b,#000000,,pill
 zvnl-bus,N4,,5-naslvb-n4,#fed92b,#000000,,pill
 zvnl-bus,N5,,5-naslvb-n5,#f5a522,#000000,,pill
 zvnl-bus,N6,,5-naslvb-n6,#fed92b,#000000,,pill

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -353,14 +353,6 @@ vvs-ssb-stadtbahn,U6,,8-vvs020-u6,#ed028c,#ffffff,,rectangle
 vvs-ssb-stadtbahn,U7,,8-vvs020-u7,#0ab38d,#ffffff,,rectangle
 vvs-ssb-stadtbahn,U8,,8-vvs020-u8,#fed304,#000000,,rectangle
 vvs-ssb-stadtbahn,U9,,8-vvs020-u9,#bfb678,#000000,,rectangle
-zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,,rectangle
-zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,,rectangle
-zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,,rectangle
-zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,,rectangle
-zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangle
-zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
-zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,,rectangle
-zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,,rectangle
 zvnl-bus,60,,5-naslvb-60,#a61580,#ffffff,,pill
 zvnl-bus,65,,5-naslvb-65,#a61580,#ffffff,,pill
 zvnl-bus,70,,5-naslvb-70,#a61580,#ffffff,,pill
@@ -404,3 +396,11 @@ zvnl-tram,50,,8-naslvt-50,#ffffff,#000000,#000000,rectangle
 zvnl-tram,56,,8-naslvt-56,#ffffff,#000000,#000000,rectangle
 zvnl-tram,N10,,8-naslvt-n10,#e1001e,#ffffff,,rectangle
 zvnl-tram,N17,,8-naslvt-n17,#67b337,#ffffff,,rectangle
+zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,,rectangle
+zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,,rectangle
+zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,,rectangle
+zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,,rectangle
+zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangle
+zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
+zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,,rectangle
+zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -374,8 +374,6 @@ zvnl-bus,N7,,5-naslvb-n7,#fee38e,#000000,,pill
 zvnl-bus,N8,,5-naslvb-n8,#f5a522,#000000,,pill
 zvnl-bus,N9,,5-naslvb-n9,#fed92b,#000000,,pill
 zvnl-bus,N60,,5-naslvb-n60,#a61580,#000000,,pill
-zvnl-bus,SEV1,,5-naslvb-sev1,#ee8322,#ffffff,,pill
-zvnl-bus,SEV2,,5-naslvb-sev2,#ee8322,#ffffff,,pill
 zvnl-tram,1,,8-naslvt-1,#67b337,#ffffff,,rectangle
 zvnl-tram,2,,8-naslvt-2,#fecb29,#000000,,rectangle
 zvnl-tram,3,,8-naslvt-3,#67b337,#ffffff,,rectangle
@@ -389,9 +387,6 @@ zvnl-tram,12,,8-naslvt-12,#233b8d,#ffffff,,rectangle
 zvnl-tram,14,,8-naslvt-14,#18a0e1,#ffffff,,rectangle
 zvnl-tram,15,,8-naslvt-15,#233b8d,#ffffff,,rectangle
 zvnl-tram,16,,8-naslvt-16,#e1001e,#ffffff,,rectangle
-zvnl-tram,34,,8-naslvt-34,#ee8322,#ffffff,,rectangle
-zvnl-tram,38,,8-naslvt-38,#e8591d,#ffffff,,rectangle
-zvnl-tram,39,,8-naslvt-39,#ee8322,#ffffff,,rectangle
 zvnl-tram,50,,8-naslvt-50,#ffffff,#000000,#000000,rectangle
 zvnl-tram,56,,8-naslvt-56,#ffffff,#000000,#000000,rectangle
 zvnl-tram,N10,,8-naslvt-n10,#e1001e,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -599,6 +599,58 @@
         ]
     },
     {
+        "shortOperatorName": "zvnl-bus",
+        "contributors": [
+            {
+                "github": "tomjschwanke"
+            }
+        ],
+        "sources": [
+            {
+                "name": "LVB-Liniennetzplan",
+                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Tag-ab-11-12-22.pdf"
+            },
+            {
+                "name": "LVB-Bau-Lininennetzplan",
+                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Bau-Lininennetzplan-ab-02-10-2023.pdf"
+            },
+            {
+                "name": "LVB-Liniennetzplan-Nacht",
+                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Nacht-ab-11-12-22.pdf"
+            },
+            {
+                "name": "LVB_Veranstaltungs-Liniennetzplan",
+                "source": "https://files.l.de/lde-typo3/default_backend_upload/LVB_Veranstaltungs-Liniennetzplan-ab-02-10-2023.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "zvnl-tram",
+        "contributors": [
+            {
+                "github": "tomjschwanke"
+            }
+        ],
+        "sources": [
+            {
+                "name": "LVB-Liniennetzplan",
+                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Tag-ab-11-12-22.pdf"
+            },
+            {
+                "name": "LVB-Bau-Lininennetzplan",
+                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Bau-Lininennetzplan-ab-02-10-2023.pdf"
+            },
+            {
+                "name": "LVB-Liniennetzplan-Nacht",
+                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Nacht-ab-11-12-22.pdf"
+            },
+            {
+                "name": "LVB_Veranstaltungs-Liniennetzplan",
+                "source": "https://files.l.de/lde-typo3/default_backend_upload/LVB_Veranstaltungs-Liniennetzplan-ab-02-10-2023.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "zvon-odeg",
         "contributors": [
             {

--- a/sources.json
+++ b/sources.json
@@ -627,10 +627,6 @@
                 "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Tag-ab-11-12-22.pdf"
             },
             {
-                "name": "LVB-Bau-Lininennetzplan",
-                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Bau-Lininennetzplan-ab-02-10-2023.pdf"
-            },
-            {
                 "name": "LVB-Liniennetzplan-Nacht",
                 "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Nacht-ab-11-12-22.pdf"
             },
@@ -651,10 +647,6 @@
             {
                 "name": "LVB-Liniennetzplan",
                 "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Liniennetzplan-Tag-ab-11-12-22.pdf"
-            },
-            {
-                "name": "LVB-Bau-Lininennetzplan",
-                "source": "https://files.l.de/lde-typo3/Leipziger/Verkehrsbetriebe/Fahrplan/Netzplan/LVB-Bau-Lininennetzplan-ab-02-10-2023.pdf"
             },
             {
                 "name": "LVB-Liniennetzplan-Nacht",


### PR DESCRIPTION
I've added all listed tram lines + the main bus lines for Leipzig (Leipziger Verkehrsbetriebe). For the operator ID I chose ZVNL since that's the listed operator for Leipzig Hbf (even tho the operator for the tram lines is listed as "nahreisezug", but the same is true for tram lines in Dresden, so I'd appreciate any advice if I should change things).

The main busses are purple colored, the rest is just gray and it's not really worth the effort to scour the plan for all of them just to make them grey imho.

Also contains the ~~current construction tram lines 34, 38 and 39, as well as~~ special event lines 50 and 56.

Sourced from plans available here: https://www.l.de/verkehrsbetriebe/netzplan/

~~Rail replacement service uses hexagon shapes which are not available here, so I decided to use pills (circles) for now. Trams use squares, rectangle should work here, and busses use circles, I hope pill works for that.~~

The [site listing changes to regular service](https://www.l.de/verkehrsbetriebe/kundenservice/aenderungen-im-linienverkehr/) shows all busses as purple and line 56 as red, but I decided to go with the network map colors.