### PR TITLE
feat: update colors and shapes of metronom and s-bahn hannover

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -455,11 +455,11 @@ mdv-swh-havag,9,,8-nashat-9,#a7b150,#ffffff,,rectangle
 mdv-swh-havag,10,,8-nashat-10,#3d682d,#ffffff,,rectangle
 mdv-swh-havag,12,,8-nashat-12,#96c75a,#ffffff,,rectangle
 mdv-swh-havag,16,,8-nashat-12,#a13671,#ffffff,,rectangle
-metronom,RB31,metronom,3-r1-rb31,#752c77,#ffffff,,rectangle
-metronom,RB41,metronom,3-r1-rb41,#5ab078,#ffffff,,rectangle
-metronom,RE2,metronom,3-r1-re2,#a4313a,#ffffff,,rectangle
-metronom,RE3,metronom,3-r1-re3,#f4b556,#ffffff,,rectangle
-metronom,RE4,metronom,3-r1-re4-1113213-5957444,#5ab078,#ffffff,,rectangle
+metronom,RB31,metronom,3-r1-rb31,#7f257b,#ffffff,,rectangle
+metronom,RB41,metronom,3-r1-rb41,#2eb273,#ffffff,,rectangle
+metronom,RE2,metronom,3-r1-re2,#b22236,#ffffff,,rectangle
+metronom,RE3,metronom,3-r1-re3,#7f257b,#ffffff,,rectangle
+metronom,RE4,metronom,3-r1-re4-1113213-5957444,#2eb273,#ffffff,,rectangle
 mitteldeutsche-regiobahn,RE 3,mitteldeutsche-regiobahn,3-cxre-3,#0093d4,#ffffff,,rectangle-rounded-corner
 mitteldeutsche-regiobahn,RE 6,mitteldeutsche-regiobahn,3-cxre-6,#9e60a4,#ffffff,,rectangle-rounded-corner
 mitteldeutsche-regiobahn,RB 30,mitteldeutsche-regiobahn,3-cxrb-30,#ed9126,#ffffff,,rectangle-rounded-corner
@@ -1102,16 +1102,16 @@ s-bahn-bern-bls,S 6,bls-ag,4-850033-6-827562-5222797,#f84e4d,#ffffff,,rectangle
 s-bahn-bern-rbs,S 7,regionalverkehr-bern-solothurn,4-850088-7,#ff812d,#ffffff,,rectangle
 s-bahn-bern-rbs,S 8,regionalverkehr-bern-solothurn,4-850088-8,#191918,#ffffff,,rectangle
 s-bahn-bern-rbs,S 9,regionalverkehr-bern-solothurn,4-850088-9,#fa2d18,#ffffff,,rectangle
-s-bahn-hannover-transdev,S 1,s-bahn-hannover-transdev,4-tdhs-1,#846daa,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 2,s-bahn-hannover-transdev,4-tdhs-2,#007a3d,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 21,s-bahn-hannover-transdev,4-tdhs-21,#007a3d,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 3,s-bahn-hannover-transdev,4-tdhs-3,#cc69a6,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 4,s-bahn-hannover-transdev,4-tdhs-4,#9b2b48,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 5,s-bahn-hannover-transdev,4-tdhs-5,#f18700,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 51,s-bahn-hannover-transdev,4-tdhs-51,#f18700,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 6,s-bahn-hannover-transdev,4-tdhs-6,#004f9f,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 7,s-bahn-hannover-transdev,4-tdhs-7,#afcb27,#ffffff,,rectangle-rounded-corner
-s-bahn-hannover-transdev,S 8,s-bahn-hannover-transdev,4-tdhs-8,#1794ca,#ffffff,,rectangle-rounded-corner
+s-bahn-hannover-transdev,S 1,s-bahn-hannover-transdev,4-tdhs-1,#846daa,#ffffff,,pill
+s-bahn-hannover-transdev,S 2,s-bahn-hannover-transdev,4-tdhs-2,#007a3d,#ffffff,,pill
+s-bahn-hannover-transdev,S 21,s-bahn-hannover-transdev,4-tdhs-21,#007a3d,#ffffff,,pill
+s-bahn-hannover-transdev,S 3,s-bahn-hannover-transdev,4-tdhs-3,#cc69a6,#ffffff,,pill
+s-bahn-hannover-transdev,S 4,s-bahn-hannover-transdev,4-tdhs-4,#9b2b48,#ffffff,,pill
+s-bahn-hannover-transdev,S 5,s-bahn-hannover-transdev,4-tdhs-5,#f18700,#ffffff,,pill
+s-bahn-hannover-transdev,S 51,s-bahn-hannover-transdev,4-tdhs-51,#f18700,#ffffff,,pill
+s-bahn-hannover-transdev,S 6,s-bahn-hannover-transdev,4-tdhs-6,#004f9f,#ffffff,,pill
+s-bahn-hannover-transdev,S 7,s-bahn-hannover-transdev,4-tdhs-7,#afcb27,#ffffff,,pill
+s-bahn-hannover-transdev,S 8,s-bahn-hannover-transdev,4-tdhs-8,#1794ca,#ffffff,,pill
 s-bahn-zentralschweiz-bls,S 6,bls-ag,4-850033-6-924462-5234071,#0165b6,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-bls,S 7,bls-ag,4-850033-7,#73c0e8,#ffffff,,rectangle-rounded-corner
 s-bahn-zentralschweiz-bls,S 77,bls-ag,4-850033-77,#7a84c4,#ffffff,,rectangle-rounded-corner

--- a/sources.json
+++ b/sources.json
@@ -187,7 +187,7 @@
         ]
     },
   {
- 
+
         "shortOperatorName": "db-regio-nordost",
         "contributors": [
             {
@@ -530,7 +530,7 @@
             {
                 "name": "KVV Liniennetzplan Bus Südlicher Landkreis Rastatt und Baden-Baden 2024",
                 "source": "https://www.kvv.de/fileadmin/user_upload/kvv/Dateien/Fahrplaene_Netzplaene/Bus/KVV-Liniennetzplan_Busnetz_Suedlicher-Landkreis-Rastatt-und-Baden-Baden.pdf"
-            }    
+            }
         ]
     },
     {
@@ -609,6 +609,9 @@
             },
             {
                 "github": "oneiricbotcelot"
+            },
+            {
+                "github": "vainamov"
             }
         ],
         "sources": [
@@ -1257,12 +1260,19 @@
         "contributors": [
             {
                 "github": "oneiricbotcelot"
+            },
+            {
+                "github": "vainamov"
             }
         ],
         "sources": [
             {
                 "name": "Liniennetzplan S-Bahn Hannover Transdev",
                 "source": "https://download.transdev.de/transdev/uploads/sbahn_hannover/media_document/18/original.pdf"
+            },
+            {
+                "name": "Liniennetzplan Regionalzug und S-Bahn",
+                "source": "https://www.uestra.de/fileadmin/user_upload/PDF/2024-Linien-und-Netzplaene/uestra-gvh-linienplan-regional-s-bahn-2023-2024.pdf"
             }
         ]
     },
@@ -1891,7 +1901,7 @@
             },
             {
                 "github": "lunas-bad-coding"
-            }            
+            }
         ],
         "sources": [
             {


### PR DESCRIPTION
Just recently the new IRIS+ compatible displays have been installed at platforms 1 and 2 of Hannover Hbf. They now also show the S-Bahn line icons as pills (like in the network plan and maps inside the trains) and I think we should adopt the look.

I also fixed the colors used for the Metronom lines, because they weren't matching the given source file.