### PR TITLE
Update NRW colours for 2024

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -174,7 +174,7 @@ nrw-regional,RE 11,national-express,re-11,#5accc2,#ffffff,,rectangle-rounded-cor
 nrw-regional,RE 12,db-regio-ag-nrw,re-12,#ad294c,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 13,eurobahn,re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 14,rheinruhrbahn-transdev,rrb-re14,#003328,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 16,db-regio-ag-nrw,re-16,#0e5778,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 16,vias-rail-gmbh,via-re16,#0e5778,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 17,db-regio-ag-nrw,re-17,#489b40,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 18,db-arriva,re-18,#10b3b4,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 19,vias-rail-gmbh,via-re19,#2f652b,#ffffff,,rectangle-rounded-corner
@@ -201,10 +201,11 @@ nrw-regional,RB 36,rheinruhrbahn-transdev,rrb-rb36,#7a7c80,#ffffff,,rectangle-ro
 nrw-regional,RB 38,db-regio-ag-nrw,rb-38,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 39,vias-rail-gmbh,via-rb39,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 40,db-regio-ag-nrw,rb-40,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 41,db-regio-ag-nrw,re-41,#5844a4,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 42,db-regio-ag-nrw,re-42,#d9bf13,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 43,db-regio-ag-nrw,rb-43,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 44,rheinruhrbahn-transdev,rrb-re44,#6294b0,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 46,db-regio-ag-nrw,rb-46,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 46,vias-rail-gmbh,via-rb46,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 47,regiobahn,r-re-47,#66cdec,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 48,national-express,rb-48,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 49,db-regio-ag-nrw,re-49,#c4836b,#ffffff,,rectangle-rounded-corner
@@ -213,10 +214,11 @@ nrw-regional,RB 51,db-regio-ag-nrw,rb-51,#7a7c80,#ffffff,,rectangle-rounded-corn
 nrw-regional,RB 52,db-regio-ag-nrw,rb-52,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 53,db-regio-ag-nrw,rb-53,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 54,db-regio-ag-nrw,rb-54,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 57,db-regio-ag-nrw,rb-57,#2e6da6,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 57,db-regio-ag-nrw,re-57,#2e6da6,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 58,nordwestbahn,nwb-rb58,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 59,eurobahn,rb-59,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 61,eurobahn,rb-61,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 62,db-regio-ag-nord,re-62,#1f52a6,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 63,db-regio-ag-nrw,rb-63,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 64,db-regio-ag-nrw,rb-64,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 65,eurobahn,rb-65,#7a7c80,#ffffff,,rectangle-rounded-corner
@@ -235,7 +237,7 @@ nrw-regional,RB 84,nordwestbahn,nwb-rb84,#7a7c80,#ffffff,,rectangle-rounded-corn
 nrw-regional,RB 85,nordwestbahn,nwb-rb85,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 89,eurobahn,rb-89,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 90,hlb-hessenbahn-gmbh,hlb-rb90,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 91,db-regio-ag-nrw,rb-91,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 91,vias-rail-gmbh,via-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 91,hlb-hessenbahn-gmbh,hlb-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 92,hlb-hessenbahn-gmbh,hlb-rb92,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 93,hlb-hessenbahn-gmbh,hlb-rb93,#7a7c80,#ffffff,,rectangle-rounded-corner
@@ -244,21 +246,21 @@ nrw-regional,RB 95,hlb-hessenbahn-gmbh,hlb-rb95,#7a7c80,#ffffff,,rectangle-round
 nrw-regional,RB 96,hlb-hessenbahn-gmbh,hlb-rb96,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 97,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-97,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 99,hlb-hessenbahn-gmbh,hlb-re99,#28b34c,#ffffff,,rectangle-rounded-corner
-nrw-sbahn,S 1,db-regio-ag-nrw,4-800337-1,#0b9a33,#ffffff,,pill
-nrw-sbahn,S 2,db-regio-ag-nrw,4-8003l1-2,#006db6,#ffffff,,pill
-nrw-sbahn,S 3,db-regio-ag-nrw,4-8003l1-3,#ffff00,#000000,,pill
-nrw-sbahn,S 4,db-regio-ag-nrw,4-800337-4,#ef7c00,#ffffff,,pill
-nrw-sbahn,S 5,db-regio-ag-nrw,4-800354-5,#98c60f,#ffffff,,pill
-nrw-sbahn,S 6,db-regio-ag-nrw,4-8003rl-6,#dc052d,#ffffff,,pill
-nrw-sbahn,S 7,vias-rail-gmbh,4-r4s7-s7,#14bae6,#ffffff,,pill
-nrw-sbahn,S 8,db-regio-ag-nrw,4-800354-8,#b03303,#ffffff,,pill
-nrw-sbahn,S 9,db-regio-ag-nrw,4-8003l1-9,#c7007f,#ffffff,,pill
-nrw-sbahn,S 11,db-regio-ag-nrw,4-8003s-11,#ef7c00,#ffffff,,pill
-nrw-sbahn,S 12,db-regio-ag-nrw,4-8003s-12,#61af20,#ffffff,,pill
-nrw-sbahn,S 19,db-regio-ag-nrw,4-8003s-19,#2d6c7e,#ffffff,,pill
-nrw-sbahn,S 23,db-regio-ag-nrw,4-800352-23,#8b3c59,#ffffff,,pill
-nrw-sbahn,S 28,regiobahn,4-m2-28,#717676,#ffffff,,pill
-nrw-sbahn,S 68,db-regio-ag-nrw,4-8003s-68,#14bae6,#ffffff,,pill
+nrw-sbahn,S 1,db-regio-ag-nrw,4-800337-1,#0cb14b,#ffffff,,pill
+nrw-sbahn,S 2,db-regio-ag-nrw,4-8003l1-2,#0074bc,#ffffff,,pill
+nrw-sbahn,S 3,db-regio-ag-nrw,4-8003l1-3,#fff200,#000000,,pill
+nrw-sbahn,S 4,db-regio-ag-nrw,4-800337-4,#f5821f,#ffffff,,pill
+nrw-sbahn,S 5,db-regio-ag-nrw,4-800354-5,#80c342,#ffffff,,pill
+nrw-sbahn,S 6,db-regio-ag-nrw,4-8003rl-6,#e21d3c,#ffffff,,pill
+nrw-sbahn,S 7,rheinruhrbahn-transdev,4-tdrr-s7,#00afb5,#ffffff,,pill
+nrw-sbahn,S 8,db-regio-ag-nrw,4-800354-8,#b23815,#ffffff,,pill
+nrw-sbahn,S 9,db-regio-ag-nrw,4-8003l1-9,#c6168d,#ffffff,,pill
+nrw-sbahn,S 11,db-regio-ag-nrw,4-8003s-11,#f26522,#ffffff,,pill
+nrw-sbahn,S 12,db-regio-ag-nrw,4-8003s-12,#4db857,#ffffff,,pill
+nrw-sbahn,S 19,db-regio-ag-nrw,4-8003s-19,#00658e,#ffffff,,pill
+nrw-sbahn,S 23,db-regio-ag-nrw,4-800352-23,#8c2a77,#ffffff,,pill
+nrw-sbahn,S 28,regiobahn,4-m2-28,#4a0b4d,#ffffff,,pill
+nrw-sbahn,S 68,db-regio-ag-nrw,4-8003s-68,#00bfe8,#ffffff,,pill
 odeg,RB33,ostdeutsche-eisenbahn-gmbh,rb-33,#a5027d,#ffffff,,rectangle
 odeg,RB37,ostdeutsche-eisenbahn-gmbh,rb-37,#ad5937,#ffffff,,rectangle
 odeg,RB46,ostdeutsche-eisenbahn-gmbh,rb-46,#da6ba2,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -299,8 +299,8 @@
         ],
         "sources": [
             {
-                "name": "NRW-Regionalverkehrsplan 2023",
-                "source": "https://www.kcitf-nrw.de/fileadmin/03_KC_Seiten/KCITF/Regionalverkehrsplan/Regionalverkehrsplan_NRW_2023_Web.pdf"
+                "name": "NRW-Fahrplanbuch 2024",
+                "source": "https://www.vrs.de/securedl/sdl-eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MDE3OTA4MTcsImV4cCI6MTcwMTgyMDgwMCwidXNlciI6MCwiZ3JvdXBzIjpbMCwtMV0sImZpbGUiOiJmaWxlYWRtaW4vRGF0ZWllbi9Eb3dubG9hZGNlbnRlci9GYWhycGxhbm1lZGllbi9OUldfRmFocnBsYW4yMDI0LlBERiIsInBhZ2UiOjEwODZ9.G9r0FkuaYSG-eIyqkKUkS_3HCX_FuVVE0C5ZV6Yf2nM/NRW_Fahrplan2024.PDF"
             }
         ]
     },
@@ -313,8 +313,8 @@
         ],
         "sources": [
             {
-                "name": "NRW-Fahrplanbuch 2023",
-                "source": "https://infoportal.mobil.nrw/information-service/fahrplanbuch-nrw.html"
+                "name": "NRW-Fahrplanbuch 2024",
+                "source": "https://www.vrs.de/securedl/sdl-eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MDE3OTA4MTcsImV4cCI6MTcwMTgyMDgwMCwidXNlciI6MCwiZ3JvdXBzIjpbMCwtMV0sImZpbGUiOiJmaWxlYWRtaW4vRGF0ZWllbi9Eb3dubG9hZGNlbnRlci9GYWhycGxhbm1lZGllbi9OUldfRmFocnBsYW4yMDI0LlBERiIsInBhZ2UiOjEwODZ9.G9r0FkuaYSG-eIyqkKUkS_3HCX_FuVVE0C5ZV6Yf2nM/NRW_Fahrplan2024.PDF"
             }
         ]
     },


### PR DESCRIPTION
- add new lines RE41, RE62 [new line RB37 could not yet be added bc it's not in Hafas yet]
- edit operator for RE16, RB46, RB91, S7
- fix RE57
- fix S-Bahn colours from better source

Please only merge this on or after 10 December 2023