### PR TITLE
Add Cologne trams 14 & 19

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1104,10 +1104,12 @@ vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,12,,8-vrs001-12,#98c01e,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,13,,8-vrs001-13,#aa8567,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,14,,8-vrs001-14,#b32499,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,15,,8-vrs001-15,#5aad31,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,16,,8-vrs001-16,#07ada5,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,17,,8-vrs001-17,#1e93d1,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,18,,8-vrs001-18,#85d1f5,#ffffff,,rectangle-rounded-corner
+vrs-stadtbahn,19,,8-vrs001-19,#28523e,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,61,stadtwerke-bonn,8-s3-61,#9ab831,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,62,stadtwerke-bonn,8-s3-62,#65a53b,#ffffff,,rectangle-rounded-corner
 vrs-stadtbahn,63,stadtwerke-bonn,8-s3-63,#8bccf3,#ffffff,,rectangle-rounded-corner


### PR DESCRIPTION
add temporary tram lines 14 & 19 during the Mülheimer Brücke bridge closure until November