### PR TITLE
Added CFL line colors

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -49,6 +49,8 @@ brb,RE 5,bayerische-regiobahn,3-m8-re5,#00416d,#ffffff,,rectangle
 brb,S3,bayerische-regiobahn,4-l8-s3,#2aa335,#ffffff,,pill
 brb,S4,bayerische-regiobahn,4-l8-s4,#a765a2,#ffffff,,pill
 ceske-drahy,RE 25,ceske-drahy,1-54a8n-re25,#006666,#ffffff,,rectangle
+cfl,RE 11,cfl,3-82-11,#20b159,#ffffff,,rectangle
+cfl,RB 83,cfl,3-82-83,#20b159,#ffffff,,rectangle
 db-fernverkehr-ag,RE87,db-fernverkehr-ag,3-nz-87,#cc0066,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,RE 2,db-regio-ag-baden-wurttemberg,3-800647-2,#0069b4,#ffffff,,rectangle
 db-regio-ag-baden-wurttemberg,IRE 3,db-regio-ag-baden-wurttemberg,3-800693-3,#e5007d,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -111,6 +111,20 @@
         ]
     },
     {
+        "shortOperatorName": "cfl",
+        "contributors": [
+            {
+                "github": "SpielenmitLili"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Fahrpläne",
+                "source": "https://www.cfl.lu/de-de/timetable"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "db-fernverkehr-ag",
         "contributors": [
             {


### PR DESCRIPTION
Farben der Linien der CFL zwischen Deutschland und Luxembourg ergänzt (RE 11, RB 83)
Daten stammen von der offiziellen Seite der CFL: https://www.cfl.lu/de-de/timetable

*Versuch 2
