### PR TITLE
Add Stadtwerke Dachau bus lines

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -185,6 +185,14 @@ mvv-mvg-ubahn,U3,,7-swm001-3,#ec6725,#ffffff,,rectangle
 mvv-mvg-ubahn,U4,,7-swm001-4,#00a984,#ffffff,,rectangle
 mvv-mvg-ubahn,U5,,7-swm001-5,#bc7a00,#ffffff,,rectangle
 mvv-mvg-ubahn,U6,,7-swm001-6,#0065ae,#ffffff,,rectangle
+mvv-stadtwerke-dachau,716,,5-mvvrbu-716,#235798,#ffffff,,rectangle
+mvv-stadtwerke-dachau,717,,5-mvvrbu-717,#000080,#ffffff,,rectangle
+mvv-stadtwerke-dachau,718,,5-mvvrbu-718,#ffcc00,#ffffff,,rectangle
+mvv-stadtwerke-dachau,719,,5-mvvrbu-719,#00adef,#ffffff,,rectangle
+mvv-stadtwerke-dachau,720,,5-mvvrbu-720,#ef3120,#ffffff,,rectangle
+mvv-stadtwerke-dachau,722,,5-mvvrbu-722,#ef3120,#ffffff,,rectangle
+mvv-stadtwerke-dachau,726,,5-mvvrbu-726,#00a880,#ffffff,,rectangle
+mvv-stadtwerke-dachau,744,,5-mvvrbu-744,#91c900,#ffffff,,rectangle
 nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,,rectangle
 nah-sh,RB 61,nordbahn-eisenbahngesellschaft,nbe-rb61,#174094,#ffffff,,rectangle
 nah-sh,RB 62,db-regio-ag-nord,rb-62,#00aeca,#000000,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -327,6 +327,10 @@
             {
                 "name": "Stadtverkehrsplan Dachau",
                 "source": "https://www.stadtwerke-dachau.de/fileadmin/Media/Downloads/Downloads_Tarife_Angebote/Downloads_Mobilitaet/Dachau_SVP_2024.pdf"
+            },
+            {
+                "name": "Übersichtsseite - Busverkehr in Dachau",
+                "source": "https://www.stadtwerke-dachau.de/tarife-angebote/mobilitaet/busverkehr-in-dachau"
             }
         ]
     },

--- a/sources.json
+++ b/sources.json
@@ -317,6 +317,20 @@
         ]
     },
     {
+        "shortOperatorName": "mvv-stadtwerke-dachau",
+        "contributors": [
+            {
+                "github": "sebiIO"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Stadtverkehrsplan Dachau",
+                "source": "https://www.stadtwerke-dachau.de/fileadmin/Media/Downloads/Downloads_Tarife_Angebote/Downloads_Mobilitaet/Dachau_SVP_2024.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "nah-sh",
         "contributors": [
             {


### PR DESCRIPTION
Hey,
I added the line colors of the city bus lines operated by Stadtwerke Dachau. They offer information about the lines they're operating on this [overview page](https://www.stadtwerke-dachau.de/tarife-angebote/mobilitaet/busverkehr-in-dachau). Their [network plan](https://www.stadtwerke-dachau.de/fileadmin/Media/Downloads/Downloads_Tarife_Angebote/Downloads_Mobilitaet/Dachau_SVP_2024.pdf) shows line colors from both lines operated by Stadtwerke Dachau and bus lines operated by other operators of the MVV network. Since i didn't find those line colors somewhere else, I only included the city lines of Dachau.