### PR TITLE
fix Freiburg S-Bahn S1 & S11

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -689,11 +689,13 @@ rmv-vgf-ubahn,U7,,7-rmv255-7,#f19e2d,#ffffff,,pill
 rmv-vgf-ubahn,U8,,7-rmv255-8,#ca7fbe,#ffffff,,pill
 rmv-vgf-ubahn,U9,,7-rmv255-9,#ffd939,#2c2e35,#2c2e35,pill
 rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c6-1,#00569e,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c4-1,#00569e,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S2,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s2,#009e3c,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S3,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s3,#e83281,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S5,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s5,#ac69a8,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S10,db-regio-ag-baden-wurttemberg,4-8006c6-10,#008bd2,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c6-11,#71cbf4,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c4-11,#71cbf4,#ffffff,,rectangle-rounded-corner
 rvf-vag-stadtbahn,1,,8-vag002-1,#ed1c24,#ffffff,,rectangle
 rvf-vag-stadtbahn,2,,8-vag002-2,#35af3f,#ffffff,,rectangle
 rvf-vag-stadtbahn,3,,8-vag002-3,#f79210,#ffffff,,rectangle


### PR DESCRIPTION
fix Freiburg lines S1, S11: on Sundays, trains between Freiburg and Breisach/Endingen am Kaiserstuhl have a different hafas code