### PR TITLE
Fix Praha - München (RE25)

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -48,7 +48,10 @@ brb,RB 83,bayerische-regiobahn,3-m8-rb83,#ffffff,#bf73bf,#bf73bf,rectangle
 brb,RE 5,bayerische-regiobahn,3-m8-re5,#00416d,#ffffff,,rectangle
 brb,S3,bayerische-regiobahn,4-l8-s3,#2aa335,#ffffff,,pill
 brb,S4,bayerische-regiobahn,4-l8-s4,#a765a2,#ffffff,,pill
-ceske-drahy,RE 25,ceske-drahy,1-54a8n-re25,#006666,#ffffff,,rectangle
+ceske-drahy,RE 25,ceske-drahy,ex-352,#006666,#ffffff,,rectangle
+ceske-drahy,RE 25,ceske-drahy,ex-354,#006666,#ffffff,,rectangle
+ceske-drahy,RE 25,ceske-drahy,ex-362,#006666,#ffffff,,rectangle
+ceske-drahy,RE 25,ceske-drahy,ex-364,#006666,#ffffff,,rectangle
 cfl,RE 11,cfl,3-82-11,#20b159,#ffffff,,rectangle
 cfl,RB 83,cfl,3-82-83,#20b159,#ffffff,,rectangle
 db-fernverkehr-ag,RE87,db-fernverkehr-ag,3-nz-87,#cc0066,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -101,6 +101,9 @@
         "contributors": [
             {
                 "github": "sebiIO"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [


### PR DESCRIPTION
The trains on this line coming from Praha and going to München were originally added with #201.
It seems like HAFAS changed. Throughout the day four trains are now leaving Praha for München: EX 352 / RE 25, EX 354 / RE 25, EX 362 / RE 25 and EX 364 / RE 25. These are added with this PR.