### PR TITLE
Added DB lines around Stuttgart

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -34,13 +34,24 @@ brb,RB 83,bayerische-regiobahn,brb-rb83,#ffffff,#bf73bf,#bf73bf,rectangle
 brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle
 brb,S3,bayerische-regiobahn,4-l8-s3,#2aa335,#ffffff,,pill
 brb,S4,bayerische-regiobahn,4-l8-s4,#a765a2,#ffffff,,pill
+db-fernverkehr-ag,RE87,db-fernverkehr-ag,3-nz-87,#cc0066,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE2,db-regio-ag-baden-wurttemberg,3-800647-2,#0069b4,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,IRE3,db-regio-ag-baden-wurttemberg,3-800693-3,#e5007d,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE4,db-regio-ag-baden-wurttemberg,3-8006d6-4,#a05a2c,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE5,db-regio-ag-baden-wurttemberg,3-800694-5,#724019,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,IRE6,db-regio-ag-baden-wurttemberg,3-800693-6,#4d4d4d,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,3-8006c5-7,#ed6e19,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RE14a,db-regio-ag-baden-wurttemberg,3-8006d6-14a,#f39794,#000000,,rectangle
+db-regio-ag-baden-wurttemberg,RE14b,db-regio-ag-baden-wurttemberg,3-8006d6-14b,#02aa9e,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,MEX19,db-regio-ag-baden-wurttemberg,3-8006d6-19,#999999,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB26,db-regio-ag-baden-wurttemberg,3-8006c4-26,#009fe3,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB27,db-regio-ag-baden-wurttemberg,3-8006c4-27,#008c3c,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB28,db-regio-ag-baden-wurttemberg,3-8006c4-28,#724019,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RE2,db-regio-ag-baden-wurttemberg,3-800647-2,#0069b4,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,RE7,db-regio-ag-baden-wurttemberg,3-8006c5-7,#ed6e19,#ffffff,,rectangle
-db-regio-ag-baden-wurttemberg,IRE3,db-regio-ag-baden-wurttemberg,3-800693-3,#e5007d,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RB30,db-regio-ag-baden-wurttemberg,3-800631-30,#571d70,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB63,db-regio-ag-baden-wurttemberg,3-8006d2-63,#d30730,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,RB74,db-regio-ag-baden-wurttemberg,3-800632-74,#0a69b2,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,MEX90,db-regio-ag-baden-wurttemberg,3-8006d6-90,#e5007d,#ffffff,,rectangle
+db-regio-ag-baden-wurttemberg,IRE200,db-regio-ag-baden-wurttemberg,3-800659-200,#aa0344,#ffffff,,rectangle
 db-regio-bayern,RB 6,db-regio-ag-bayern,rb-6,#e50000,#ffffff,,rectangle
 db-regio-bayern,RB 10,db-regio-ag-bayern,rb-10,#90bf26,#ffffff,,rectangle
 db-regio-bayern,RB 11,db-regio-ag-bayern,rb-11,#00ace5,#ffffff,,rectangle
@@ -2026,6 +2037,8 @@ vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle
 vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle
 vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle
 vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle
+vvs-db-sbs,RB11,db-regio-ag-s-bahn-stuttgart,3-800643-11,#02aa9e,#ffffff,,rectangle
+vvs-db-sbs,RB64,db-regio-ag-s-bahn-stuttgart,3-800643-64,#b6931d,#ffffff,,rectangle
 vvs-ssb-nachtbus,N 1,,5-vvs033-n1,#3c389e,#ffffff,,rectangle
 vvs-ssb-nachtbus,N 2,,5-vvs033-n2,#6fdaf8,#ffffff,,rectangle
 vvs-ssb-nachtbus,N 3,,5-vvs033-n3,#6fdaf8,#06429a,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -91,6 +91,41 @@
         ]
     },
     {
+        "shortOperatorName": "db-fernverkehr-ag",
+        "contributors": [
+            {
+                "github": "Nagiphaaa"
+            }
+        ],
+        "sources": [
+            {
+                "name": "ICE/IC Liniennetz 2024",
+                "source": "https://assets.static-bahn.de/dam/jcr:a2ed983a-36e1-4533-a4ee-8b85daf684c2/231127_Liniennetz%20ICE%20IC%202024.pdf"
+            }
+        ]
+    },
+    {
+        "shortOperatorName": "db-regio-ag-baden-wurttemberg",
+        "contributors": [
+            {
+                "github": "nxrvincent"
+            },
+            {
+                "github": "Nagiphaaa"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Liniennetzplan bwegt",
+                "source": "https://www.bwegt.de/fileadmin/assets/www.bwegt.de/0000_v2/c_PDFs/Karten/bwegt_Liniennetzplan_Regionalverkehr_BW_08.12.2023_barrierefrei.pdf"
+            },
+            {
+                "name": "Liniennetzplan Rheinland-Pfalz",
+                "source": "https://www.rolph.de/fileadmin/user_upload/Liniennetzplan_Rheinland-Pfalz_02-2024.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "db-regio-bayern",
         "contributors": [
             {
@@ -1917,12 +1952,19 @@
         "contributors": [
             {
                 "github": "jheubuch"
+            },
+            {
+                "github": "Nagiphaaa"
             }
         ],
         "sources": [
             {
                 "name": "Netzplan S-Bahn Stuttgart",
                 "source": "https://download.vvs.de/SBahn_Liniennetz.pdf"
+            },
+            {
+                "name": "Liniennetzplan bwegt",
+                "source": "https://www.bwegt.de/fileadmin/assets/www.bwegt.de/0000_v2/c_PDFs/Karten/bwegt_Liniennetzplan_Regionalverkehr_BW_08.12.2023_barrierefrei.pdf"
             }
         ]
     },
@@ -2178,24 +2220,6 @@
             {
                 "name": "Netzplan",
                 "source": "https://www.vvo-online.de/doc/VVO-Liniennetzplan-SPNV-Sachsen.pdf"
-            }
-        ]
-    },
-    {
-        "shortOperatorName": "db-regio-ag-baden-wurttemberg",
-        "contributors": [
-            {
-                "github": "nxrvincent"
-            }
-        ],
-        "sources": [
-            {
-                "name": "Liniennetzplan bwegt",
-                "source": "https://www.bwegt.de/fileadmin/assets/www.bwegt.de/0000_v2/c_PDFs/Karten/bwegt_Liniennetzplan_Regionalverkehr_BW_08.12.2023_barrierefrei.pdf"
-            },
-            {
-                "name": "Liniennetzplan Rheinland-Pfalz",
-                "source": "https://www.rolph.de/fileadmin/user_upload/Liniennetzplan_Rheinland-Pfalz_02-2024.pdf"
             }
         ]
     }


### PR DESCRIPTION
Added:
- RE4
- RE5
- IRE6 (_not_ the SWEG one)
- RB11 (S-Bahn Stuttgart)
- RE14a/b
- MEX19
- RB63
- RB64 (S-Bahn Stuttgart)
- RB74
- RE87 (DB Fernverkehr)
- MEX90
- IRE200

Colours are based on the bwegt map (except for the RE87, where the colour is based on the DB FV map)

Also fixed some line IDs and sorting