### PR TITLE
Update Stuttgarts tram lines

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -721,22 +721,24 @@ vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle
 vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle
 vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle
 vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U1,,8-vvs020-u1,#cd9c72,#000000,,rectangle
-vvs-ssb-stadtbahn,U11,,8-vvs020-u11,#939598,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U12,,8-vvs020-u12,#85bbe5,#000000,,rectangle
-vvs-ssb-stadtbahn,U13,,8-vvs020-u13,#f59eb2,#000000,,rectangle
-vvs-ssb-stadtbahn,U14,,8-vvs020-u14,#69bd51,#000000,,rectangle
-vvs-ssb-stadtbahn,U15,,8-vvs020-u15,#015aaa,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U2,,8-vvs020-u2,#f36e31,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U29,,8-vvs020-u29,#fed304,#000000,,rectangle
-vvs-ssb-stadtbahn,U3,,8-vvs020-u3,#946241,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U34,,8-vvs020-u34,#69bd51,#000000,,rectangle
-vvs-ssb-stadtbahn,U4,,8-vvs020-u4,#7a67ae,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U5,,8-vvs020-u5,#00baf1,#000000,,rectangle
-vvs-ssb-stadtbahn,U6,,8-vvs020-u6,#ed028c,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U7,,8-vvs020-u7,#0ab38d,#ffffff,,rectangle
-vvs-ssb-stadtbahn,U8,,8-vvs020-u8,#fed304,#000000,,rectangle
-vvs-ssb-stadtbahn,U9,,8-vvs020-u9,#bfb678,#000000,,rectangle
+vvs-ssb-stadtbahn,SB,,3-vvs021-20,#ffb530,#24629d,,rectangle
+vvs-ssb-stadtbahn,U 1,,8-vvs020-u1,#d39d70,#000000,,rectangle
+vvs-ssb-stadtbahn,U 11,,8-vvs020-u11,#9b9c9f,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 12,,8-vvs020-u12,#80c6ea,#000000,,rectangle
+vvs-ssb-stadtbahn,U 13,,8-vvs020-u13,#fea0ba,#000000,,rectangle
+vvs-ssb-stadtbahn,U 14,,8-vvs020-u14,#64c255,#000000,,rectangle
+vvs-ssb-stadtbahn,U 15,,8-vvs020-u15,#0155ae,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 16,,8-vvs020-u16,#c6c03b,#000000,,rectangle
+vvs-ssb-stadtbahn,U 19,,8-vvs020-u19,#ffb530,#000000,,rectangle
+vvs-ssb-stadtbahn,U 2,,8-vvs020-u2,#ff6a2f,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 3,,8-vvs020-u3,#925d39,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 4,,8-vvs020-u4,#6866b5,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 5,,8-vvs020-u5,#18c5f4,#000000,,rectangle
+vvs-ssb-stadtbahn,U 6,,8-vvs020-u6,#fb3199,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 7,,8-vvs020-u7,#2bbb8f,#ffffff,,rectangle
+vvs-ssb-stadtbahn,U 8,,8-vvs020-u8,#c8b97b,#000000,,rectangle
+vvs-ssb-stadtbahn,U 9,,8-vvs020-u9,#ffd036,#000000,,rectangle
+vvs-ssb-stadtbahn,Zacke,,8-vvs021-10,#ffb530,#24629d,,rectangle
 westfalenbahn,RE 15,westfalenbahn,wfb-re15,#ea9d22,#ffffff,,rectangle
 westfalenbahn,RE 60,westfalenbahn,wfb-re60,#00a3de,#ffffff,,rectangle
 westfalenbahn,RE 70,westfalenbahn,wfb-re70,#005174,#ffffff,,rectangle


### PR DESCRIPTION
Updated Stuttgarts tram lines and added Seilbahn and Zahnradbahn. sources.json does not need an update.