### PR TITLE
Deleted false entry for MVG tram 27

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -242,7 +242,6 @@ mvv-mvg-tram,20,,8-swm002-20,#16c0e9,#ffffff,,rectangle
 mvv-mvg-tram,21,,8-swm002-21,#16c0e9,#ffffff,,rectangle
 mvv-mvg-tram,23,,8-swm002-23,#b3d235,#ffffff,,rectangle
 mvv-mvg-tram,25,,8-swm002-25,#f48f99,#ffffff,,rectangle
-mvv-mvg-tram,27,,8-swm002-27,#903f97,#ffffff,,rectangle
 mvv-mvg-tram,27,,8-swm002-27,#fba61c,#ffffff,,rectangle
 mvv-mvg-tram,28,,8-swm002-28,#ffffff,#fba822,#fba822,rectangle
 mvv-mvg-tram,29,,8-swm002-29,#ffffff,#ec1622,#ec1622,rectangle


### PR DESCRIPTION
I deleted the false entry for MVG tram 27 according to fix #92. After merging the issue can be closed.