### PR TITLE
Here we go again: fix line ids after recent HAFAS change

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -204,11 +204,11 @@ db-regio-nordost,S1,db-regio-ag-nordost,4-800156-1,#00a998,#ffffff,,rectangle
 db-regio-nordost,S2,db-regio-ag-nordost,4-800156-2,#a0138e,#ffffff,,rectangle
 db-regio-nordost,S2X,db-regio-ag-nordost,4-800156-2x,#a0138e,#ffffff,,rectangle
 db-regio-nordost,S3,db-regio-ag-nordost,4-800156-3,#a64c35,#ffffff,,rectangle
-db-regio-sudost,RB 51,db-regio-ag-sudost,3-8004a9-51,#469cd7,#ffffff,,rectangle
-db-regio-sudost,RE 7,db-regio-ag-sudost,3-8004nt-7,#992e00,#ffffff,,rectangle
-db-regio-sudost,RE13,db-regio-ag-sudost,3-8004a9-13,#ebaa3b,#ffffff,,rectangle
-db-regio-sudost,RE14,db-regio-ag-sudost,3-8004a9-14,#a98956,#ffffff,,rectangle
-db-regio-sudost,RE 57,db-regio-ag-sudost,3-8004nt-57,#992e00,#ffffff,,rectangle
+db-regio-sudost,RB 51,db-regio-ag-sudost,rb-51,#469cd7,#ffffff,,rectangle
+db-regio-sudost,RE 7,db-regio-ag-sudost,re-7,#992e00,#ffffff,,rectangle
+db-regio-sudost,RE 13,db-regio-ag-sudost,re-13,#ebaa3b,#ffffff,,rectangle
+db-regio-sudost,RE 14,db-regio-ag-sudost,re-14,#a98956,#ffffff,,rectangle
+db-regio-sudost,RE 57,db-regio-ag-sudost,re-57,#992e00,#ffffff,,rectangle
 db-regio-sudost,S1,db-regio-ag-sudost,4-800486-1,#f5de2b,#000000,,pill
 db-regio-sudost,S2,db-regio-ag-sudost,4-8004a9-2,#18a2e3,#ffffff,,pill
 db-regio-sudost,S3,db-regio-ag-sudost,4-800486-3,#e1001e,#ffffff,,pill
@@ -270,20 +270,20 @@ dvg-dessau,Rufbus N4,,9-nas001-n4,#000000,#ffffff,,pill
 dvg-dessau,N5,,5-nas001-n5,#000000,#ffffff,,pill
 dvg-dessau,N6,,5-nas001-n6,#000000,#ffffff,,pill
 dwe-dessau,DWE,dessau-worlitzer-eisenbahn,dwe,#ffffff,#000000,#000000,rectangle
-erfurter-bahn,RB 13,erfurter-bahn-gmbh,3-eb-13,#24b27d,#ffffff,,rectangle
-erfurter-bahn,RB 40,erfurter-bahn-gmbh,3-eb-40,#24b27d,#ffffff,,rectangle
-erfurter-bahn,RB 50,erfurter-bahn-gmbh,3-eb-50,#24b27d,#ffffff,,rectangle
+erfurter-bahn,RB 13,erfurter-bahn-gmbh,rb-13,#24b27d,#ffffff,,rectangle
+erfurter-bahn,RB 40,erfurter-bahn-gmbh,rb-40,#24b27d,#ffffff,,rectangle
+erfurter-bahn,RB 50,erfurter-bahn-gmbh,rb-50,#24b27d,#ffffff,,rectangle
 hans,RB16,hanseatische-eisenbahn-gmbh,rb-16,#775fb0,#ffffff,,rectangle
 hans,RB33,hanseatische-eisenbahn-gmbh,rb-33,#ed1c24,#ffffff,,rectangle
 hans,RB34,hanseatische-eisenbahn-gmbh,rb-34,#0066ad,#ffffff,,rectangle
 hans,RB73,hanseatische-eisenbahn-gmbh,rb-73,#009686,#ffffff,,rectangle
 hans,RB74,hanseatische-eisenbahn-gmbh,rb-74,#0066ad,#ffffff,,rectangle
 hans,RE27,hanseatische-eisenbahn-gmbh,re27,#399fdf,#ffffff,,rectangle
-hlb,RB21,hlb-hessenbahn-gmbh,3-k4rb-rb21,#007ec5,#ffffff,,rectangle-rounded-corner
-hlb,RB29,hlb-hessenbahn-gmbh,3-k4rb-rb29,#c77db4,#ffffff,,rectangle-rounded-corner
-hlb,RB45,hlb-hessenbahn-gmbh,3-k4rb-rb45,#007ec5,#ffffff,,rectangle-rounded-corner
-hlb,RB90,hlb-hessenbahn-gmbh,3-k4rb-rb90,#90268f,#ffffff,,rectangle-rounded-corner
-hlb,RE24,hlb-hessenbahn-gmbh,3-k4re-re24,#007ec5,#ffffff,,rectangle-rounded-corner
+hlb,RB21,hlb-hessenbahn-gmbh,hlb-rb21,#007ec5,#ffffff,,rectangle-rounded-corner
+hlb,RB29,hlb-hessenbahn-gmbh,hlb-rb29,#c77db4,#ffffff,,rectangle-rounded-corner
+hlb,RB45,hlb-hessenbahn-gmbh,hlb-rb45,#007ec5,#ffffff,,rectangle-rounded-corner
+hlb,RB90,hlb-hessenbahn-gmbh,hlb-rb90,#90268f,#ffffff,,rectangle-rounded-corner
+hlb,RE24,hlb-hessenbahn-gmbh,hlb-re24,#007ec5,#ffffff,,rectangle-rounded-corner
 hvv-akn,A 1,akn-eisenbahn-gmbh,akn-a1,#f7931d,#ffffff,,pill
 hvv-akn,A 2,akn-eisenbahn-gmbh,akn-a2,#f7931d,#ffffff,,pill
 hvv-akn,A 3,akn-eisenbahn-gmbh,akn-a3,#f7931d,#ffffff,,pill
@@ -490,16 +490,16 @@ mdv-swh-havag,9,,8-nashat-9,#a7b150,#ffffff,,rectangle
 mdv-swh-havag,10,,8-nashat-10,#3d682d,#ffffff,,rectangle
 mdv-swh-havag,12,,8-nashat-12,#96c75a,#ffffff,,rectangle
 mdv-swh-havag,16,,8-nashat-12,#a13671,#ffffff,,rectangle
-metronom,RB31,metronom,3-r1-rb31,#7f257b,#ffffff,,rectangle
-metronom,RB41,metronom,3-r1-rb41,#2eb273,#ffffff,,rectangle
-metronom,RE2,metronom,3-r1-re2,#b22236,#ffffff,,rectangle
-metronom,RE3,metronom,3-r1-re3,#7f257b,#ffffff,,rectangle
-metronom,RE4,metronom,3-r1-re4-1113213-5957444,#2eb273,#ffffff,,rectangle
-mitteldeutsche-regiobahn,RE 3,mitteldeutsche-regiobahn,3-cxre-3,#0093d4,#ffffff,,rectangle-rounded-corner
-mitteldeutsche-regiobahn,RE 6,mitteldeutsche-regiobahn,3-cxre-6,#9e60a4,#ffffff,,rectangle-rounded-corner
-mitteldeutsche-regiobahn,RB 30,mitteldeutsche-regiobahn,3-cxrb-30,#ed9126,#ffffff,,rectangle-rounded-corner
-mitteldeutsche-regiobahn,RB 45,mitteldeutsche-regiobahn,3-cxrb-45,#ed694a,#ffffff,,rectangle-rounded-corner
-mitteldeutsche-regiobahn,RB 110,mitteldeutsche-regiobahn,3-cxrb-110,#a2cbba,#ffffff,,rectangle-rounded-corner
+metronom,RB31,metronom,me-rb31,#7f257b,#ffffff,,rectangle
+metronom,RB41,metronom,me-rb41,#2eb273,#ffffff,,rectangle
+metronom,RE2,metronom,me-re2,#b22236,#ffffff,,rectangle
+metronom,RE3,metronom,me-re3,#7f257b,#ffffff,,rectangle
+metronom,RE4,metronom,me-re4,#2eb273,#ffffff,,rectangle
+mitteldeutsche-regiobahn,RE 3,mitteldeutsche-regiobahn,re-3,#0093d4,#ffffff,,rectangle-rounded-corner
+mitteldeutsche-regiobahn,RE 6,mitteldeutsche-regiobahn,re-6,#9e60a4,#ffffff,,rectangle-rounded-corner
+mitteldeutsche-regiobahn,RB 30,mitteldeutsche-regiobahn,rb-30,#ed9126,#ffffff,,rectangle-rounded-corner
+mitteldeutsche-regiobahn,RB 45,mitteldeutsche-regiobahn,rb-45,#ed694a,#ffffff,,rectangle-rounded-corner
+mitteldeutsche-regiobahn,RB 110,mitteldeutsche-regiobahn,rb-110,#a2cbba,#ffffff,,rectangle-rounded-corner
 mvb-magdeburg,51,,5-nasmbb-51,#38529b,#ffffff,,pill
 mvb-magdeburg,52,,5-nasmbb-52,#e8a038,#ffffff,,pill
 mvb-magdeburg,53,,5-nasmbb-53,#f7ce46,#000000,,pill
@@ -623,8 +623,7 @@ nah-sh,RB 66,norddeutsche-eisenbahn-gesellschaft,neg-rb66,#798e0e,#ffffff,,recta
 nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,,rectangle
 nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,,rectangle
 nah-sh,RB 71,nordbahn,nbe-rb71,#008bd2,#ffffff,,rectangle
-nah-sh,RE 72,nordbahn,nbe-re72-1049761-6093308,#adce6d,#000000,,rectangle
-nah-sh,RE 72,nordbahn,nbe-re72-1127126-6042240,#adce6d,#000000,,rectangle
+nah-sh,RE 72,nordbahn,nbe-re72,#adce6d,#000000,,rectangle
 nah-sh,RB 73,nordbahn,nbe-re73,#008c57,#ffffff,,rectangle
 nah-sh,RE 74,nordbahn,nbe-re74,#693b58,#ffffff,,rectangle
 nah-sh,RB 75,nordbahn,nbe-re75,#ba731a,#ffffff,,rectangle
@@ -649,85 +648,84 @@ neb-niederbarnimer-eisenbahn,RB61,neb-niederbarnimer-eisenbahn,rb-61,#992746,#ff
 neb-niederbarnimer-eisenbahn,RB62,neb-niederbarnimer-eisenbahn,rb-62,#da6ba2,#ffffff,,rectangle
 neb-niederbarnimer-eisenbahn,RB63,neb-niederbarnimer-eisenbahn,rb-63,#ffd502,#000000,,rectangle
 neb-niederbarnimer-eisenbahn,TES,neb-niederbarnimer-eisenbahn,rb-tes,#d70000,#ffffff,,rectangle
-nrw-regional,RE 1,national-express,3-nxre-1,#ff2d16,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 2,db-regio-ag-nrw,3-800349-2,#00b8f1,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 3,eurobahn,3-r2re-3,#e46e25,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 4,national-express,3-nxre-4,#e88f24,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 5,national-express,3-nxre-5,#0182ba,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 6,national-express,3-nxre-6,#9e2a96,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 7,national-express,3-nxre-7,#052e69,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 8,db-regio-ag-nrw,3-8003g2-8,#006bbb,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 9,db-regio-ag-nrw,3-800338-9,#401446,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 10,rheinruhrbahn-transdev,3-tdrr-re10,#e66caf,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 11,national-express,3-nxre-11,#5accc2,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 12,db-regio-ag-nrw,3-800352-12,#ad294c,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 13,eurobahn,3-r2re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 14,rheinruhrbahn-transdev,3-tdrr-re14,#003328,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 16,vias-rail-gmbh,3-r4nrn-re16,#0e5778,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 17,db-regio-ag-nrw,3-800348-17,#489b40,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 18,db-arriva,3-800318-18,#10b3b4,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 19,vias-rail-gmbh,3-r4nrn-re19,#2f652b,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 20,db-regio-ag-nrw,3-8003a5-20-677645-5647636,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 20,db-regio-ag-nrw,3-8003a5-20-721137-5652276,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 21,rurtalbahn,3-d3-rb21,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 22,db-regio-ag-nrw,3-800352-22-774120-5667129,#ffad3e,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 24,db-regio-ag-nrw,3-800352-24,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 25,db-regio-ag-nrw,3-800352-25,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 26,mittelrheinbahn-trans-regio,3-tr-26,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 27,db-regio-ag-nrw,3-8003h5-27,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 28,rurtalbahn,3-d3-rb28,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 29,sncb,3-88-29,#d594c8,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 30,db-regio-ag-nrw,3-800352-30,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 31,rheinruhrbahn-transdev,3-tdrr-rb31,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 1,national-express,re-1,#ff2d16,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 2,db-regio-ag-nrw,re-2,#00b8f1,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 3,eurobahn,re-3,#e46e25,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 4,national-express,re-4,#e88f24,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 5,national-express,re-5,#0182ba,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 6,national-express,re-6,#9e2a96,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 7,national-express,re-7,#052e69,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 8,db-regio-ag-nrw,re-8,#006bbb,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 9,db-regio-ag-nrw,re-9,#401446,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 10,rheinruhrbahn-transdev,rrb-re10,#e66caf,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 11,national-express,re-11,#5accc2,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 12,db-regio-ag-nrw,re-12,#ad294c,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 13,eurobahn,re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 14,rheinruhrbahn-transdev,rrb-re14,#003328,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 16,vias-rail-gmbh,via-re16,#0e5778,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 17,db-regio-ag-nrw,re-17,#489b40,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 18,db-arriva,re-18,#10b3b4,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 19,vias-rail-gmbh,via-re19,#2f652b,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 20,db-regio-ag-nrw,rb-20,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 21,rurtalbahn,rtb-rb21,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 22,db-regio-ag-nrw,re-22,#ffad3e,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 24,db-regio-ag-nrw,rb-24,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 25,db-regio-ag-nrw,rb-25,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 26,mittelrheinbahn-trans-regio,rb-26,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 27,db-regio-ag-nrw,rb-27,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 28,rurtalbahn,rtb-rb28,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 29,sncb,re-29,#d594c8,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 30,db-regio-ag-nrw,rb-30,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 31,rheinruhrbahn-transdev,rrb-rb31,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 32,db-regio-ag-nrw,rb-32,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 33,db-regio-ag-nrw,3-800333-33,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 33,db-regio-ag-nrw,rb-33,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 34,db-fernverkehr-ag,re-34,#8c467d,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 34,db-regio-ag-nrw,re-34,#8c467d,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 34,hlb-hessenbahn-gmbh,hlb-re34,#8c467d,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 34,vias-rail-gmbh,3-r4nrn-rb34,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 35,vias-rail-gmbh,3-r4nrn-rb35,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 36,rheinruhrbahn-transdev,3-tdrr-rb36,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 34,vias-rail-gmbh,via-rb34,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 35,vias-rail-gmbh,via-rb35,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 36,rheinruhrbahn-transdev,rrb-rb36,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 37,tri-train-rental-gmbh,tri-rb37,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 38,db-regio-ag-nrw,rb-38,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 39,vias-rail-gmbh,3-r4nrn-rb39,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 40,db-regio-ag-nrw,3-8003l1-40,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 39,vias-rail-gmbh,via-rb39,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 40,db-regio-ag-nrw,rb-40,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 41,db-regio-ag-nrw,re-41,#5844a4,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 42,db-regio-ag-nrw,re-42,#d9bf13,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 43,db-regio-ag-nrw,rb-43,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 44,rheinruhrbahn-transdev,3-tdrr-4,#6294b0,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 46,vias-rail-gmbh,3-r4nrn-rb46,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 44,rheinruhrbahn-transdev,rrb-re44,#6294b0,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 46,vias-rail-gmbh,via-rb46,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 47,regiobahn,r-re-47,#66cdec,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 48,national-express,3-nxrb-48,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 48,national-express,rb-48,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 49,db-regio-ag-nrw,re-49,#c4836b,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 50,eurobahn,3-r2rb-50,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 50,eurobahn,rb-50,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 51,db-regio-ag-nrw,rb-51,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 52,db-regio-ag-nrw,rb-52,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 53,db-regio-ag-nrw,rb-53,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 54,db-regio-ag-nrw,rb-54,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 57,db-regio-ag-nrw,re-57,#2e6da6,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 58,nordwestbahn,nwb-rb58,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 59,eurobahn,3-r2rb-59,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 61,eurobahn,3-r2rb-61,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 59,eurobahn,rb-59,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 61,eurobahn,rb-61,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RE 62,db-regio-ag-nord,re-62,#1f52a6,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 63,db-regio-ag-nrw,rb-63,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 64,db-regio-ag-nrw,rb-64,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 65,eurobahn,3-r2rb-65,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 66,eurobahn,3-r2rb-66,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 67,eurobahn,3-r2rb-67,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 69,eurobahn,3-r2rb-69,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 71,eurobahn,3-r2rb-71,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 72,eurobahn,3-r2rb-72,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 73,eurobahn,3-r2rb-73,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 65,eurobahn,rb-65,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 66,eurobahn,rb-66,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 67,eurobahn,rb-67,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 69,eurobahn,rb-69,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 71,eurobahn,rb-71,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 72,eurobahn,rb-72,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 73,eurobahn,rb-73,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 74,nordwestbahn,nwb-rb74,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 75,nordwestbahn,nwb-rb75,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 77,regionalverkehre-start-deutschland-gmbh-start-niedersachsen-mitte,rb-77,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 78,eurobahn,3-r2re-78,#52b9ce,#ffffff,,rectangle-rounded-corner
-nrw-regional,RE 82,eurobahn,3-r2re-82,#489b40,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 78,eurobahn,re-78,#52b9ce,#ffffff,,rectangle-rounded-corner
+nrw-regional,RE 82,eurobahn,re-82,#489b40,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 84,nordwestbahn,nwb-rb84,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 85,nordwestbahn,nwb-rb85,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 89,eurobahn,3-r2rb-89,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 89,eurobahn,rb-89,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 90,hlb-hessenbahn-gmbh,hlb-rb90,#7a7c80,#ffffff,,rectangle-rounded-corner
-nrw-regional,RB 91,vias-rail-gmbh,3-r4nrn-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner
+nrw-regional,RB 91,vias-rail-gmbh,via-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 91,hlb-hessenbahn-gmbh,hlb-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 92,hlb-hessenbahn-gmbh,hlb-rb92,#7a7c80,#ffffff,,rectangle-rounded-corner
 nrw-regional,RB 93,hlb-hessenbahn-gmbh,hlb-rb93,#7a7c80,#ffffff,,rectangle-rounded-corner
@@ -770,10 +768,10 @@ nvs,16,,5-vwmbus-16,#a65a44,#ffffff,,pill
 nvs,17,,5-vwmbus-17,#afca05,#ffffff,,pill
 nvs,18,,5-vwmbus-18,#00963f,#ffffff,,pill
 nvs,19,,5-vwmbus-19,#f7a940,#ffffff,,pill
-oberpfalzbahn-dlb,RB 23,oberpfalzbahn-die-landerbahn-gmbh-dlb,3-o9-rb23,#6cc3d9,#ffffff,,rectangle
-oberpfalzbahn-dlb,RB 27,oberpfalzbahn-die-landerbahn-gmbh-dlb,3-o9-rb27,#ffb200,#ffffff,,rectangle
-oberpfalzbahn-dlb,RB 28,oberpfalzbahn-die-landerbahn-gmbh-dlb,3-o9-rb28,#90bf26,#ffffff,,rectangle
-oberpfalzbahn-dlb,RB 29,oberpfalzbahn-die-landerbahn-gmbh-dlb,3-o9-rb29,#ff6600,#ffffff,,rectangle
+oberpfalzbahn-dlb,RB 23,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb23,#6cc3d9,#ffffff,,rectangle
+oberpfalzbahn-dlb,RB 27,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb27,#ffb200,#ffffff,,rectangle
+oberpfalzbahn-dlb,RB 28,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb28,#90bf26,#ffffff,,rectangle
+oberpfalzbahn-dlb,RB 29,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb29,#ff6600,#ffffff,,rectangle
 odeg,RB13,ostdeutsche-eisenbahn-gmbh,rb-13,#3f4545,#ffffff,,rectangle
 odeg,RB14,ostdeutsche-eisenbahn-gmbh,rb-14,#196e76,#ffffff,,rectangle
 odeg,RB15,ostdeutsche-eisenbahn-gmbh,rb-15,#00a998,#ffffff,,rectangle
@@ -844,13 +842,13 @@ pid-prague,A,dopravni-podnik-hl-m-prahy,7-540001-a,#00a54f,#ffffff,,rectangle
 pid-prague,B,dopravni-podnik-hl-m-prahy,7-540001-b,#feca0a,#293219,,rectangle
 pid-prague,C,dopravni-podnik-hl-m-prahy,7-540001-c,#ee1d23,#ffffff,,rectangle
 polregio,RB91,polregio,r-91,#eb7405,#ffffff,,rectangle
-regio-s-bahn-donau-iller,RS 2,db-regio-ag-baden-wurttemberg,3-800622-rs2,#901411,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 21,db-regio-ag-baden-wurttemberg,3-800622-rs21,#e92a1c,#ffffff,,pill
+regio-s-bahn-donau-iller,RS 2,db-regio-ag-baden-wurttemberg,rs2,#901411,#ffffff,,pill
+regio-s-bahn-donau-iller,RS 21,db-regio-ag-baden-wurttemberg,rs21,#e92a1c,#ffffff,,pill
 regio-s-bahn-donau-iller,RS 3,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs3,#62358a,#ffffff,,pill
 regio-s-bahn-donau-iller,RS 5,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs5,#00622e,#ffffff,,pill
 regio-s-bahn-donau-iller,RS 51,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs51,#43aa2c,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 7,db-regio-ag-bayern,3-8007du-rs7,#234997,#ffffff,,pill
-regio-s-bahn-donau-iller,RS 71,db-regio-ag-bayern,3-8007du-rs71,#1398d3,#ffffff,,pill
+regio-s-bahn-donau-iller,RS 7,db-regio-ag-bayern,rs7,#234997,#ffffff,,pill
+regio-s-bahn-donau-iller,RS 71,db-regio-ag-bayern,rs71,#1398d3,#ffffff,,pill
 regiobus-hannover,170,,5-webrbg-170,#ffffff,#2c2e35,#ff9027,pill
 regiobus-hannover,300,,5-webrbg-300,#ffffff,#2c2e35,#903da0,pill
 regiobus-hannover,301,,5-webrbg-301,#ffffff,#2c2e35,#ff2e17,pill
@@ -1251,15 +1249,15 @@ sweg-sudwest,RB 25,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb25,#b6931d,#ff
 sweg-sudwest,RB 20,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb20,#d30630,#ffffff,,rectangle
 sweg-sudwest,RB 24,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb24,#afca0b,#ffffff,,rectangle
 sweg-sudwest,RB 22,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb22,#b15a9e,#ffffff,,rectangle
-tlx,L2,trilex-die-landerbahn-gmbh-dlb,3-ld-l2,#0f7ec0,#ffffff,,rectangle-rounded-corner
-tlx,L24,trilex-die-landerbahn-gmbh-dlb,3-ld-l24,#6eae47,#ffffff,,rectangle-rounded-corner
-tlx,L4,trilex-die-landerbahn-gmbh-dlb,3-ld-l4,#242320,#ffffff,,rectangle-rounded-corner
-tlx,L7,trilex-die-landerbahn-gmbh-dlb,3-ld-7,#ea7b09,#ffffff,,rectangle-rounded-corner
-tlx,RB60,trilex-die-landerbahn-gmbh-dlb,3-ld-rb60,#569b6d,#ffffff,,rectangle-rounded-corner
-tlx,RB61,trilex-die-landerbahn-gmbh-dlb,3-ld-rb61,#438577,#ffffff,,rectangle-rounded-corner
-tlx,RE1,trilex-express-die-landerbahn-gmbh-dlb,3-ldtlx-re1,#e97b3b,#ffffff,,rectangle-rounded-corner
-tlx,RE2,trilex-express-die-landerbahn-gmbh-dlb,3-ldtlx-re2,#db031c,#ffffff,,rectangle-rounded-corner
-tlx,T9,trilex-die-landerbahn-gmbh-dlb,3-ld-t9,#f6b90b,#ffffff,,rectangle-rounded-corner
+tlx,L2,trilex-die-landerbahn-gmbh-dlb,tl-l2,#0f7ec0,#ffffff,,rectangle-rounded-corner
+tlx,L24,trilex-die-landerbahn-gmbh-dlb,tl-l24,#6eae47,#ffffff,,rectangle-rounded-corner
+tlx,L4,trilex-die-landerbahn-gmbh-dlb,tl-l4,#242320,#ffffff,,rectangle-rounded-corner
+tlx,L7,trilex-die-landerbahn-gmbh-dlb,tl-l7,#ea7b09,#ffffff,,rectangle-rounded-corner
+tlx,RB60,trilex-die-landerbahn-gmbh-dlb,tl-rb60,#569b6d,#ffffff,,rectangle-rounded-corner
+tlx,RB61,trilex-die-landerbahn-gmbh-dlb,tl-rb61,#438577,#ffffff,,rectangle-rounded-corner
+tlx,RE1,trilex-express-die-landerbahn-gmbh-dlb,tlx-re1,#e97b3b,#ffffff,,rectangle-rounded-corner
+tlx,RE2,trilex-express-die-landerbahn-gmbh-dlb,tlx-re2,#db031c,#ffffff,,rectangle-rounded-corner
+tlx,T9,trilex-die-landerbahn-gmbh-dlb,tl-t9,#f6b90b,#ffffff,,rectangle-rounded-corner
 uestra,1,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-1,#ffffff,#2c2e35,#ff2e3e,rectangle
 uestra,2,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-2,#ffffff,#2c2e35,#ff2e3e,rectangle
 uestra,3,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-3,#ffffff,#2c2e35,#0073c0,rectangle
@@ -1393,10 +1391,10 @@ vbb-vip-tram,94,,8-vbbvit-94,#89969e,#ffffff,,rectangle
 vbb-vip-tram,96,,8-vbbvit-96,#00b098,#ffffff,,rectangle
 vbb-vip-tram,98,,8-vbbvit-98,#daedf9,#009edd,#009edd,rectangle
 vbb-vip-tram,99,,8-vbbvit-99,#5fbf49,#ffffff,,rectangle
-vbg,RB 1,vogtlandbahn-die-landerbahn-gmbh-dlb,3-rd-rb1,#e30613,#ffffff,,rectangle-rounded-corner
-vbg,RB 2,vogtlandbahn-die-landerbahn-gmbh-dlb,3-rd-rb2,#0067b0,#ffffff,,rectangle-rounded-corner
-vbg,RB 4,vogtlandbahn-die-landerbahn-gmbh-dlb,3-rd-rb4,#954b3f,#ffffff,,rectangle-rounded-corner
-vbg,RB 5,vogtlandbahn-die-landerbahn-gmbh-dlb,3-rd-rb5,#009641,#ffffff,,rectangle-rounded-corner
+vbg,RB 1,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb1,#e30613,#ffffff,,rectangle-rounded-corner
+vbg,RB 2,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb2,#0067b0,#ffffff,,rectangle-rounded-corner
+vbg,RB 4,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb4,#954b3f,#ffffff,,rectangle-rounded-corner
+vbg,RB 5,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb5,#009641,#ffffff,,rectangle-rounded-corner
 vbn-bsag,1,bremer-strassenbahn-ag,8-webbtr-1,#00a54f,#ffffff,,rectangle
 vbn-bsag,1E,bremer-strassenbahn-ag,8-webbtr-1e,#00a54f,#ffffff,,rectangle
 vbn-bsag,1S,bremer-strassenbahn-ag,8-webbtr-1s,#00a54f,#ffffff,,rectangle

--- a/sources.json
+++ b/sources.json
@@ -263,6 +263,9 @@
             },
             {
                 "github": "verbuchselt"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
@@ -451,6 +454,9 @@
         "contributors": [
             {
                 "github": "SpielenmitLili"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
@@ -701,6 +707,9 @@
         "contributors": [
             {
                 "github": "hoolycrash"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
@@ -829,6 +838,9 @@
             },
             {
                 "github": "laugengebaeck"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
@@ -978,6 +990,9 @@
         "contributors": [
             {
                 "github": "verbuchselt"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [
@@ -1494,6 +1509,9 @@
         "contributors": [
             {
                 "github": "feuer1998"
+            },
+            {
+                "github": "oneiricbotcelot"
             }
         ],
         "sources": [


### PR DESCRIPTION
I fixed the next batch of lines including DB Regio Südost, Erfurter Bahn, Hessische Landesbahn, Metronom, Mitteldeutsche Regiobahn, one line operated by Nordbahn in Schleswig-Holstein, all NRW regional lines, Oberpfalzbahn, four lines of Regio-S-Bahn Donau-Iller operated by DB Regio Baden-Württemberg and DB Regio Bayern, TRILEX and Vogtlandbahn.