### PR TITLE
add MDV S-Bahn

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -267,11 +267,11 @@ vrn-sbahn-rn,S33,db-regio-ag-mitte,4-801539-33,#833aa1,#ffffff,,pill
 vrn-sbahn-rn,S39,db-regio-ag-mitte,4-801539-39,#ffffff,#bf5810,#bf5810,pill
 vrn-sbahn-rn,S44,db-regio-ag-mitte,4-801539-44,#ffffff,#00a650,#00a650,pill
 vrn-sbahn-rn,S51,db-regio-ag-mitte,4-801518-51,#f68a25,#ffffff,,pill
-vrr-rrx-regional,RE 1,national-express,re-1,#ef7c00,#fffff,,rectangle-rounded-corner
-vrr-rrx-regional,RE 4,national-express,re-4,#ef7c00,#fffff,,rectangle-rounded-corner
-vrr-rrx-regional,RE 5,national-express,re-5,#ef7c00,#fffff,,rectangle-rounded-corner
-vrr-rrx-regional,RE 6,national-express,re-5,#ef7c00,#fffff,,rectangle-rounded-corner
-vrr-rrx-regional,RE 11,national-express,re-5,#ef7c00,#fffff,,rectangle-rounded-corner
+vrr-rrx-regional,RE 1,national-express,re-1,#ef7c00,#ffffff,,rectangle-rounded-corner
+vrr-rrx-regional,RE 4,national-express,re-4,#ef7c00,#ffffff,,rectangle-rounded-corner
+vrr-rrx-regional,RE 5,national-express,re-5,#ef7c00,#ffffff,,rectangle-rounded-corner
+vrr-rrx-regional,RE 6,national-express,re-5,#ef7c00,#ffffff,,rectangle-rounded-corner
+vrr-rrx-regional,RE 11,national-express,re-5,#ef7c00,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,4 +1,5 @@
 shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,borderColor,shape
+ams,S7,abellio-rail-mitteldeutschland-gmbh,4-ams-7,#0a579b,#ffffff,,pill
 db-regio-nordost,FEX,db-regio-ag-nordost,fex19829,#79122f,#ffffff,,rectangle
 db-regio-nordost,RB10,db-regio-ag-nordost,rb-10,#66aa22,#ffffff,,rectangle
 db-regio-nordost,RB14,db-regio-ag-nordost,rb-14,#a5027d,#ffffff,,rectangle
@@ -26,6 +27,17 @@ db-regio-nordost,RE6,db-regio-ag-nordost,re-6,#da6ba2,#ffffff,,rectangle
 db-regio-nordost,RE66,db-regio-ag-nordost,re-66,#007734,#ffffff,,rectangle
 db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#007734,#ffffff,,rectangle
 db-regio-sudost,RE14,db-regio-ag-sudost,re-14,#a98956,#ffffff,,rectangle
+db-regio-sudost,S1,db-regio-ag-sudost,4-800486-1,#f5de2b,#000000,,pill
+db-regio-sudost,S2,db-regio-ag-sudost,4-8004a9-2,#18a2e3,#ffffff,,pill
+db-regio-sudost,S3,db-regio-ag-sudost,4-800486-3,#e1001e,#ffffff,,pill
+db-regio-sudost,S4,db-regio-ag-sudost,4-800486-4,#109644,#ffffff,,pill
+db-regio-sudost,S5,db-regio-ag-sudost,4-800486-5,#ed7c1c,#ffffff,,pill
+db-regio-sudost,S5X,db-regio-ag-sudost,4-800486-5x,#fdce5c,#ffffff,,pill
+db-regio-sudost,S6,db-regio-ag-sudost,4-800486-6,#5c1239,#ffffff,,pill
+db-regio-sudost,S8,db-regio-ag-sudost,4-8004a9-8,#5c2582,#ffffff,,pill
+db-regio-sudost,S9,db-regio-ag-sudost,4-8004a9-9,#be006b,#ffffff,,pill
+db-regio-sudost,S10,db-regio-ag-sudost,4-800486-10,#ffffff,#000000,#f5de2b,pill
+db-regio-sudost,S47,db-regio-ag-sudost,4-8004a9-47,#53af4c,#ffffff,,pill
 gabw,IRE 1,go-ahead-baden-wurttemberg-gmbh,ire-1,#88c946,#ffffff,,rectangle
 gabw,MEX 13,go-ahead-baden-wurttemberg-gmbh,mex-13,#00b9f2,#ffffff,,rectangle
 gabw,MEX 16,go-ahead-baden-wurttemberg-gmbh,mex-16,#0073c0,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,19 @@
 [
     {
+        "shortOperatorName": "ams",
+        "contributors": [
+            {
+                "github": "tomjschwanke"
+            }
+        ],
+        "sources": [
+            {
+                "name": "MDV Liniennetzplan",
+                "source": "https://www.mdv.de/site/uploads/lnp_plusbus.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "db-regio-nordost",
         "contributors": [
             {

--- a/sources.json
+++ b/sources.json
@@ -18,12 +18,19 @@
         "contributors": [
             {
                 "github": "jeyemwey"
+            },
+            {
+                "github": "tomjschwanke"
             }
         ],
         "sources": [
             {
                 "name": "VBB Liniennetz Regionalverkehr",
                 "source": "https://www.vbb.de/fileadmin/user_upload/VBB/Dokumente/Liniennetze/bahn-regionalverkehr-brandenburg-und-berlin-mit-plusbus-linien.pdf"
+            },
+            {
+                "name": "MDV Liniennetzplan",
+                "source": "https://www.mdv.de/site/uploads/lnp_plusbus.pdf"
             }
         ]
     },


### PR DESCRIPTION
Added suburban S-Bahn trains from Mitteldeutscher Verkehrsverbund (MDV) using the network map provided here: https://www.mdv.de/site/uploads/lnp_plusbus.pdf

All but one line are operated by DB Regio AG Südost, only line S7 is operated by Abellio Rail Mitteldeutschland. Not entirely sure how to attribute that source since I read that from the HAFAS data