### PR TITLE
added UK trains just for funsies

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1155,14 +1155,11 @@ uestra,610,,5-webueb-610,#ffffff,#2c2e35,#3ebc6d,pill
 uestra,611,,5-webueb-611,#ffffff,#2c2e35,#af2a21,pill
 uestra,631,,5-webueb-631,#ffffff,#2c2e35,#95cc45,pill
 uestra,800,,5-webueb-800,#ffffff,#2c2e35,#35ccf6,pill
-
-// UK trains
-uk-avanti,Avanti West Coast,avanti-west-coast,null,#014053,#ffffff,,rectangle
-uk-emr,EMR,east-midland,null,#4c2f48,#ffffff,,rectangle
-uk-lnwr,London Northwestern Railway,london-midland,null,#004c45,#ffffff,,rectangle
-uk-northern,northern,northern,null,#262262,#ffffff,,rectangle
+uk-trains,Avanti West Coast,avanti-west-coast,null,#014053,#ffffff,,rectangle
+uk-trains,EMR,east-midland,null,#4c2f48,#ffffff,,rectangle
+uk-trains,London Northwestern Railway,london-midland,null,#004c45,#ffffff,,rectangle
+uk-trains,northern,northern,null,#262262,#ffffff,,rectangle
 uk-tfw-wales-and-borders,TfW Wales&Borders,wales-borders,null,#ae1c0f,#ffffff,,rectangle
-
 vbb-bvg-tram,M1,,8-vbbbvt-m1,#63b9e9,#ffffff,,rectangle
 vbb-bvg-tram,M2,,8-vbbbvt-m2,#7ab929,#ffffff,,rectangle
 vbb-bvg-tram,M4,,8-vbbbvt-m4,#ca1214,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1035,6 +1035,14 @@ uestra,610,,5-webueb-610,#ffffff,#2c2e35,#3ebc6d,pill
 uestra,611,,5-webueb-611,#ffffff,#2c2e35,#af2a21,pill
 uestra,631,,5-webueb-631,#ffffff,#2c2e35,#95cc45,pill
 uestra,800,,5-webueb-800,#ffffff,#2c2e35,#35ccf6,pill
+
+// UK trains
+uk-avanti,Avanti West Coast,avanti-west-coast,null,#014053,#ffffff,,rectangle
+uk-emr,EMR,east-midland,null,#4c2f48,#ffffff,,rectangle
+uk-lnwr,London Northwestern Railway,london-midland,null,#004c45,#ffffff,,rectangle
+uk-northern,northern,northern,null,#262262,#ffffff,,rectangle
+uk-tfw-wales-and-borders,TfW Wales&Borders,wales-borders,null,#ae1c0f,#ffffff,,rectangle
+
 vbb-bvg-tram,M1,,8-vbbbvt-m1,#63b9e9,#ffffff,,rectangle
 vbb-bvg-tram,M2,,8-vbbbvt-m2,#7ab929,#ffffff,,rectangle
 vbb-bvg-tram,M4,,8-vbbbvt-m4,#ca1214,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1159,7 +1159,7 @@ uk-trains,Avanti West Coast,avanti-west-coast,null,#014053,#ffffff,,rectangle
 uk-trains,EMR,east-midland,null,#4c2f48,#ffffff,,rectangle
 uk-trains,London Northwestern Railway,london-midland,null,#004c45,#ffffff,,rectangle
 uk-trains,northern,northern,null,#262262,#ffffff,,rectangle
-uk-tfw-wales-and-borders,TfW Wales&Borders,wales-borders,null,#ae1c0f,#ffffff,,rectangle
+uk-trains,TfW Wales&Borders,wales-borders,null,#ae1c0f,#ffffff,,rectangle
 vbb-bvg-tram,M1,,8-vbbbvt-m1,#63b9e9,#ffffff,,rectangle
 vbb-bvg-tram,M2,,8-vbbbvt-m2,#7ab929,#ffffff,,rectangle
 vbb-bvg-tram,M4,,8-vbbbvt-m4,#ca1214,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -1283,6 +1283,32 @@
         ]
     },
     {
+        "shortOperatorName": "uk-trains",
+        "contributors": [
+            {
+                "github": "lunas-bad-coding"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Northern Rail (Website)",
+                "source": "https://www.northernrailway.co.uk/"
+            },
+            {
+                "name": "Avanti West Coast",
+                "source": "https://www.gvh.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/gvh-linienplan-bus-hannover-2023-2024.pdf"
+            },
+            {
+                "name": "EMR",
+                "source": "https://www.eastmidlandsrailway.co.uk/"
+            },
+            {
+                "name": "London Northwestern Railway",
+                "source": "https://www.londonnorthwesternrailway.co.uk/"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "vbb-bvg-tram",
         "contributors": [
             {


### PR DESCRIPTION
i'm honestly not sure how useful that is.
UK trains are a bit different with DB HAFAS, there's no hafasLineId, that's why I used "null" as a value.
UK railway (apart from local tram networks and London Underground) don't use line names or train numbers, it's just the operator's name that's being used.

If it isn't useful, you don't have to approve this PR 😅