### PR TITLE
Update Baden-Württemberg

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -94,6 +94,12 @@ db-regio-bayern,RE 73,db-regio-ag-bayern,re-73,#e5a05c,#ffffff,,rectangle
 db-regio-bayern,RE 75,db-regio-ag-bayern,re-75,#e50000,#ffffff,,rectangle
 db-regio-bayern,RE 76,db-regio-ag-bayern,re-76,#006629,#ffffff,,rectangle
 db-regio-bayern,RE 79,db-regio-ag-bayern,re-79,#800080,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,re-7,#ED6E19,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB28,db-regio-ag-baden-wurttemberg,rb-28,#724019,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB27,db-regio-ag-baden-wurttemberg,rb-27,#008c3c,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB26,db-regio-ag-baden-wurttemberg,rb-26,#009fe3,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,IRE3,db-regio-ag-baden-wurttemberg,ire-3,#e5007d,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB30,db-regio-ag-baden-wurttemberg,rb-30,#571d70,#ffffff,,rectangle
 db-regio-mitte,RE 40,db-regio-ag-mitte,re-40,#ff9027,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RB 41,db-regio-ag-mitte,rb-41,#00ab4f,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RB 44,db-regio-ag-mitte,rb-44,#7ac547,#ffffff,,rectangle-rounded-corner
@@ -982,14 +988,14 @@ rmv-vgf-ubahn,U6,,7-rmv255-6,#0082ca,#ffffff,,pill
 rmv-vgf-ubahn,U7,,7-rmv255-7,#f19e2d,#ffffff,,pill
 rmv-vgf-ubahn,U8,,7-rmv255-8,#ca7fbe,#ffffff,,pill
 rmv-vgf-ubahn,U9,,7-rmv255-9,#ffd939,#2c2e35,#2c2e35,pill
-rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c6-1,#00569e,#ffffff,,rectangle-rounded-corner
-rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c4-1,#00569e,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c6-1,#d30630,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c4-1,#d30630,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S2,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s2,#009e3c,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S3,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s3,#e83281,#ffffff,,rectangle-rounded-corner
 rvf-sbahn,S5,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s5,#ac69a8,#ffffff,,rectangle-rounded-corner
-rvf-sbahn,S10,db-regio-ag-baden-wurttemberg,4-8006c6-10,#008bd2,#ffffff,,rectangle-rounded-corner
-rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c6-11,#71cbf4,#ffffff,,rectangle-rounded-corner
-rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c4-11,#71cbf4,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S10,db-regio-ag-baden-wurttemberg,4-8006c6-10,#d30630,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c6-11,#f69795,#ffffff,,rectangle-rounded-corner
+rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c4-11,#f69795,#ffffff,,rectangle-rounded-corner
 rvf-sweg-sudwest,1,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb1,#a3238e,#ffffff,,rectangle
 rvf-sweg-sudwest,1,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-1,#a3238e,#ffffff,,rectangle
 rvf-sweg-sudwest,2,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb2,#fab383,#ffffff,,rectangle

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -34,6 +34,12 @@ brb,RB 83,bayerische-regiobahn,brb-rb83,#ffffff,#bf73bf,#bf73bf,rectangle
 brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle
 brb,S3,bayerische-regiobahn,4-l8-s3,#2aa335,#ffffff,,pill
 brb,S4,bayerische-regiobahn,4-l8-s4,#a765a2,#ffffff,,pill
+db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,re-7,#ed6e19,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB28,db-regio-ag-baden-wurttemberg,rb-28,#724019,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB27,db-regio-ag-baden-wurttemberg,rb-27,#008c3c,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB26,db-regio-ag-baden-wurttemberg,rb-26,#009fe3,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,IRE3,db-regio-ag-baden-wurttemberg,ire-3,#e5007d,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB30,db-regio-ag-baden-wurttemberg,rb-30,#571d70,#ffffff,,rectangle
 db-regio-bayern,RB 6,db-regio-ag-bayern,rb-6,#e50000,#ffffff,,rectangle
 db-regio-bayern,RB 10,db-regio-ag-bayern,rb-10,#90bf26,#ffffff,,rectangle
 db-regio-bayern,RB 11,db-regio-ag-bayern,rb-11,#00ace5,#ffffff,,rectangle
@@ -94,12 +100,6 @@ db-regio-bayern,RE 73,db-regio-ag-bayern,re-73,#e5a05c,#ffffff,,rectangle
 db-regio-bayern,RE 75,db-regio-ag-bayern,re-75,#e50000,#ffffff,,rectangle
 db-regio-bayern,RE 76,db-regio-ag-bayern,re-76,#006629,#ffffff,,rectangle
 db-regio-bayern,RE 79,db-regio-ag-bayern,re-79,#800080,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,re-7,#ed6e19,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RB28,db-regio-ag-baden-wurttemberg,rb-28,#724019,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RB27,db-regio-ag-baden-wurttemberg,rb-27,#008c3c,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RB26,db-regio-ag-baden-wurttemberg,rb-26,#009fe3,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,IRE3,db-regio-ag-baden-wurttemberg,ire-3,#e5007d,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RB30,db-regio-ag-baden-wurttemberg,rb-30,#571d70,#ffffff,,rectangle
 db-regio-mitte,RE 40,db-regio-ag-mitte,re-40,#ff9027,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RB 41,db-regio-ag-mitte,rb-41,#00ab4f,#ffffff,,rectangle-rounded-corner
 db-regio-mitte,RB 44,db-regio-ag-mitte,rb-44,#7ac547,#ffffff,,rectangle-rounded-corner

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -94,7 +94,7 @@ db-regio-bayern,RE 73,db-regio-ag-bayern,re-73,#e5a05c,#ffffff,,rectangle
 db-regio-bayern,RE 75,db-regio-ag-bayern,re-75,#e50000,#ffffff,,rectangle
 db-regio-bayern,RE 76,db-regio-ag-bayern,re-76,#006629,#ffffff,,rectangle
 db-regio-bayern,RE 79,db-regio-ag-bayern,re-79,#800080,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,re-7,#ED6E19,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,re-7,#ed6e19,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB28,db-regio-ag-baden-wurttemberg,rb-28,#724019,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB27,db-regio-ag-baden-wurttemberg,rb-27,#008c3c,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB26,db-regio-ag-baden-wurttemberg,rb-26,#009fe3,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -2100,5 +2100,19 @@
                 "source": "https://www.vvo-online.de/doc/VVO-Liniennetzplan-SPNV-Sachsen.pdf"
             }
         ]
+    },
+    {
+        "shortOperatorName": "db-regio-ag-baden-wurttemberg",
+        "contributors": [
+            {
+                "github": "nxrvincent"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan Regionalverkehr",
+                "source": "https://www.bwegt.de/fileadmin/assets/www.bwegt.de/0000_v2/c_PDFs/Karten/bwegt_Liniennetzplan_Regionalverkehr_BW_08.12.2023_barrierefrei.pdf"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
added DB Regio AG Baden-Württemberg:
RE 7 (RK - RB)
RB 28 (RF - XFMV)
RB 27 (RF - RB)
RB 26 (RF - RO)

updated "rvf-sbahn":
S1, S10 & S11 to the right colors

source: https://www.bwegt.de/fileadmin/assets/www.bwegt.de/0000_v2/c_PDFs/Karten/bwegt_Liniennetzplan_Regionalverkehr_BW_08.12.2023_barrierefrei.pdf