### PR TITLE
Added tram lines in Ulm

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -26,6 +26,8 @@ db-regio-nordost,RE6,db-regio-ag-nordost,re-6,#da6ba2,#ffffff,,rectangle
 db-regio-nordost,RE66,db-regio-ag-nordost,re-66,#007734,#ffffff,,rectangle
 db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#007734,#ffffff,,rectangle
 db-regio-sudost,RE14,db-regio-ag-sudost,re-14,#a98956,#ffffff,,rectangle
+ding-swu,STR 1,,8-ald087-1,#e52329,#ffffff,,rectangle
+ding-swu,STR 2,,8-ald087-2,#3fad56,#ffffff,,rectangle
 gabw,IRE 1,go-ahead-baden-wurttemberg-gmbh,ire-1,#88c946,#ffffff,,rectangle
 gabw,MEX 13,go-ahead-baden-wurttemberg-gmbh,mex-13,#00b9f2,#ffffff,,rectangle
 gabw,MEX 16,go-ahead-baden-wurttemberg-gmbh,mex-16,#0073c0,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -27,6 +27,21 @@
             }
         ]
     },
+    
+    {
+        "shortOperatorName": "ding-swu",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "SWU Liniennetz Bus und Tram 2023",
+                "source": "https://www.swu.de/fileadmin/content/mobilitaet/karten/2023/Liniennetzplan_2023-05-27.pdf"
+            }
+        ]
+    },
     {
         "shortOperatorName": "gabw",
         "contributors": [

--- a/sources.json
+++ b/sources.json
@@ -27,7 +27,6 @@
             }
         ]
     },
-    
     {
         "shortOperatorName": "ding-swu",
         "contributors": [


### PR DESCRIPTION
Added tram lines according to https://www.swu.de/fileadmin/content/mobilitaet/karten/2023/Liniennetzplan_2023-05-27.pdf .

Because circles are not yet supported as icon shapes, the busses are not added.