### PR TITLE
Added missing lines operated by Bayerische Regiobahn (BRB)

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,5 +1,13 @@
 shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,borderColor,shape
 ams,S7,abellio-rail-mitteldeutschland-gmbh,4-ams-7,#0a579b,#ffffff,,pill
+avv-brb,RB 83,bayerische-regiobahn,brb-rb83,#c794ac,#ffffff,,rectangle-rounde-corner
+brb,RB 13,bayerische-regiobahn,brb-rb13,#ffb530,#ffffff,,rectangle-rounde-corner
+brb,RB 53,bayerische-regiobahn,brb-rb53,#ffaa90,#ffffff,,rectangle-rounde-corner
+brb,RB 67,bayerische-regiobahn,brb-rb67,#cb8daa,#ffffff,,rectangle-rounde-corner
+brb,RB 68,bayerische-regiobahn,brb-rb68,#a0b050,#ffffff,,rectangle-rounde-corner
+brb,RB 69,bayerische-regiobahn,brb-rb69,#008ac7,#ffffff,,rectangle-rounde-corner
+brb,RB 77,bayerische-regiobahn,brb-rb77,#188e94,#ffffff,,rectangle-rounde-corner
+brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle-rounde-corner
 db-regio-bayern,RB 11,db-regio-ag-bayern,rb-11,#00ace5,#ffffff,,rectangle
 db-regio-bayern,RB 12,db-regio-ag-bayern,rb-12,#6cc3d9,#ffffff,,rectangle
 db-regio-bayern,RB 16,db-regio-ag-bayern,rb-16,#ff9999,#ffffff,,rectangle
@@ -117,6 +125,7 @@ hvv-hha,U 1,,7-hvv001-1,#0072bc,#ffffff,,rectangle
 hvv-hha,U 2,,7-hvv001-2,#ee1d23,#ffffff,,rectangle
 hvv-hha,U 3,,7-hvv001-3,#ffdc01,#ffffff,,rectangle
 hvv-hha,U 4,,7-hvv001-4,#00aaad,#ffffff,,rectangle
+invg-brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb530,#ffffff,,rectangle-rounde-corner
 kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
 kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner
@@ -225,6 +234,11 @@ mobiel,1,mobiel-gmbh,8-owl031-1,#009fe0,#ffffff,,rectangle
 mobiel,2,mobiel-gmbh,8-owl031-2,#008f36,#ffffff,,rectangle
 mobiel,3,mobiel-gmbh,8-owl031-3,#ffed00,#00264f,,rectangle
 mobiel,4,mobiel-gmbh,8-owl031-4,#e3001b,#ffffff,,rectangle
+mvv-brb,RB 54,bayerische-regiobahn,brb-rb54,#4263a8,#ffffff,,rectangle
+mvv-brb,RB 55,bayerische-regiobahn,brb-rb55,#b27a2a,#ffffff,,rectangle
+mvv-brb,RB 56,bayerische-regiobahn,brb-rb56,#b27a2a,#ffffff,,rectangle
+mvv-brb,RB 57,bayerische-regiobahn,brb-rb57,#b27a2a,#ffffff,,rectangle
+mvv-brb,RB 58,bayerische-regiobahn,brb-rb58,#ccb236,#ffffff,,rectangle
 mvv-db-sbm,S1,db-regio-ag-s-bahn-munchen,4-800725-1,#1fbce6,#ffffff,,pill
 mvv-db-sbm,S2,db-regio-ag-s-bahn-munchen,4-800725-2,#79b833,#ffffff,,pill
 mvv-db-sbm,S20,db-regio-ag-s-bahn-munchen,4-800725-20,#f05972,#ffffff,,pill

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -125,7 +125,6 @@ hvv-hha,U 1,,7-hvv001-1,#0072bc,#ffffff,,rectangle
 hvv-hha,U 2,,7-hvv001-2,#ee1d23,#ffffff,,rectangle
 hvv-hha,U 3,,7-hvv001-3,#ffdc01,#ffffff,,rectangle
 hvv-hha,U 4,,7-hvv001-4,#00aaad,#ffffff,,rectangle
-invg-brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb530,#ffffff,,rectangle-rounded-corner
 kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
 kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner
@@ -994,6 +993,7 @@ vbn-nwb-regio-s-bahn,RS 3,nordwestbahn,4-n1-rs3,#93bf30,#ffffff,,rectangle-round
 vbn-nwb-regio-s-bahn,RS 30,nordwestbahn,4-n1-rs30,#4faf3b,#ffffff,,rectangle-rounded-corner
 vbn-nwb-regio-s-bahn,RS 4,nordwestbahn,4-n1-rs4,#e2000b,#ffffff,,rectangle-rounded-corner
 vbn-nwb-regio-s-bahn,RS 6,nordwestbahn,4-n1-rs6,#899bb9,#ffffff,,rectangle-rounded-corner
+vgi-brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb530,#ffffff,,rectangle-rounded-corner
 vgn-db-sbn,S 1,db-regio-ag-bayern,4-800721-1,#92292e,#ffffff,,rectangle
 vgn-db-sbn,S 2,db-regio-ag-bayern,4-800721-2,#4dbd38,#ffffff,,rectangle
 vgn-db-sbn,S 3,db-regio-ag-bayern,4-800721-3,#f1471d,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,13 +1,13 @@
 shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,borderColor,shape
 ams,S7,abellio-rail-mitteldeutschland-gmbh,4-ams-7,#0a579b,#ffffff,,pill
-avv-brb,RB 83,bayerische-regiobahn,brb-rb83,#c794ac,#ffffff,,rectangle-rounde-corner
-brb,RB 13,bayerische-regiobahn,brb-rb13,#ffb530,#ffffff,,rectangle-rounde-corner
-brb,RB 53,bayerische-regiobahn,brb-rb53,#ffaa90,#ffffff,,rectangle-rounde-corner
-brb,RB 67,bayerische-regiobahn,brb-rb67,#cb8daa,#ffffff,,rectangle-rounde-corner
-brb,RB 68,bayerische-regiobahn,brb-rb68,#a0b050,#ffffff,,rectangle-rounde-corner
-brb,RB 69,bayerische-regiobahn,brb-rb69,#008ac7,#ffffff,,rectangle-rounde-corner
-brb,RB 77,bayerische-regiobahn,brb-rb77,#188e94,#ffffff,,rectangle-rounde-corner
-brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle-rounde-corner
+avv-brb,RB 83,bayerische-regiobahn,brb-rb83,#c794ac,#ffffff,,rectangle-rounded-corner
+brb,RB 13,bayerische-regiobahn,brb-rb13,#ffb530,#ffffff,,rectangle-rounded-corner
+brb,RB 53,bayerische-regiobahn,brb-rb53,#ffaa90,#ffffff,,rectangle-rounded-corner
+brb,RB 67,bayerische-regiobahn,brb-rb67,#cb8daa,#ffffff,,rectangle-rounded-corner
+brb,RB 68,bayerische-regiobahn,brb-rb68,#a0b050,#ffffff,,rectangle-rounded-corner
+brb,RB 69,bayerische-regiobahn,brb-rb69,#008ac7,#ffffff,,rectangle-rounded-corner
+brb,RB 77,bayerische-regiobahn,brb-rb77,#188e94,#ffffff,,rectangle-rounded-corner
+brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle-rounded-corner
 db-regio-bayern,RB 11,db-regio-ag-bayern,rb-11,#00ace5,#ffffff,,rectangle
 db-regio-bayern,RB 12,db-regio-ag-bayern,rb-12,#6cc3d9,#ffffff,,rectangle
 db-regio-bayern,RB 16,db-regio-ag-bayern,rb-16,#ff9999,#ffffff,,rectangle
@@ -125,7 +125,7 @@ hvv-hha,U 1,,7-hvv001-1,#0072bc,#ffffff,,rectangle
 hvv-hha,U 2,,7-hvv001-2,#ee1d23,#ffffff,,rectangle
 hvv-hha,U 3,,7-hvv001-3,#ffdc01,#ffffff,,rectangle
 hvv-hha,U 4,,7-hvv001-4,#00aaad,#ffffff,,rectangle
-invg-brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb530,#ffffff,,rectangle-rounde-corner
+invg-brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb530,#ffffff,,rectangle-rounded-corner
 kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner
 kvv-avg,S2,albtal-verkehrs-gesellschaft-mbh,4-a6-2,#a066aa,#ffffff,,rectangle-rounded-corner
 kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner

--- a/sources.json
+++ b/sources.json
@@ -14,6 +14,34 @@
         ]
     },
     {
+        "shortOperatorName": "avv-brb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "AVV Schienennetzplan 2023/12",
+                "source": "https://www.avv-augsburg.de/fileadmin/user_upload/Netzplaene_und_Karten/avv_schienennetzplan_2023_12_web.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "brb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "BRB Streckennetz 2024",
+                "source": "https://download.transdev.de/transdev/uploads/bb/media_document/500/original.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "db-regio-bayern",
         "contributors": [
             {
@@ -223,6 +251,20 @@
         ]
     },
     {
+        "shortOperatorName": "invg-brb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "BRB Streckennetz 2024",
+                "source": "https://download.transdev.de/transdev/uploads/bb/media_document/500/original.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "kvv-avg",
         "contributors": [
             {
@@ -323,6 +365,20 @@
             {
                 "name": "Netzplan 2023",
                 "source": "https://www.mobiel.de/fileadmin/user_upload/Downloads/Netzplaene_Karten/schematischer_Netzplan_2023.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "mvv-brb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "MVV Netzplan 2024 Gesamtnetz",
+                "source": "https://www.mvv-muenchen.de/fileadmin/mediapool/03-Plaene_Bahnhoefe/Netzplaene/Downloads_2024/2024_layout_SUR_gesamtnetz_SCR.pdf"
             }
         ]
     },

--- a/sources.json
+++ b/sources.json
@@ -251,20 +251,6 @@
         ]
     },
     {
-        "shortOperatorName": "invg-brb",
-        "contributors": [
-            {
-                "github": "oneiricbotcelot"
-            }
-        ],
-        "sources": [
-            {
-                "name": "BRB Streckennetz 2024",
-                "source": "https://download.transdev.de/transdev/uploads/bb/media_document/500/original.pdf"
-            }
-        ]
-    },
-    {
         "shortOperatorName": "kvv-avg",
         "contributors": [
             {
@@ -1145,6 +1131,20 @@
             {
                 "name": "Liniennetz Regio-S-Bahn Bremen Niedersachsen",
                 "source": "https://download.transdev.de/transdev/uploads/nwb/pictures/item_paragraph/43/s1200.jpg"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "vgi-brb",
+        "contributors": [
+            {
+                "github": "oneiricbotcelot"
+            }
+        ],
+        "sources": [
+            {
+                "name": "BRB Streckennetz 2024",
+                "source": "https://download.transdev.de/transdev/uploads/bb/media_document/500/original.pdf"
             }
         ]
     },


### PR DESCRIPTION
- Lines RB 13, RB 53, RB 67, RB 68, RB 69, RB 77 and RE 5 operate in multiple local transport networks, so I chose the colors [provided by BRB](https://download.transdev.de/transdev/uploads/bb/media_document/500/original.pdf) itself.
- RB 83 operates only in Ausburger Verkehrsverbund, so I sticked to [their map](https://www.avv-augsburg.de/fileadmin/user_upload/Netzplaene_und_Karten/avv_schienennetzplan_2023_12_web.pdf).
- RB 14 operates only in Verkehrsverbund Großraum Ingolstadt, but they don't provide colors for trains in their network map, so I sticked to the BRB map.
- RB 54, RB 55, RB 56, RB 57 and RB 58 operates only in Ausburger Verkehrsverbund, so I sticked to [the MVV map](https://www.mvv-muenchen.de/fileadmin/mediapool/03-Plaene_Bahnhoefe/Netzplaene/Downloads_2024/2024_layout_SUR_gesamtnetz_SCR.pdf).