### PR TITLE
Reorder sources.json and line-colors.csv

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -20,9 +20,9 @@ db-regio-bayern,RE 20,db-regio-ag-bayern,re-20,#e50000,#ffffff,,rectangle
 db-regio-bayern,RE 28,db-regio-ag-bayern,re-28,#e50000,#ffffff,,rectangle
 db-regio-bayern,RE 29,db-regio-ag-bayern,re-29,#ffffff,#ff6600,#ff6600,rectangle
 db-regio-bayern,RE 60,db-regio-ag-bayern,re-60,#ffffff,#800080,#800080,rectangle
-db-regio-mitte,RE 40,db-regio-ag-mitte,re-40,#ff9027,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RB 41,db-regio-ag-mitte,rb-41,#00ab4f,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RB 44,db-regio-ag-mitte,rb-44,#7ac547,#ffffff,,rectangle-rounded-corner
+db-regio-mitte,RE 40,db-regio-ag-mitte,re-40,#ff9027,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RE 45,db-regio-ag-mitte,re-45,#cf631a,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RE 73,db-regio-ag-mitte,re-73,#ff2e17,#ffffff,,rectangle-rounded-corner
 db-regio-nordost,FEX,db-regio-ag-nordost,fex19829,#79122f,#ffffff,,rectangle
@@ -53,24 +53,24 @@ db-regio-nordost,RE66,db-regio-ag-nordost,re-66,#007734,#ffffff,,rectangle
 db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#007734,#ffffff,,rectangle
 db-regio-sudost,RE14,db-regio-ag-sudost,re-14,#a98956,#ffffff,,rectangle
 db-regio-sudost,S1,db-regio-ag-sudost,4-800486-1,#f5de2b,#000000,,pill
+db-regio-sudost,S10,db-regio-ag-sudost,4-800486-10,#ffffff,#000000,#f5de2b,pill
 db-regio-sudost,S2,db-regio-ag-sudost,4-8004a9-2,#18a2e3,#ffffff,,pill
 db-regio-sudost,S3,db-regio-ag-sudost,4-800486-3,#e1001e,#ffffff,,pill
 db-regio-sudost,S4,db-regio-ag-sudost,4-800486-4,#109644,#ffffff,,pill
+db-regio-sudost,S47,db-regio-ag-sudost,4-8004a9-47,#53af4c,#ffffff,,pill
 db-regio-sudost,S5,db-regio-ag-sudost,4-800486-5,#ed7c1c,#ffffff,,pill
 db-regio-sudost,S5X,db-regio-ag-sudost,4-800486-5x,#fdce5c,#ffffff,,pill
 db-regio-sudost,S6,db-regio-ag-sudost,4-800486-6,#5c1239,#ffffff,,pill
 db-regio-sudost,S8,db-regio-ag-sudost,4-8004a9-8,#5c2582,#ffffff,,pill
 db-regio-sudost,S9,db-regio-ag-sudost,4-8004a9-9,#be006b,#ffffff,,pill
-db-regio-sudost,S10,db-regio-ag-sudost,4-800486-10,#ffffff,#000000,#f5de2b,pill
-db-regio-sudost,S47,db-regio-ag-sudost,4-8004a9-47,#53af4c,#ffffff,,pill
-db-regionetz-westfrankenbahn,RB 56,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-56,#fab23c,#ffffff,,rectangle
-db-regionetz-westfrankenbahn,RB 83,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-83,#fdd245,#000000,,rectangle
-db-regionetz-westfrankenbahn,RB 84,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-84,#e29c57,#ffffff,,rectangle
-db-regionetz-westfrankenbahn,RB 88,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-88,#47359c,#ffffff,,rectangle
-db-regionetz-westfrankenbahn,RE 80,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-80,#423f41,#ffffff,,rectangle
-db-regionetz-westfrankenbahn,RE 87,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-87,#ff2e17,#ffffff,,rectangle
-ding-swu,STR 1,,8-ald087-1,#e52329,#ffffff,,rectangle
-ding-swu,STR 2,,8-ald087-2,#3fad56,#ffffff,,rectangle
+db-wfb,RB 56,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-56,#fab23c,#ffffff,,rectangle
+db-wfb,RB 83,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-83,#fdd245,#000000,,rectangle
+db-wfb,RB 84,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-84,#e29c57,#ffffff,,rectangle
+db-wfb,RB 88,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-88,#47359c,#ffffff,,rectangle
+db-wfb,RE 80,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-80,#423f41,#ffffff,,rectangle
+db-wfb,RE 87,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-87,#ff2e17,#ffffff,,rectangle
+ding-swu,1,,8-ald087-1,#e52329,#ffffff,,rectangle
+ding-swu,2,,8-ald087-2,#3fad56,#ffffff,,rectangle
 gabw,IRE 1,go-ahead-baden-wurttemberg-gmbh,ire-1,#88c946,#ffffff,,rectangle
 gabw,MEX 13,go-ahead-baden-wurttemberg-gmbh,mex-13,#00b9f2,#ffffff,,rectangle
 gabw,MEX 16,go-ahead-baden-wurttemberg-gmbh,mex-16,#0073c0,#ffffff,,rectangle
@@ -99,33 +99,33 @@ hvv-hha,U 1,,7-hvv001-1,#0072bc,#ffffff,,rectangle
 hvv-hha,U 2,,7-hvv001-2,#ee1d23,#ffffff,,rectangle
 hvv-hha,U 3,,7-hvv001-3,#ffdc01,#ffffff,,rectangle
 hvv-hha,U 4,,7-hvv001-4,#00aaad,#ffffff,,rectangle
+kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#ffffff,#000000,,rectangle-rounded-corner
+kvv-avg,S FEX,albtal-verkehrs-gesellschaft-mbh,4-a6s1-fex,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner
-kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
-kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner
-kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,,rectangle-rounded-corner
-kvv-avg,S6,albtal-verkehrs-gesellschaft-mbh,4-a6s6-6,#282268,#ffffff,,rectangle-rounded-corner
-kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,,rectangle-rounded-corner
-kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,,rectangle-rounded-corner
 kvv-avg,S11,albtal-verkehrs-gesellschaft-mbh,4-a6s11-11,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S12,albtal-verkehrs-gesellschaft-mbh,4-a6s12-12,#00a76d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
 kvv-avg,S31,albtal-verkehrs-gesellschaft-mbh,4-a6s31-31,#00a99d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S32,albtal-verkehrs-gesellschaft-mbh,4-a6s32-32,#00a99d,#ffffff,,rectangle-rounded-corner
+kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner
 kvv-avg,S41,albtal-verkehrs-gesellschaft-mbh,4-a6s41-41,#bed730,#ffffff,,rectangle-rounded-corner
 kvv-avg,S42,albtal-verkehrs-gesellschaft-mbh,4-a6s42-42,#0097bb,#ffffff,,rectangle-rounded-corner
+kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,,rectangle-rounded-corner
 kvv-avg,S51,albtal-verkehrs-gesellschaft-mbh,4-a6s51-51,#f69795,#ffffff,,rectangle-rounded-corner
 kvv-avg,S52,albtal-verkehrs-gesellschaft-mbh,4-a6s52-52,#f69795,#ffffff,,rectangle-rounded-corner
+kvv-avg,S6,albtal-verkehrs-gesellschaft-mbh,4-a6s6-6,#282268,#ffffff,,rectangle-rounded-corner
+kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,,rectangle-rounded-corner
 kvv-avg,S71,albtal-verkehrs-gesellschaft-mbh,4-a6s71-71,#fff200,#000000,,rectangle-rounded-corner
+kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,,rectangle-rounded-corner
 kvv-avg,S81,albtal-verkehrs-gesellschaft-mbh,4-a6s81-81,#6e692a,#ffffff,,rectangle-rounded-corner
-kvv-avg,S FEX,albtal-verkehrs-gesellschaft-mbh,4-a6s1-fex,#00a76d,#ffffff,,rectangle-rounded-corner
-kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#ffffff,#000000,,rectangle-rounded-corner
 kvv-vbk,1,,8-kvv021-1,#ed1c24,#ffffff,,rectangle
+kvv-vbk,16,,8-kvv021-16,#660000,#ffffff,,rectangle
+kvv-vbk,17,,8-kvv021-17,#660000,#ffffff,,rectangle
+kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,,rectangle
 kvv-vbk,2,,8-kvv021-2,#0071bc,#ffffff,,rectangle
 kvv-vbk,3,,8-kvv021-3,#947139,#ffffff,,rectangle
 kvv-vbk,4,,8-kvv021-4,#ffcb04,#000000,,rectangle
 kvv-vbk,5,,8-kvv021-5,#00c0f3,#ffffff,,rectangle
-kvv-vbk,16,,8-kvv021-16,#660000,#ffffff,,rectangle
-kvv-vbk,17,,8-kvv021-17,#660000,#ffffff,,rectangle
-kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,,rectangle
 kvv-vbk,E,,8-kvv021-e,#ffffff,#000000,,rectangle
 kvv-vbk,NL1,,8-kvv021-nl1,#ed1c24,#ffffff,,rectangle
 kvv-vbk,NL2,,8-kvv021-nl2,#0071bc,#ffffff,,rectangle
@@ -162,28 +162,28 @@ mvv-mvg-ubahn,U3,,7-swm001-3,#ec6725,#ffffff,,rectangle
 mvv-mvg-ubahn,U4,,7-swm001-4,#00a984,#ffffff,,rectangle
 mvv-mvg-ubahn,U5,,7-swm001-5,#bc7a00,#ffffff,,rectangle
 mvv-mvg-ubahn,U6,,7-swm001-6,#0065ae,#ffffff,,rectangle
-nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,,rectangle
 nah-sh,RB 61,nordbahn-eisenbahngesellschaft,nbe-rb61,#174094,#ffffff,,rectangle
 nah-sh,RB 62,db-regio-ag-nord,rb-62,#00aeca,#000000,,rectangle
 nah-sh,RB 63,nordbahn-eisenbahngesellschaft,nbe-rb63,#ffdc00,#000000,,rectangle
 nah-sh,RB 64,db-regio-ag-nord,rb-64,#c2d0eb,#000000,,rectangle
 nah-sh,RB 65,norddeutsche-eisenbahn-gesellschaft,neg-rb65,#dedd00,#000000,,rectangle
 nah-sh,RB 66,norddeutsche-eisenbahn-gesellschaft,neg-rb66,#798e0e,#ffffff,,rectangle
-nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,,rectangle
-nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,,rectangle
 nah-sh,RB 71,nordbahn-eisenbahngesellschaft,nbe-rb71,#008bd2,#ffffff,,rectangle
-nah-sh,RE 72,db-regio-ag-nord,re-72,#adce6d,#000000,,rectangle
 nah-sh,RB 73,db-regio-ag-nord,rb-73,#008c57,#ffffff,,rectangle
-nah-sh,RE 74,db-regio-ag-nord,re-74,#0069b4,#ffffff,,rectangle
 nah-sh,RB 75,db-regio-ag-nord,rb-75,#ba731a,#ffffff,,rectangle
 nah-sh,RB 76,erixx,erx-rb76,#ffdc00,#000000,,rectangle
-nah-sh,RE 8,db-regio-ag-nord,re-8,#a3d9f0,#000000,,rectangle
-nah-sh,RE 80,db-regio-ag-nord,re-80,#d9338a,#ffffff,,rectangle
 nah-sh,RB 81,db-regio-ag-nord,rb-81,#798e0e,#ffffff,,rectangle
 nah-sh,RB 82,nordbahn-eisenbahngesellschaft,nbe-rb82,#9c9c9c,#ffffff,,rectangle
-nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,,rectangle
 nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,,rectangle
 nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,,rectangle
+nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,,rectangle
+nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,,rectangle
+nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,,rectangle
+nah-sh,RE 72,db-regio-ag-nord,re-72,#adce6d,#000000,,rectangle
+nah-sh,RE 74,db-regio-ag-nord,re-74,#0069b4,#ffffff,,rectangle
+nah-sh,RE 8,db-regio-ag-nord,re-8,#a3d9f0,#000000,,rectangle
+nah-sh,RE 80,db-regio-ag-nord,re-80,#d9338a,#ffffff,,rectangle
+nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,,rectangle
 nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#fbb902,#000000,,rectangle
 neb-niederbarnimer-eisenbahn,RB12,neb-niederbarnimer-eisenbahn,rb-12,#a5027d,#ffffff,,rectangle
 neb-niederbarnimer-eisenbahn,RB25,neb-niederbarnimer-eisenbahn,rb-25,#007cb0,#ffffff,,rectangle
@@ -196,65 +196,35 @@ neb-niederbarnimer-eisenbahn,RB60,neb-niederbarnimer-eisenbahn,rb-60,#66aa22,#ff
 neb-niederbarnimer-eisenbahn,RB61,neb-niederbarnimer-eisenbahn,rb-61,#992746,#ffffff,,rectangle
 neb-niederbarnimer-eisenbahn,RB62,neb-niederbarnimer-eisenbahn,rb-62,#da6ba2,#ffffff,,rectangle
 neb-niederbarnimer-eisenbahn,RB63,neb-niederbarnimer-eisenbahn,rb-63,#ffd502,#000000,,rectangle
-nrw-regional,RE 1,national-express,re-1,#ff2d16,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 2,db-regio-ag-nrw,re-2,#00b8f1,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 3,eurobahn,re-3,#e46e25,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 4,national-express,re-4,#e88f24,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 5,national-express,re-5,#0182ba,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 6,national-express,re-6,#9e2a96,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 7,national-express,re-7,#052e69,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 8,db-regio-ag-nrw,re-8,#006bbb,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 9,db-regio-ag-nrw,re-9,#401446,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 10,rheinruhrbahn-transdev,rrb-re10,#e66caf,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 11,national-express,re-11,#5accc2,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 12,db-regio-ag-nrw,re-12,#ad294c,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 13,eurobahn,re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 14,rheinruhrbahn-transdev,rrb-re14,#003328,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 16,vias-rail-gmbh,via-re16,#0e5778,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 17,db-regio-ag-nrw,re-17,#489b40,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 18,db-arriva,re-18,#10b3b4,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 19,vias-rail-gmbh,via-re19,#2f652b,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 20,db-regio-ag-nrw,rb-20,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 21,rurtalbahn,rtb-rb21,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 22,db-regio-ag-nrw,re-22,#ffad3e,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 23,db-regio-ag-nrw,rb-23,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 24,db-regio-ag-nrw,rb-24,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 25,db-regio-ag-nrw,rb-25,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 26,mittelrheinbahn-trans-regio,rb-26,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 27,db-regio-ag-nrw,rb-27,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 28,rurtalbahn,rtb-rb28,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 29,sncb,re-29,#d594c8,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 30,db-regio-ag-nrw,rb-30,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 31,rheinruhrbahn-transdev,rrb-rb31,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 32,db-regio-ag-nrw,rb-32,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 33,db-regio-ag-nrw,rb-33,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 34,db-fernverkehr-ag,re-34,#8c467d,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 34,db-regio-ag-nrw,re-34,#8c467d,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 34,hlb-hessenbahn-gmbh,hlb-re34,#8c467d,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 34,vias-rail-gmbh,via-rb34,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 35,vias-rail-gmbh,via-rb35,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 36,rheinruhrbahn-transdev,rrb-rb36,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 38,db-regio-ag-nrw,rb-38,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 39,vias-rail-gmbh,via-rb39,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 40,db-regio-ag-nrw,rb-40,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 41,db-regio-ag-nrw,re-41,#5844a4,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 42,db-regio-ag-nrw,re-42,#d9bf13,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 43,db-regio-ag-nrw,rb-43,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 44,rheinruhrbahn-transdev,rrb-re44,#6294b0,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 46,vias-rail-gmbh,via-rb46,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 47,regiobahn,r-re-47,#66cdec,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 48,national-express,rb-48,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 49,db-regio-ag-nrw,re-49,#c4836b,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 50,eurobahn,rb-50,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 51,db-regio-ag-nrw,rb-51,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 52,db-regio-ag-nrw,rb-52,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 53,db-regio-ag-nrw,rb-53,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 54,db-regio-ag-nrw,rb-54,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 57,db-regio-ag-nrw,re-57,#2e6da6,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 58,nordwestbahn,nwb-rb58,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 59,eurobahn,rb-59,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 61,eurobahn,rb-61,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 62,db-regio-ag-nord,re-62,#1f52a6,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 63,db-regio-ag-nrw,rb-63,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 64,db-regio-ag-nrw,rb-64,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 65,eurobahn,rb-65,#7a7c80,#ffffff,,rectangle-rounded-corner
@@ -267,8 +237,6 @@ nrw-regional,RB 73,eurobahn,rb-73,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 74,nordwestbahn,nwb-rb74,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 75,nordwestbahn,nwb-rb75,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 77,regionalverkehre-start-deutschland-gmbh-start-niedersachsen-mitte,rb-77,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 78,eurobahn,re-78,#52b9ce,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 82,eurobahn,re-82,#489b40,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 84,nordwestbahn,nwb-rb84,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 85,nordwestbahn,nwb-rb85,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 89,eurobahn,rb-89,#7a7c80,#ffffff,,rectangle-rounded-corner
@@ -281,22 +249,54 @@ nrw-regional,RB 94,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-94,#7a7c80,#fffff
 nrw-regional,RB 95,hlb-hessenbahn-gmbh,hlb-rb95,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 96,hlb-hessenbahn-gmbh,hlb-rb96,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 97,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-97,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 1,national-express,re-1,#ff2d16,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 10,rheinruhrbahn-transdev,rrb-re10,#e66caf,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 11,national-express,re-11,#5accc2,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 12,db-regio-ag-nrw,re-12,#ad294c,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 13,eurobahn,re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 14,rheinruhrbahn-transdev,rrb-re14,#003328,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 16,vias-rail-gmbh,via-re16,#0e5778,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 17,db-regio-ag-nrw,re-17,#489b40,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 18,db-arriva,re-18,#10b3b4,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 19,vias-rail-gmbh,via-re19,#2f652b,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 2,db-regio-ag-nrw,re-2,#00b8f1,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 22,db-regio-ag-nrw,re-22,#ffad3e,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 29,sncb,re-29,#d594c8,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 3,eurobahn,re-3,#e46e25,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 34,db-fernverkehr-ag,re-34,#8c467d,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 34,db-regio-ag-nrw,re-34,#8c467d,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 34,hlb-hessenbahn-gmbh,hlb-re34,#8c467d,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 4,national-express,re-4,#e88f24,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 41,db-regio-ag-nrw,re-41,#5844a4,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 42,db-regio-ag-nrw,re-42,#d9bf13,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 44,rheinruhrbahn-transdev,rrb-re44,#6294b0,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 47,regiobahn,r-re-47,#66cdec,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 49,db-regio-ag-nrw,re-49,#c4836b,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 5,national-express,re-5,#0182ba,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 57,db-regio-ag-nrw,re-57,#2e6da6,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 6,national-express,re-6,#9e2a96,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 62,db-regio-ag-nord,re-62,#1f52a6,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 7,national-express,re-7,#052e69,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 78,eurobahn,re-78,#52b9ce,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 8,db-regio-ag-nrw,re-8,#006bbb,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 82,eurobahn,re-82,#489b40,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 9,db-regio-ag-nrw,re-9,#401446,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 99,hlb-hessenbahn-gmbh,hlb-re99,#28b34c,#ffffff,,rectangle-rounded-corner
 nrw-sbahn,S 1,db-regio-ag-nrw,4-800337-1,#0cb14b,#ffffff,,pill
+nrw-sbahn,S 11,db-regio-ag-nrw,4-8003s-11,#f26522,#ffffff,,pill
+nrw-sbahn,S 12,db-regio-ag-nrw,4-8003s-12,#4db857,#ffffff,,pill
+nrw-sbahn,S 19,db-regio-ag-nrw,4-8003s-19,#00658e,#ffffff,,pill
 nrw-sbahn,S 2,db-regio-ag-nrw,4-8003l1-2,#0074bc,#ffffff,,pill
+nrw-sbahn,S 23,db-regio-ag-nrw,4-800352-23,#8c2a77,#ffffff,,pill
+nrw-sbahn,S 28,regiobahn,4-m2-28,#4a0b4d,#ffffff,,pill
 nrw-sbahn,S 3,db-regio-ag-nrw,4-8003l1-3,#fff200,#000000,,pill
 nrw-sbahn,S 4,db-regio-ag-nrw,4-800337-4,#f5821f,#ffffff,,pill
 nrw-sbahn,S 5,db-regio-ag-nrw,4-800354-5,#80c342,#ffffff,,pill
 nrw-sbahn,S 6,db-regio-ag-nrw,4-8003rl-6,#e21d3c,#ffffff,,pill
+nrw-sbahn,S 68,db-regio-ag-nrw,4-8003s-68,#00bfe8,#ffffff,,pill
 nrw-sbahn,S 7,rheinruhrbahn-transdev,4-tdrr-s7,#00afb5,#ffffff,,pill
 nrw-sbahn,S 8,db-regio-ag-nrw,4-800354-8,#b23815,#ffffff,,pill
 nrw-sbahn,S 9,db-regio-ag-nrw,4-8003l1-9,#c6168d,#ffffff,,pill
-nrw-sbahn,S 11,db-regio-ag-nrw,4-8003s-11,#f26522,#ffffff,,pill
-nrw-sbahn,S 12,db-regio-ag-nrw,4-8003s-12,#4db857,#ffffff,,pill
-nrw-sbahn,S 19,db-regio-ag-nrw,4-8003s-19,#00658e,#ffffff,,pill
-nrw-sbahn,S 23,db-regio-ag-nrw,4-800352-23,#8c2a77,#ffffff,,pill
-nrw-sbahn,S 28,regiobahn,4-m2-28,#4a0b4d,#ffffff,,pill
-nrw-sbahn,S 68,db-regio-ag-nrw,4-8003s-68,#00bfe8,#ffffff,,pill
 odeg,RB33,ostdeutsche-eisenbahn-gmbh,rb-33,#a5027d,#ffffff,,rectangle
 odeg,RB37,ostdeutsche-eisenbahn-gmbh,rb-37,#ad5937,#ffffff,,rectangle
 odeg,RB46,ostdeutsche-eisenbahn-gmbh,rb-46,#da6ba2,#ffffff,,rectangle
@@ -312,13 +312,6 @@ ooevv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1589920-5372014,#342980,#fffff
 ooevv-oebb,S4,osterreichische-bundesbahnen,4-81-4-1589920-5372014,#a4ba00,#ffffff,,rectangle-rounded-corner
 ooevv-stern-hafferl,S5,stern-hafferl-verkehrs-gmbh,4-810008-5,#e2007a,#ffffff,,rectangle-rounded-corner
 polregio,RB91,polregio,r-91,#eb7405,#ffffff,,rectangle
-regio-s-bahn-donau-iller,RS 2,db-regio-ag-baden-wurttemberg,rs2,#901411,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 21,db-regio-ag-baden-wurttemberg,rs21,#e92a1c,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 3,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs3,#62358a,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 5,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs5,#00622e,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 51,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs51,#43aa2c,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 7,db-regio-ag-bayern,rs7,#234997,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 71,db-regio-ag-bayern,rs71,#1398d3,#ffffff,,pill
 regiobus-hannover,170,,5-webrbg-170,#ffffff,#2c2e35,#ff9027,pill
 regiobus-hannover,300,,5-webrbg-300,#ffffff,#2c2e35,#903da0,pill
 regiobus-hannover,301,,5-webrbg-301,#ffffff,#2c2e35,#ff2e17,pill
@@ -445,6 +438,7 @@ rmv-db-sbahn,S7,db-regio-ag-s-bahn-rhein-main,4-800528-7,#214d36,#ffffff,,pill
 rmv-db-sbahn,S8,db-regio-ag-s-bahn-rhein-main,4-800528-8,#88c946,#ffffff,,pill
 rmv-db-sbahn,S9,db-regio-ag-s-bahn-rhein-main,4-800528-9,#872996,#ffffff,,pill
 rmv-heag-tram,1,,8-rmvhtr-1,#f77893,#ffffff,,pill
+rmv-heag-tram,10,,8-rmvhtr-10,#872996,#ffffff,,pill
 rmv-heag-tram,2,,8-rmvhtr-2,#00ab4f,#ffffff,,pill
 rmv-heag-tram,3,,8-rmvhtr-3,#ffbe3c,#ffffff,,pill
 rmv-heag-tram,4,,8-rmvhtr-4,#1e78c2,#ffffff,,pill
@@ -453,7 +447,6 @@ rmv-heag-tram,6,,8-rmvhtr-6,#fe782b,#ffffff,,pill
 rmv-heag-tram,7,,8-rmvhtr-7,#fb3199,#ffffff,,pill
 rmv-heag-tram,8,,8-rmvhtr-8,#f5381f,#ffffff,,pill
 rmv-heag-tram,9,,8-rmvhtr-9,#7ac64d,#ffffff,,pill
-rmv-heag-tram,10,,8-rmvhtr-10,#872996,#ffffff,,pill
 rmv-vgf-ubahn,U1,,7-rmv255-1,#c52b1e,#ffffff,,pill
 rmv-vgf-ubahn,U2,,7-rmv255-2,#00ab4f,#ffffff,,pill
 rmv-vgf-ubahn,U3,,7-rmv255-3,#345aaf,#ffffff,,pill
@@ -463,11 +456,18 @@ rmv-vgf-ubahn,U6,,7-rmv255-6,#0082ca,#ffffff,,pill
 rmv-vgf-ubahn,U7,,7-rmv255-7,#f19e2d,#ffffff,,pill
 rmv-vgf-ubahn,U8,,7-rmv255-8,#ca7fbe,#ffffff,,pill
 rmv-vgf-ubahn,U9,,7-rmv255-9,#ffd939,#2c2e35,#2c2e35,pill
-rvf-vag-stadtbahn,STR 1,,8-vag011-1,#e8001b,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 2,,8-vag011-2,#13a538,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 3,,8-vag011-3,#f59e00,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 4,,8-vag011-4,#ea5297,#ffffff,,rectangle-rounded-corner
-rvf-vag-stadtbahn,STR 5,,8-vag011-5,#008bc5,#ffffff,,rectangle-rounded-corner
+rsb-di,RS 2,db-regio-ag-baden-wurttemberg,rs2,#901411,#ffffff,,pill
+rsb-di,RS 21,db-regio-ag-baden-wurttemberg,rs21,#e92a1c,#ffffff,,pill
+rsb-di,RS 3,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs3,#62358a,#ffffff,,pill
+rsb-di,RS 5,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs5,#00622e,#ffffff,,pill
+rsb-di,RS 51,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs51,#43aa2c,#ffffff,,pill
+rsb-di,RS 7,db-regio-ag-bayern,rs7,#234997,#ffffff,,pill
+rsb-di,RS 71,db-regio-ag-bayern,rs71,#1398d3,#ffffff,,pill
+rvf-vag-stadtbahn,1,,8-vag011-1,#e8001b,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,2,,8-vag011-2,#13a538,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,3,,8-vag011-3,#f59e00,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,4,,8-vag011-4,#ea5297,#ffffff,,rectangle-rounded-corner
+rvf-vag-stadtbahn,5,,8-vag011-5,#008bc5,#ffffff,,rectangle-rounded-corner
 s-bahn-bern-bls,S 1,bls-ag,4-850033-1,#50b447,#ffffff,,rectangle
 s-bahn-bern-bls,S 2,bls-ag,4-850033-2,#1cb1e6,#ffffff,,rectangle
 s-bahn-bern-bls,S 3,bls-ag,4-850033-3,#8868b3,#ffffff,,rectangle
@@ -513,37 +513,27 @@ svv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1451275-5318936,#28ab48,#ffffff,
 svv-slb,R33,salzburger-lokalbahnen,,#b93146,#ffffff,,rectangle-rounded-corner
 svv-slb,S1,salzburger-lokalbahnen,4-810007-1,#b4193c,#ffffff,,rectangle-rounded-corner
 svv-slb,S11,salzburger-lokalbahnen,4-810007-11,#b4193c,#ffffff,,rectangle-rounded-corner
-sweg-stuttgart,IRE 6,sweg-bahn-stuttgart-gmbh,ire-6,#ebaf2d,#ffffff,,rectangle
-sweg-stuttgart,MEX 12,sweg-bahn-stuttgart-gmbh,mex-12,#f27320,#ffffff,,rectangle
-sweg-stuttgart,MEX 17a,sweg-bahn-stuttgart-gmbh,mex-17a,#00a9df,#ffffff,,rectangle
-sweg-stuttgart,MEX 17c,sweg-bahn-stuttgart-gmbh,mex-17c,#ec2933,#ffffff,,rectangle
-sweg-stuttgart,MEX 18,sweg-bahn-stuttgart-gmbh,mex-18,#009c48,#ffffff,,rectangle
-sweg-stuttgart,RB 17a,sweg-bahn-stuttgart-gmbh,rb-17a,#00a9df,#ffffff,,rectangle
-sweg-stuttgart,RB 17c,sweg-bahn-stuttgart-gmbh,rb-17c,#ec2933,#ffffff,,rectangle
-sweg-stuttgart,RB 18,sweg-bahn-stuttgart-gmbh,rb-18,#009c48,#ffffff,,rectangle
-sweg-stuttgart,RE 10a,sweg-bahn-stuttgart-gmbh,re-10a,#014f9f,#ffffff,,rectangle
-sweg-stuttgart,RE 10b,sweg-bahn-stuttgart-gmbh,re-10b,#014f9f,#ffffff,,rectangle
-sweg-stuttgart,RE 17b,sweg-bahn-stuttgart-gmbh,re-17b,#7db83f,#ffffff,,rectangle
-sweg-sudwest,RB 59a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb59a,#ffc734,#ffffff,,rectangle
-sweg-sudwest,RB 66,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb66,#014f9f,#ffffff,,rectangle
-sweg-sudwest,RB 67,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb67,#00a9df,#ffffff,,rectangle
-sweg-sudwest,RB 68,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb68,#ec2933,#ffffff,,rectangle
-sweg-sudwest,RB 69,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb69,#f27320,#ffffff,,rectangle
+sweg,IRE 6,sweg-bahn-stuttgart-gmbh,ire-6,#ebaf2d,#ffffff,,rectangle
+sweg,MEX 12,sweg-bahn-stuttgart-gmbh,mex-12,#f27320,#ffffff,,rectangle
+sweg,MEX 17a,sweg-bahn-stuttgart-gmbh,mex-17a,#00a9df,#ffffff,,rectangle
+sweg,MEX 17c,sweg-bahn-stuttgart-gmbh,mex-17c,#ec2933,#ffffff,,rectangle
+sweg,MEX 18,sweg-bahn-stuttgart-gmbh,mex-18,#009c48,#ffffff,,rectangle
+sweg,RB 17a,sweg-bahn-stuttgart-gmbh,rb-17a,#00a9df,#ffffff,,rectangle
+sweg,RB 17c,sweg-bahn-stuttgart-gmbh,rb-17c,#ec2933,#ffffff,,rectangle
+sweg,RB 18,sweg-bahn-stuttgart-gmbh,rb-18,#009c48,#ffffff,,rectangle
+sweg,RB 59a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb59a,#ffc734,#ffffff,,rectangle
+sweg,RB 66,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb66,#014f9f,#ffffff,,rectangle
+sweg,RB 67,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb67,#00a9df,#ffffff,,rectangle
+sweg,RB 68,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb68,#ec2933,#ffffff,,rectangle
+sweg,RB 69,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb69,#f27320,#ffffff,,rectangle
+sweg,RE 10a,sweg-bahn-stuttgart-gmbh,re-10a,#014f9f,#ffffff,,rectangle
+sweg,RE 10b,sweg-bahn-stuttgart-gmbh,re-10b,#014f9f,#ffffff,,rectangle
+sweg,RE 17b,sweg-bahn-stuttgart-gmbh,re-17b,#7db83f,#ffffff,,rectangle
 uestra,1,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-1,#ffffff,#2c2e35,#ff2e3e,rectangle
-uestra,2,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-2,#ffffff,#2c2e35,#ff2e3e,rectangle
-uestra,3,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-3,#ffffff,#2c2e35,#0073c0,rectangle
-uestra,4,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-4,#ffffff,#2c2e35,#ffac2e,rectangle
-uestra,5,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-5,#ffffff,#2c2e35,#ffac2e,rectangle
-uestra,6,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-6,#ffffff,#2c2e35,#ffac2e,rectangle
-uestra,7,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-7,#ffffff,#2c2e35,#0073c0,rectangle
-uestra,8,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-8,#ffffff,#2c2e35,#ff2e3e,rectangle
-uestra,9,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-9,#ffffff,#2c2e35,#0073c0,rectangle
 uestra,10,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-10,#ffffff,#2c2e35,#6dc248,rectangle
+uestra,100,,5-webueb-100,#ffffff,#2c2e35,#fb3199,pill
 uestra,11,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-11,#ffffff,#2c2e35,#ffac2e,rectangle
 uestra,12,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-12,#ffffff,#2c2e35,#6dc248,rectangle
-uestra,13,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-13,#ffffff,#2c2e35,#0073c0,rectangle
-uestra,17,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-17,#ffffff,#2c2e35,#6dc248,rectangle
-uestra,100,,5-webueb-100,#ffffff,#2c2e35,#fb3199,pill
 uestra,120,,5-webueb-120,#ffffff,#2c2e35,#ff9027,pill
 uestra,121,,5-webueb-121,#ffffff,#2c2e35,#95cc45,pill
 uestra,122,,5-webueb-122,#ffffff,#2c2e35,#95cc45,pill
@@ -554,16 +544,20 @@ uestra,126,,5-webueb-126,#ffffff,#2c2e35,#ff2e17,pill
 uestra,127,,5-webueb-127,#ffffff,#2c2e35,#ffbe32,pill
 uestra,128,,5-webueb-128,#ffffff,#2c2e35,#af2a21,pill
 uestra,129,,5-webueb-129,#ffffff,#2c2e35,#fc5cac,pill
+uestra,13,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-13,#ffffff,#2c2e35,#0073c0,rectangle
 uestra,130,,5-webueb-130,#ffffff,#2c2e35,#95cc45,pill
 uestra,133,,5-webueb-133,#ffffff,#2c2e35,#ffbe32,pill
 uestra,134,,5-webueb-134,#ffffff,#2c2e35,#3ebc6d,pill
 uestra,135,,5-webueb-135,#ffffff,#2c2e35,#3ebc6d,pill
 uestra,136,,5-webueb-136,#ffffff,#2c2e35,#af2a21,pill
 uestra,137,,5-webueb-137,#ffffff,#2c2e35,#ff9027,pill
+uestra,17,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-17,#ffffff,#2c2e35,#6dc248,rectangle
+uestra,2,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-2,#ffffff,#2c2e35,#ff2e3e,rectangle
 uestra,200,,5-webueb-200,#ffffff,#2c2e35,#fc87bf,pill
 uestra,253,,5-webueb-253,#ffffff,#2c2e35,#ff9027,pill
 uestra,254,,5-webueb-254,#ffffff,#2c2e35,#35ccf6,pill
 uestra,267,,5-webueb-267,#ffffff,#2c2e35,#3ebc6d,pill
+uestra,3,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-3,#ffffff,#2c2e35,#0073c0,rectangle
 uestra,330,,5-webueb-330,#ffffff,#2c2e35,#ffbe32,pill
 uestra,340,,5-webueb-340,#ffffff,#2c2e35,#ff2e17,pill
 uestra,341,,5-webueb-341,#ffffff,#2c2e35,#3ebc6d,pill
@@ -576,15 +570,21 @@ uestra,371,,5-webueb-371,#ffffff,#2c2e35,#0155ae,pill
 uestra,372,,5-webueb-372,#ffffff,#2c2e35,#35ccf6,pill
 uestra,373,,5-webueb-373,#ffffff,#2c2e35,#ff9027,pill
 uestra,390,,5-webueb-390,#ffffff,#2c2e35,#95cc45,pill
+uestra,4,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-4,#ffffff,#2c2e35,#ffac2e,rectangle
 uestra,420,,5-webueb-420,#ffffff,#2c2e35,#fc87bf,pill
 uestra,450,,5-webueb-450,#ffffff,#2c2e35,#ffbe32,pill
 uestra,470,,5-webueb-470,#ffffff,#2c2e35,#fc87bf,pill
 uestra,480,,5-webueb-480,#ffffff,#2c2e35,#3ebc6d,pill
+uestra,5,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-5,#ffffff,#2c2e35,#ffac2e,rectangle
 uestra,581,,5-webueb-581,#ffffff,#2c2e35,#903da0,pill
+uestra,6,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-6,#ffffff,#2c2e35,#ffac2e,rectangle
 uestra,610,,5-webueb-610,#ffffff,#2c2e35,#3ebc6d,pill
 uestra,611,,5-webueb-611,#ffffff,#2c2e35,#af2a21,pill
 uestra,631,,5-webueb-631,#ffffff,#2c2e35,#95cc45,pill
+uestra,7,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-7,#ffffff,#2c2e35,#0073c0,rectangle
+uestra,8,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-8,#ffffff,#2c2e35,#ff2e3e,rectangle
 uestra,800,,5-webueb-800,#ffffff,#2c2e35,#35ccf6,pill
+uestra,9,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-9,#ffffff,#2c2e35,#0073c0,rectangle
 vbb-bvg-ubahn,U1,,7-vbbbvu-1,#7dad4c,#ffffff,,rectangle
 vbb-bvg-ubahn,U2,,7-vbbbvu-2,#da421e,#ffffff,,rectangle
 vbb-bvg-ubahn,U3,,7-vbbbvu-3,#16683d,#ffffff,,rectangle
@@ -648,11 +648,11 @@ vor-oebb,S1,osterreichische-bundesbahnen,4-81-1-1821578-5360392,#0097d5,#ffffff,
 vor-oebb,S2,osterreichische-bundesbahnen,4-81-2-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S3,osterreichische-bundesbahnen,4-81-3-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S4,osterreichische-bundesbahnen,4-81-4-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner
-vor-oebb,S7,osterreichische-bundesbahnen,4-81-7-1822664-5362609,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S40,osterreichische-bundesbahnen,4-81-40,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S45,osterreichische-bundesbahnen,4-81-45,#c8d200,#ffffff,,rectangle-rounded-corner
 vor-oebb,S50,osterreichische-bundesbahnen,4-81-50-1817428-5361639,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S60,osterreichische-bundesbahnen,4-81-60,#0097d5,#ffffff,,rectangle-rounded-corner
+vor-oebb,S7,osterreichische-bundesbahnen,4-81-7-1822664-5362609,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-oebb,S80,osterreichische-bundesbahnen,4-81-80,#0097d5,#ffffff,,rectangle-rounded-corner
 vor-wl,18,wiener-linien,8-810009-18,#c00808,#ffffff,,rectangle
 vor-wl,U1,wiener-linien,7-810009-1,#e3000f,#ffffff,,rectangle
@@ -661,7 +661,15 @@ vor-wl,U3,wiener-linien,7-810009-3,#ef7c00,#ffffff,,rectangle
 vor-wl,U4,wiener-linien,7-810009-4,#00963f,#ffffff,,rectangle
 vor-wl,U6,wiener-linien,7-810009-6,#9d6830,#ffffff,,rectangle
 vrn-rnv-tram,1,rhein-neckar-verkehr-gmbh,8-vrn008-1,#f39b9a,#ffffff,,rectangle
+vrn-rnv-tram,10,rhein-neckar-verkehr-gmbh,8-vrn008-10,#a60f80,#ffffff,,rectangle
+vrn-rnv-tram,15,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-15,#f7ab63,#ffffff,,rectangle
+vrn-rnv-tram,16,rhein-neckar-verkehr-gmbh,8-vrn008-16,#5e6baf,#ffffff,,rectangle
 vrn-rnv-tram,2,rhein-neckar-verkehr-gmbh,8-vrn008-2,#b00044,#ffffff,,rectangle
+vrn-rnv-tram,21,rhein-neckar-verkehr-gmbh,8-vrn011-21,#e3000b,#ffffff,,rectangle
+vrn-rnv-tram,22,rhein-neckar-verkehr-gmbh,8-vrn011-22,#fdc300,#ffffff,,rectangle
+vrn-rnv-tram,23,rhein-neckar-verkehr-gmbh,8-vrn011-23,#e48e00,#ffffff,,rectangle
+vrn-rnv-tram,24,rhein-neckar-verkehr-gmbh,8-vrn011-24,#8c1d75,#ffffff,,rectangle
+vrn-rnv-tram,26,rhein-neckar-verkehr-gmbh,8-vrn011-26,#f39b9a,#ffffff,,rectangle
 vrn-rnv-tram,3,rhein-neckar-verkehr-gmbh,8-vrn008-3,#d5ad00,#ffffff,,rectangle
 vrn-rnv-tram,4,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4,#e3000b,#ffffff,,rectangle
 vrn-rnv-tram,4A,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4a,#e3000b,#ffffff,,rectangle
@@ -673,30 +681,22 @@ vrn-rnv-tram,6E,rhein-neckar-verkehr-gmbh,8-vrn008-6e,#956b25,#ffffff,,rectangle
 vrn-rnv-tram,7,rhein-neckar-verkehr-gmbh,8-vrn008-7,#ffcc00,#ffffff,,rectangle
 vrn-rnv-tram,8,rhein-neckar-verkehr-gmbh,8-vrn008-8,#e17500,#ffffff,,rectangle
 vrn-rnv-tram,9,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-9,#93c23b,#ffffff,,rectangle
-vrn-rnv-tram,10,rhein-neckar-verkehr-gmbh,8-vrn008-10,#a60f80,#ffffff,,rectangle
-vrn-rnv-tram,15,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-15,#f7ab63,#ffffff,,rectangle
-vrn-rnv-tram,16,rhein-neckar-verkehr-gmbh,8-vrn008-16,#5e6baf,#ffffff,,rectangle
-vrn-rnv-tram,21,rhein-neckar-verkehr-gmbh,8-vrn011-21,#e3000b,#ffffff,,rectangle
-vrn-rnv-tram,22,rhein-neckar-verkehr-gmbh,8-vrn011-22,#fdc300,#ffffff,,rectangle
-vrn-rnv-tram,23,rhein-neckar-verkehr-gmbh,8-vrn011-23,#e48e00,#ffffff,,rectangle
-vrn-rnv-tram,24,rhein-neckar-verkehr-gmbh,8-vrn011-24,#8c1d75,#ffffff,,rectangle
-vrn-rnv-tram,26,rhein-neckar-verkehr-gmbh,8-vrn011-26,#f39b9a,#ffffff,,rectangle
 vrn-rnv-tram,X,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4x,#9d9d9d,#ffffff,,rectangle
 vrn-sbahn-rn,RE5,db-regio-ag-mitte,re-5,#f68a25,#ffffff,,pill
 vrn-sbahn-rn,RE9,db-regio-ag-mitte,re-9,#73c82c,#ffffff,,pill
 vrn-sbahn-rn,S1,db-regio-ag-mitte,4-801539-1,#ed1c24,#ffffff,,pill
 vrn-sbahn-rn,S2,db-regio-ag-mitte,4-801539-2,#1575c5,#ffffff,,pill
 vrn-sbahn-rn,S3,db-regio-ag-mitte,4-801539-3,#fddd04,#231f20,,pill
+vrn-sbahn-rn,S33,db-regio-ag-mitte,4-801539-33,#833aa1,#ffffff,,pill
+vrn-sbahn-rn,S39,db-regio-ag-mitte,4-801539-39,#ffffff,#bf5810,#bf5810,pill
 vrn-sbahn-rn,S4,db-regio-ag-mitte,4-801539-4,#00a650,#ffffff,,pill
+vrn-sbahn-rn,S44,db-regio-ag-mitte,4-801539-44,#ffffff,#00a650,#00a650,pill
 vrn-sbahn-rn,S5,db-regio-ag-mitte,4-801518-5,#f68a25,#ffffff,,pill
+vrn-sbahn-rn,S51,db-regio-ag-mitte,4-801518-51,#f68a25,#ffffff,,pill
 vrn-sbahn-rn,S6,db-regio-ag-mitte,4-801518-6,#40c1f3,#ffffff,,pill
 vrn-sbahn-rn,S7,db-regio-ag-mitte,4-801539-7,#ffffff,#ef249c,#ef249c,pill
 vrn-sbahn-rn,S8,db-regio-ag-mitte,4-801518-8,#a25bad,#ffffff,,pill
 vrn-sbahn-rn,S9,db-regio-ag-mitte,4-801518-9,#73c82c,#ffffff,,pill
-vrn-sbahn-rn,S33,db-regio-ag-mitte,4-801539-33,#833aa1,#ffffff,,pill
-vrn-sbahn-rn,S39,db-regio-ag-mitte,4-801539-39,#ffffff,#bf5810,#bf5810,pill
-vrn-sbahn-rn,S44,db-regio-ag-mitte,4-801539-44,#ffffff,#00a650,#00a650,pill
-vrn-sbahn-rn,S51,db-regio-ag-mitte,4-801518-51,#f68a25,#ffffff,,pill
 vrr-hst,CE51,,5-vrr050-ce51,#c10004,#ffffff,,rectangle-rounded-corner
 vrr-hst,CE52,,5-vrr050-ce52,#e63758,#ffffff,,rectangle-rounded-corner
 vrr-hst,510,,5-vrr050-510,#b06520,#ffffff,,rectangle-rounded-corner
@@ -723,6 +723,13 @@ vrr-hst,540,,5-vrr050-540,#364a9c,#ffffff,,rectangle-rounded-corner
 vrr-hst,541,,5-vrr050-541,#e63758,#ffffff,,rectangle-rounded-corner
 vrr-hst,542,,5-vrr050-542,#71c837,#ffffff,,rectangle-rounded-corner
 vrr-hst,543,,5-vrr050-543,#f49b00,#ffffff,,rectangle-rounded-corner
+vrr-rheinbahn,701,,8-vrr071-701,#f07d00,#ffffff,,rectangle
+vrr-rheinbahn,704,,8-vrr071-704,#bd1616,#ffffff,,rectangle
+vrr-rheinbahn,705,,8-vrr071-705,#c0087f,#ffffff,,rectangle
+vrr-rheinbahn,706,,8-vrr071-706,#e30613,#ffffff,,rectangle
+vrr-rheinbahn,707,,8-vrr071-707,#7e1974,#ffffff,,rectangle
+vrr-rheinbahn,708,,8-vrr071-708,#f29eb7,#ffffff,,rectangle
+vrr-rheinbahn,709,,8-vrr071-709,#e94190,#ffffff,,rectangle
 vrr-rheinbahn,U70,,7-vrr070-70,#71b2d0,#ffffff,,rectangle
 vrr-rheinbahn,U71,,7-vrr070-71,#59c6f2,#ffffff,,rectangle
 vrr-rheinbahn,U72,,7-vrr070-72,#25b8c5,#ffffff,,rectangle
@@ -734,25 +741,16 @@ vrr-rheinbahn,U77,,7-vrr070-77,#7197cf,#ffffff,,rectangle
 vrr-rheinbahn,U78,,7-vrr070-78,#009adf,#ffffff,,rectangle
 vrr-rheinbahn,U79,,7-vrr070-79,#009a93,#ffffff,,rectangle
 vrr-rheinbahn,U83,,7-vrr070-83,#1d3a8f,#ffffff,,rectangle
-vrr-rheinbahn,701,,8-vrr071-701,#f07d00,#ffffff,,rectangle
-vrr-rheinbahn,704,,8-vrr071-704,#bd1616,#ffffff,,rectangle
-vrr-rheinbahn,705,,8-vrr071-705,#c0087f,#ffffff,,rectangle
-vrr-rheinbahn,706,,8-vrr071-706,#e30613,#ffffff,,rectangle
-vrr-rheinbahn,707,,8-vrr071-707,#7e1974,#ffffff,,rectangle
-vrr-rheinbahn,708,,8-vrr071-708,#f29eb7,#ffffff,,rectangle
-vrr-rheinbahn,709,,8-vrr071-709,#e94190,#ffffff,,rectangle
 vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,,rectangle-rounded-corner
-vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner
-vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner
-vrs-stadtbahn,5,,8-vrs001-5,#a69dc8,#ffffff,,rectangle-rounded-corner
-vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,,rectangle-rounded-corner
-vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,12,,8-vrs001-12,#98c01e,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,13,,8-vrs001-13,#aa8567,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,15,,8-vrs001-15,#5aad31,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,16,,8-vrs001-16,#07ada5,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,17,,8-vrs001-17,#1e93d1,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,18,,8-vrs001-18,#85d1f5,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,5,,8-vrs001-5,#a69dc8,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,61,stadtwerke-bonn,8-s3-61,#9ab831,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,62,stadtwerke-bonn,8-s3-62,#65a53b,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,63,stadtwerke-bonn,8-s3-63,#8bccf3,#ffffff,,rectangle-rounded-corner
@@ -760,11 +758,13 @@ vrs-stadtbahn,65,stadtwerke-bonn,8-s3-65,#c6cc2a,#ffffff,,rectangle-rounded-corn
 vrs-stadtbahn,66,stadtwerke-bonn,8-s3-66,#d4417d,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,67,stadtwerke-bonn,8-s3-67,#e7a8c4,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,68,stadtwerke-bonn,8-s3-68,#cbaece,#ffffff,,rectangle-rounded-corner
-vvo-db-regio,RB U28,db-regio-ag-sudost,5400003,#014d6f,#ffffff,,pill
+vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,,rectangle-rounded-corner
 vvo-db-regio,RB 31,db-regio-ag-nordost,8010089,#6ab023,#ffffff,,rectangle
 vvo-db-regio,RB 33,db-regio-ag-sudost,8010089,#ec7797,#ffffff,,rectangle
 vvo-db-regio,RB 71,db-regio-ag-sudost,8012959,#ad006f,#ffffff,,rectangle
 vvo-db-regio,RB 72,db-regio-ag-sudost,8010163,#9c321b,#ffffff,,rectangle
+vvo-db-regio,RB U28,db-regio-ag-sudost,5400003,#014d6f,#ffffff,,pill
 vvo-db-regio,RE 15,db-regio-ag-nordost,8010177,#ffd400,#000000,,rectangle
 vvo-db-regio,RE 18,db-regio-ag-nordost,8010073,#ec7404,#ffffff,,rectangle
 vvo-db-regio,RE 19,db-regio-ag-sudost,8010085,#00895d,#ffffff,,rectangle
@@ -774,18 +774,18 @@ vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,,pill
 vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,,pill
 vvo-db-sbd,S 8,db-regio-ag-sudost,8010006,#2d92ad,#ffffff,,pill
 vvo-tram,1,,8-voe011-1,#e30018,#ffffff,,rectangle-rounded-corner
+vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,,rectangle-rounded-corner
+vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner
+vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner
+vvo-tram,13,,8-voe011-13,#fdc300,#000000,,rectangle-rounded-corner
 vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,,rectangle-rounded-corner
+vvo-tram,20,,8-voe011-20,#000000,#ffffff,,rectangle-rounded-corner
 vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,,rectangle-rounded-corner
 vvo-tram,4,,8-voe011-4,#c9061a,#ffffff,,rectangle-rounded-corner
 vvo-tram,6,,8-voe011-6,#ffdd00,#000000,,rectangle-rounded-corner
 vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,,rectangle-rounded-corner
 vvo-tram,8,,8-voe011-8,#229133,#ffffff,,rectangle-rounded-corner
 vvo-tram,9,,8-voe011-9,#93c355,#ffffff,,rectangle-rounded-corner
-vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,,rectangle-rounded-corner
-vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner
-vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner
-vvo-tram,13,,8-voe011-13,#fdc300,#000000,,rectangle-rounded-corner
-vvo-tram,20,,8-voe011-20,#000000,#ffffff,,rectangle-rounded-corner
 vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,,rectangle
 vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,,rectangle
 vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,,rectangle
@@ -843,32 +843,32 @@ zvnl-bus,N3,,5-naslvb-n3,#fed92b,#000000,,pill
 zvnl-bus,N4,,5-naslvb-n4,#fed92b,#000000,,pill
 zvnl-bus,N5,,5-naslvb-n5,#f5a522,#000000,,pill
 zvnl-bus,N6,,5-naslvb-n6,#fed92b,#000000,,pill
+zvnl-bus,N60,,5-naslvb-n60,#a61580,#000000,,pill
 zvnl-bus,N7,,5-naslvb-n7,#fee38e,#000000,,pill
 zvnl-bus,N8,,5-naslvb-n8,#f5a522,#000000,,pill
 zvnl-bus,N9,,5-naslvb-n9,#fed92b,#000000,,pill
-zvnl-bus,N60,,5-naslvb-n60,#a61580,#000000,,pill
 zvnl-tram,1,,8-naslvt-1,#67b337,#ffffff,,rectangle
-zvnl-tram,2,,8-naslvt-2,#fecb29,#000000,,rectangle
-zvnl-tram,3,,8-naslvt-3,#67b337,#ffffff,,rectangle
-zvnl-tram,4,,8-naslvt-4,#233b8d,#ffffff,,rectangle
-zvnl-tram,7,,8-naslvt-7,#233b8d,#ffffff,,rectangle
-zvnl-tram,8,,8-naslvt-8,#fecb29,#000000,,rectangle
-zvnl-tram,9,,8-naslvt-9,#fecb29,#000000,,rectangle
 zvnl-tram,10,,8-naslvt-10,#e1001e,#ffffff,,rectangle
 zvnl-tram,11,,8-naslvt-11,#e1001e,#ffffff,,rectangle
 zvnl-tram,12,,8-naslvt-12,#233b8d,#ffffff,,rectangle
 zvnl-tram,14,,8-naslvt-14,#18a0e1,#ffffff,,rectangle
 zvnl-tram,15,,8-naslvt-15,#233b8d,#ffffff,,rectangle
 zvnl-tram,16,,8-naslvt-16,#e1001e,#ffffff,,rectangle
+zvnl-tram,2,,8-naslvt-2,#fecb29,#000000,,rectangle
+zvnl-tram,3,,8-naslvt-3,#67b337,#ffffff,,rectangle
+zvnl-tram,4,,8-naslvt-4,#233b8d,#ffffff,,rectangle
 zvnl-tram,50,,8-naslvt-50,#ffffff,#000000,#000000,rectangle
 zvnl-tram,56,,8-naslvt-56,#ffffff,#000000,#000000,rectangle
+zvnl-tram,7,,8-naslvt-7,#233b8d,#ffffff,,rectangle
+zvnl-tram,8,,8-naslvt-8,#fecb29,#000000,,rectangle
+zvnl-tram,9,,8-naslvt-9,#fecb29,#000000,,rectangle
 zvnl-tram,N10,,8-naslvt-n10,#e1001e,#ffffff,,rectangle
 zvnl-tram,N17,,8-naslvt-n17,#67b337,#ffffff,,rectangle
 zvon-odeg,RB 64,ostdeutsche-eisenbahn-gmbh,8010177,#006552,#ffffff,,rectangle
 zvon-odeg,RB 65,ostdeutsche-eisenbahn-gmbh,8010073,#005b94,#ffffff,,rectangle
-zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,,rectangle
-zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,,rectangle
-zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangle
-zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
 zvon-tl,TL L7,trilex-die-landerbahn-gmbh-dlb,8012979,#ec7404,#ffffff,,rectangle
 zvon-tl,TL L9,trilex-die-landerbahn-gmbh-dlb,5400198,#58585a,#ffffff,,rectangle
+zvon-tl,TL RB60,trilex-die-landerbahn-gmbh-dlb,8010085,#38a962,#ffffff,,rectangle
+zvon-tl,TL RB61,trilex-die-landerbahn-gmbh-dlb,8010085,#00632e,#ffffff,,rectangle
+zvon-tl,TLX RE1,trilex-express-die-landerbahn-gmbh-dlb,8010085,#ec7404,#ffffff,,rectangle
+zvon-tl,TLX RE2,trilex-express-die-landerbahn-gmbh-dlb,8010085,#e2001a,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -1,19 +1,5 @@
 [
     {
-        "shortOperatorName": "db-regio-mitte",
-        "contributors": [
-            {
-                "github": "oneiricbotcelot"
-            }
-        ],
-        "sources": [
-            {
-                "name": "bwegt Netz 7b Liniennetz Regionalverkehr",
-                "source": "https://assets.static-bahn.de/dam/jcr:25a7e259-1c4f-45c5-ac0f-b257daf118a8/220825_Netz_7b_bwegt_CD_800x350_ET.pdf"
-            }
-        ]
-    },
-    {
         "shortOperatorName": "ams",
         "contributors": [
             {
@@ -41,6 +27,20 @@
             {
                 "name": "Liniennetzplan Bayern 2024",
                 "source": "https://assets.static-bahn.de/dam/jcr:bb360a26-c64c-4e3c-a6e2-71b57a1745d3/bayern-liniennetzplan-2024.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "db-regio-mitte",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "bwegt Netz 7b Liniennetz Regionalverkehr",
+                "source": "https://assets.static-bahn.de/dam/jcr:25a7e259-1c4f-45c5-ac0f-b257daf118a8/220825_Netz_7b_bwegt_CD_800x350_ET.pdf"
             }
         ]
     },
@@ -81,7 +81,7 @@
         ]
     },
     {
-        "shortOperatorName": "db-regionetz-westfrankenbahn",
+        "shortOperatorName": "db-wfb",
         "contributors": [
             {
                 "github": "oneiricbotcelot"
@@ -316,20 +316,6 @@
         ]
     },
     {
-        "shortOperatorName": "rvf-vag-stadtbahn",
-        "contributors": [
-            {
-                "github": "oneiricbotcelot"
-            }
-        ],
-        "sources": [
-            {
-                "name": "Linienfahrpläne",
-                "source": "https://www.vag-freiburg.de/fahrplan/linien-fahrplaene"
-            }
-        ]
-    },
-    {
         "shortOperatorName": "neb-niederbarnimer-eisenbahn",
         "contributors": [
             {
@@ -442,6 +428,28 @@
         ]
     },
     {
+        "shortOperatorName": "regiobus-hannover",
+        "contributors": [
+            {
+                "github": "vainamov"
+            }
+        ],
+        "sources": [
+            {
+                "name": "GVH Bus Hannover",
+                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplan-bus-hannover-2023-2024.pdf"
+            },
+            {
+                "name": "GVH Plan Stadt Hannover",
+                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplaene-faltplan-stadt-2023-2024.pdf"
+            },
+            {
+                "name": "GVH Plan Region Hannover",
+                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplaene-faltplan-region-2023-2024.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "rmv-db-sbahn",
         "contributors": [
             {
@@ -484,7 +492,7 @@
         ]
     },
     {
-        "shortOperatorName": "regio-s-bahn-donau-iller",
+        "shortOperatorName": "rsb-di",
         "contributors": [
             {
                 "github": "oneiricbotcelot"
@@ -498,24 +506,16 @@
         ]
     },
     {
-        "shortOperatorName": "regiobus-hannover",
+        "shortOperatorName": "rvf-vag-stadtbahn",
         "contributors": [
             {
-                "github": "vainamov"
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
             {
-                "name": "GVH Bus Hannover",
-                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplan-bus-hannover-2023-2024.pdf"
-            },
-            {
-                "name": "GVH Plan Stadt Hannover",
-                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplaene-faltplan-stadt-2023-2024.pdf"
-            },
-            {
-                "name": "GVH Plan Region Hannover",
-                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplaene-faltplan-region-2023-2024.pdf"
+                "name": "Linienfahrpläne",
+                "source": "https://www.vag-freiburg.de/fahrplan/linien-fahrplaene"
             }
         ]
     },
@@ -618,20 +618,6 @@
         ]
     },
     {
-        "shortOperatorName": "sweg-sudwest",
-        "contributors": [
-            {
-                "github": "oneriricbotcelot"
-            }
-        ],
-        "sources": [
-            {
-                "name": "Gesamtnetz Zollern-Alb und Ulmer Stern",
-                "source": "https://www.sweg.de/fileadmin//user_upload/pdf/liniennetzplaene/zollernalb/2021_11_22_SWEG_bwegt_GesamtNetz.pdf"
-            }
-        ]
-    },
-    {
         "shortOperatorName": "svv-slb",
         "contributors": [
             {
@@ -646,13 +632,17 @@
         ]
     },
     {
-        "shortOperatorName": "sweg-stuttgart",
+        "shortOperatorName": "sweg",
         "contributors": [
             {
-                "github": "oneiricbotcelot"
+                "github": "oneriricbotcelot"
             }
         ],
         "sources": [
+            {
+                "name": "Gesamtnetz Zollern-Alb und Ulmer Stern",
+                "source": "https://www.sweg.de/fileadmin//user_upload/pdf/liniennetzplaene/zollernalb/2021_11_22_SWEG_bwegt_GesamtNetz.pdf"
+            },
             {
                 "name": "Liniennetzplan Stuttgart-Neckartal 2023",
                 "source": "https://www.sweg.de/fileadmin//user_upload/pdf/liniennetzplaene/stuttgart-neckartal/Liniennetzplan-SBS-2023.pdf"
@@ -734,20 +724,6 @@
         ]
     },
     {
-        "shortOperatorName": "vgn-vag-tram",
-        "contributors": [
-            {
-                "github": "tomabrafix"
-            }
-        ],
-        "sources": [
-            {
-                "name": "VGN Schienennetzplan Nürnberg-Fürth",
-                "source": "https://www.vgn.de/liniennetze/schienennetz_nuernberg_furth/"
-            }
-        ]
-    },
-    {
         "shortOperatorName": "vgn-infra-bus",
         "contributors": [
             {
@@ -758,6 +734,20 @@
             {
                 "name": "VGN Netzplan Fürth",
                 "source": "https://www.vgn.de/liniennetze/stadtverkehr_fuerth_stilisiert/"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "vgn-vag-tram",
+        "contributors": [
+            {
+                "github": "tomabrafix"
+            }
+        ],
+        "sources": [
+            {
+                "name": "VGN Schienennetzplan Nürnberg-Fürth",
+                "source": "https://www.vgn.de/liniennetze/schienennetz_nuernberg_furth/"
             }
         ]
     },
@@ -916,20 +906,6 @@
         ]
     },
     {
-        "shortOperatorName": "vvs-db-sbs",
-        "contributors": [
-            {
-                "github": "jheubuch"
-            }
-        ],
-        "sources": [
-            {
-                "name": "Netzplan S-Bahn Stuttgart",
-                "source": "https://download.vvs.de/SBahn_Liniennetz.pdf"
-            }
-        ]
-    },
-    {
         "shortOperatorName": "vvo-tram",
         "contributors": [
             {
@@ -940,6 +916,20 @@
             {
                 "name": "Netzplan",
                 "source": "https://www.dvb.de/-/media/files/liniennetz/2023-09-04/dvblnp040923bauwebpdf.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "vvs-db-sbs",
+        "contributors": [
+            {
+                "github": "jheubuch"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Netzplan S-Bahn Stuttgart",
+                "source": "https://download.vvs.de/SBahn_Liniennetz.pdf"
             }
         ]
     },


### PR DESCRIPTION
The sorting in line-colors.csv is now strictly alphanumeric for shortOperatorName and lineName. The sorting in sources.json is now strictly alphanumeric for shortOperatorName.

Additonally I did the following very small changes:

- I removed the prefix _STR_ in the lineName for the trams in Ulm and Freiburg to unify the data corpus for trams. While I initially submitted the colors of both trams back in October, I purposely added _STR_ based on the way Träwelling displayed these lines before line colors were introduced.
-  I changed four shortOperatorNames for lines I previously submitted myself:
db-regionetz-westfrankenbahn --> db-wfb
regio-s-bahn-donau-iller --> rsb-di
sweg-stuttgart --> sweg
sweg-sudwest --> sweg