### PR TITLE
feat: add uestra tram lines

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -375,6 +375,20 @@ sweg-sudwest,RB 66,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb66,#014f9f,#ff
 sweg-sudwest,RB 67,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb67,#00a9df,#ffffff,,rectangle
 sweg-sudwest,RB 68,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb68,#ec2933,#ffffff,,rectangle
 sweg-sudwest,RB 69,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb69,#f27320,#ffffff,,rectangle
+uestra,1,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-1,#ffffff,#2c2e35,#ff2e3e,rectangle
+uestra,2,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-2,#ffffff,#2c2e35,#ff2e3e,rectangle
+uestra,3,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-3,#ffffff,#2c2e35,#0073c0,rectangle
+uestra,4,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-4,#ffffff,#2c2e35,#ffac2e,rectangle
+uestra,5,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-5,#ffffff,#2c2e35,#ffac2e,rectangle
+uestra,6,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-6,#ffffff,#2c2e35,#ffac2e,rectangle
+uestra,7,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-7,#ffffff,#2c2e35,#0073c0,rectangle
+uestra,8,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-8,#ffffff,#2c2e35,#ff2e3e,rectangle
+uestra,9,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-9,#ffffff,#2c2e35,#0073c0,rectangle
+uestra,10,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-10,#ffffff,#2c2e35,#6dc248,rectangle
+uestra,11,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-11,#ffffff,#2c2e35,#ffac2e,rectangle
+uestra,12,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-12,#ffffff,#2c2e35,#6dc248,rectangle
+uestra,13,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-13,#ffffff,#2c2e35,#0073c0,rectangle
+uestra,17,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-17,#ffffff,#2c2e35,#6dc248,rectangle
 vbb-bvg-ubahn,U1,,7-vbbbvu-1,#7dad4c,#ffffff,,rectangle
 vbb-bvg-ubahn,U2,,7-vbbbvu-2,#da421e,#ffffff,,rectangle
 vbb-bvg-ubahn,U3,,7-vbbbvu-3,#16683d,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -585,6 +585,20 @@
         ]
     },
     {
+        "shortOperatorName": "uestra",
+        "contributors": [
+            {
+                "github": "vainamov"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan Stadtbahn Hannover (PDF) ab dem 10. Dezember 2023",
+                "source": "https://www.uestra.de/fileadmin/Material/Fahrgast/Linieplaene/GVH_Stadtbahn_2024.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "vbb-bvg-ubahn",
         "contributors": [
             {


### PR DESCRIPTION
This PR adds the tram lines operated by the ÜSTRA in Hannover as of the newest timetable. Consequently it includes the new lines 12 and 13 and lacks the no longer existing lines 16 and 18.