### PR TITLE
Completed train lines in Salzburger Verkehrsverbund (SVV)

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -831,14 +831,17 @@ saarbahn,163,,5-vgssbb-163,#008bd2,#ffffff,,rectangle
 saarbahn,164,,5-vgssbb-164,#008bd2,#ffffff,,rectangle
 saarbahn,165,,5-vgssbb-165,#008bd2,#ffffff,,rectangle
 saarbahn,168,,5-vgssbb-168,#008bd2,#ffffff,,rectangle
-svv-oebb,R9,osterreichische-bundesbahnen,r-9,#dbbe2b,#ffffff,,rectangle-rounded-corner
-svv-oebb,R21,osterreichische-bundesbahnen,r-21,#42b3ca,#ffffff,,rectangle-rounded-corner
-svv-oebb,REX21,osterreichische-bundesbahnen,rex-21,#f6861f,#ffffff,,rectangle-rounded-corner
-svv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1451275-5318936,#0074b9,#ffffff,,rectangle-rounded-corner
-svv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1451275-5318936,#28ab48,#ffffff,,rectangle-rounded-corner
-svv-slb,R33,salzburger-lokalbahnen,,#b93146,#ffffff,,rectangle-rounded-corner
-svv-slb,S1,salzburger-lokalbahnen,4-810007-1,#b4193c,#ffffff,,rectangle-rounded-corner
-svv-slb,S11,salzburger-lokalbahnen,4-810007-11,#b4193c,#ffffff,,rectangle-rounded-corner
+svv-brb,S3,bayerische-regiobahn,4-l8-s3,#3ab048,#ffffff,,rectangle-rounded-corner
+svv-brb,S4,bayerische-regiobahn,4-l8-s4,#9764ac,#ffffff,,rectangle-rounded-corner
+svv-oebb,R3,osterreichische-bundesbahnen,r-3,#99be41,#ffffff,,rectangle-rounded-corner
+svv-oebb,R9,osterreichische-bundesbahnen,r-9,#e4be3d,#ffffff,,rectangle-rounded-corner
+svv-oebb,R21,osterreichische-bundesbahnen,r-21,#44bccf,#ffffff,,rectangle-rounded-corner
+svv-oebb,REX21,osterreichische-bundesbahnen,rex-21,#ff8124,#ffffff,,rectangle-rounded-corner
+svv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1451275-5318936,#0077bd,#ffffff,,rectangle-rounded-corner
+svv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1451275-5318936,#3ab048,#ffffff,,rectangle-rounded-corner
+svv-slb,R33,salzburger-lokalbahnen,,#c22438,#ffffff,,rectangle-rounded-corner
+svv-slb,S1,salzburger-lokalbahnen,4-810007-1,#c22438,#ffffff,,rectangle-rounded-corner
+svv-slb,S11,salzburger-lokalbahnen,4-810007-11,#c22438,#ffffff,,rectangle-rounded-corner
 sweg-stuttgart,IRE 6,sweg-bahn-stuttgart-gmbh,ire-6,#ebaf2d,#ffffff,,rectangle
 sweg-stuttgart,MEX 12,sweg-bahn-stuttgart-gmbh,mex-12,#f27320,#ffffff,,rectangle
 sweg-stuttgart,MEX 17a,sweg-bahn-stuttgart-gmbh,mex-17a,#00a9df,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -921,16 +921,44 @@
         ]
     },
     {
-        "shortOperatorName": "svv-oebb",
+        "shortOperatorName": "svv-brb",
         "contributors": [
             {
-                "github": "rnewhost"
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
             {
-                "name": "Netzplan SVV",
-                "source": "https://salzburg-verkehr.at/download/bahnnetz-land-salzburg/?wpdmdl=32234&refresh=6501827b0c3a01694597755"
+                "name": "Liniennetz Zentralraum",
+                "source": "https://www.oebb.at/dam/jcr:69a41a9c-57a1-4c6d-9619-c67fd076d9a1/Liniennetz_Zentralraum.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "svv-oebb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetz Zentralraum",
+                "source": "https://www.oebb.at/dam/jcr:69a41a9c-57a1-4c6d-9619-c67fd076d9a1/Liniennetz_Zentralraum.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "svv-slb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetz Zentralraum",
+                "source": "https://www.oebb.at/dam/jcr:69a41a9c-57a1-4c6d-9619-c67fd076d9a1/Liniennetz_Zentralraum.pdf"
             }
         ]
     },
@@ -945,20 +973,6 @@
             {
                 "name": "Gesamtnetz Zollern-Alb und Ulmer Stern",
                 "source": "https://www.sweg.de/fileadmin//user_upload/pdf/liniennetzplaene/zollernalb/2021_11_22_SWEG_bwegt_GesamtNetz.pdf"
-            }
-        ]
-    },
-    {
-        "shortOperatorName": "svv-slb",
-        "contributors": [
-            {
-                "github": "rnewhost"
-            }
-        ],
-        "sources": [
-            {
-                "name": "Netzplan SVV",
-                "source": "https://salzburg-verkehr.at/download/bahnnetz-land-salzburg/?wpdmdl=32234&refresh=6501827b0c3a01694597755"
             }
         ]
     },


### PR DESCRIPTION
You can find a [network map on the website of the SVV](https://salzburg-verkehr.at/download/bahnnetz-land-salzburg/?wpdmdl=32234&refresh=6633b6fd808cb1714665213), but it has not been updated since November 2022.

On the ÖBB sites you can actually find [the same map](https://www.oebb.at/dam/jcr:69a41a9c-57a1-4c6d-9619-c67fd076d9a1/Liniennetz_Zentralraum.pdf), but in a newer version dating from December 2023.

I conclude, that either SVV forgot to upload the newer version or the map is made by ÖBB in the first place and the new version was not given out to SVV (yet).

Anyway, I updated all existing lines in the dataset according to the newer version and added S3 and S$ from the BRB as well as line R3.