### PR TITLE
Add S-Bahn Zentralschweiz

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -242,10 +242,10 @@ s-bahn-zentralschweiz-bls,S 6,bls-ag,4-850033-6-924462-5234071,#0165b6,#ffffff,,
 s-bahn-zentralschweiz-bls,S 7,bls-ag,4-850033-7,#73c0e8,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-bls,S 77,bls-ag,4-850033-77,#7a84c4,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-sbb,S 1,sbb,4-85-1-924462-5234071,#1bb04d,#ffffff,,rectangle-rounded-corner
-s-bahn-zentralschweiz-sbb,S 2,sbb,4-85-2-947252-5247813,#f93f27,#ffffff,,rectangle-rounded,corner
-s-bahn-zentralschweiz-sbb,S 3,sbb,4-85-3-924462-5234071,#fe7d25,#ffffff,,rectangle-rounded,corner
-s-bahn-zentralschweiz-sbb,S 9,sbb,4-85-9-924462-5234071,#a3cf45,#ffffff,,rectangle-rounded,corner
-s-bahn-zentralschweiz-sbb,S 99,sbb,4-85-99,#95b15e,#ffffff,,rectangle-rounded,corner
+s-bahn-zentralschweiz-sbb,S 2,sbb,4-85-2-947252-5247813,#f93f27,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-sbb,S 3,sbb,4-85-3-924462-5234071,#fe7d25,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-sbb,S 9,sbb,4-85-9-924462-5234071,#a3cf45,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-sbb,S 99,sbb,4-85-99,#95b15e,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-zb,S 4,zentralbahn,4-850086-4,#aa2a3f,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-zb,S 41,zentralbahn,4-850086-41,#055d80,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-zb,S 44,zentralbahn,4-850086-44,#d35d68,#ffffff,,rectangle-rounded-corner

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -238,6 +238,19 @@ s-bahn-hannover-transdev,S 51,s-bahn-hannover-transdev,4-tdhs-51,#f18700,#ffffff
 s-bahn-hannover-transdev,S 6,s-bahn-hannover-transdev,4-tdhs-6,#004f9f,#ffffff,,rectangle-rounded-corner
 s-bahn-hannover-transdev,S 7,s-bahn-hannover-transdev,4-tdhs-7,#afcb27,#ffffff,,rectangle-rounded-corner
 s-bahn-hannover-transdev,S 4,s-bahn-hannover-transdev,4-tdhs-8,#1794ca,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-bls,S 6,bls-ag,4-850033-6-924462-5234071,#0165b6,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-bls,S 7,bls-ag,4-850033-7,#73c0e8,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-bls,S 77,bls-ag,4-850033-77,#7a84c4,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-sbb,S 1,sbb,4-85-1-924462-5234071,#1bb04d,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-sbb,S 2,sbb,4-85-2-947252-5247813,#f93f27,#ffffff,,rectangle-rounded,corner
+s-bahn-zentralschweiz-sbb,S 3,sbb,4-85-3-924462-5234071,#fe7d25,#ffffff,,rectangle-rounded,corner
+s-bahn-zentralschweiz-sbb,S 9,sbb,4-85-9-924462-5234071,#a3cf45,#ffffff,,rectangle-rounded,corner
+s-bahn-zentralschweiz-sbb,S 99,sbb,4-85-99,#95b15e,#ffffff,,rectangle-rounded,corner
+s-bahn-zentralschweiz-zb,S 4,zentralbahn,4-850086-4,#aa2a3f,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-zb,S 41,zentralbahn,4-850086-41,#055d80,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-zb,S 44,zentralbahn,4-850086-44,#d35d68,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-zb,S 5,zentralbahn,4-850086-5,#fb47a3,#ffffff,,rectangle-rounded-corner
+s-bahn-zentralschweiz-zb,S 55,zentralbahn,4-850086-55,#fc87bf,#ffffff,,rectangle-rounded-corner
 svv-oebb,R3,osterreichische-bundesbahnen,r-3,#9dba3b,#ffffff,,rectangle-rounded-corner
 svv-oebb,R9,osterreichische-bundesbahnen,r-9,#dbbe2b,#ffffff,,rectangle-rounded-corner
 svv-oebb,R21,osterreichische-bundesbahnen,r-21,#42b3ca,#ffffff,,rectangle-rounded-corner

--- a/sources.json
+++ b/sources.json
@@ -459,6 +459,48 @@
         ]
     },
     {
+        "shortOperatorName": "s-bahn-zentralschweiz-bls",
+        "contributors": [
+            {
+                "github": "sinsa92"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan Regionalverkehr Zentralschweiz",
+                "source": "https://www.vvl.ch/application/files/9616/8129/0865/SBB_RV_S-Bahn_LUZERN_A2_2022.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "s-bahn-zentralschweiz-sbb",
+        "contributors": [
+            {
+                "github": "sinsa92"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan Regionalverkehr Zentralschweiz",
+                "source": "https://www.vvl.ch/application/files/9616/8129/0865/SBB_RV_S-Bahn_LUZERN_A2_2022.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "s-bahn-zentralschweiz-zb",
+        "contributors": [
+            {
+                "github": "sinsa92"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan Regionalverkehr Zentralschweiz",
+                "source": "https://www.vvl.ch/application/files/9616/8129/0865/SBB_RV_S-Bahn_LUZERN_A2_2022.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "svv-oebb",
         "contributors": [
             {


### PR DESCRIPTION
This merge requests adds the line colors for the S-Bahn Luzern and the S-Bahn Zug (commonly referred to as S-Bahn Zentralschweiz, since they share the S 1 and the S 3, and have no overlapping line numbers).

There are three different operators (BLS, SBB, Zentralbahn), which is why the source entry is entered three times.

The line id's are quite long for some lines, since some operators have multiple lines with the same name (e.g. BLS has two S6, one for Bern and one for Luzern).

All colors and sources are from https://www.vvl.ch/application/files/9616/8129/0865/SBB_RV_S-Bahn_LUZERN_A2_2022.pdf.