### PR TITLE
add DSB S-Tog (Koebenhavn)

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -255,6 +255,13 @@ db-sev-riedbahn,Q1,db-regio-ag-mitte,3-8005sv-q1,#ff9027,#ffffff,,pill,
 db-sev-riedbahn,Q2,db-regio-ag-mitte,3-8005sv-q2,#1f612d,#ffffff,,pill,
 ding-swu,1,,8-ald087-1,#e52329,#ffffff,,rectangle,
 ding-swu,2,,8-ald087-2,#3fad56,#ffffff,,rectangle,
+dsb-s-tog,A,,4-860022-a,#00a8e7,#ffffff,,rectangle-rounded-corner,Q2323144
+dsb-s-tog,B,,4-860022-b,#52ae32,#ffffff,,rectangle-rounded-corner,Q1903862
+dsb-s-tog,Bx,,4-860022-bx,#adce6d,#ffffff,,rectangle-rounded-corner,Q2127863
+dsb-s-tog,C,,4-860022-c,#f39200,#ffffff,,rectangle-rounded-corner,Q4452746
+dsb-s-tog,E,,4-860022-e,#7c6eb0,#ffffff,,rectangle-rounded-corner,Q4624816
+dsb-s-tog,F,,4-860022-f,#fdc300,#ffffff,,rectangle-rounded-corner,Q2133631
+dsb-s-tog,H,,4-860022-h,#e74011,#ffffff,,rectangle-rounded-corner,Q1891933
 dvg-dessau,1,,8-nasdvg-1,#f59c00,#ffffff,,rectangle,
 dvg-dessau,3,,8-nasdvg-3,#f59c00,#ffffff,,rectangle,
 dvg-dessau,10,,5-nas001-10,#2e76bb,#ffffff,,pill,

--- a/sources.json
+++ b/sources.json
@@ -345,6 +345,20 @@
         ]
     },
     {
+        "shortOperatorName": "dsb-s-tog",
+        "contributors": [
+            {
+                "github": "jonaes"
+            }
+        ],
+        "sources": [
+            {
+                "name": "Fahrplan S-Tog",
+                "source": "https://www.dsb.dk/globalassets/pdf/koereplaner/s-tog/s25/s-tog-s25.pdf"
+            }
+        ]
+    },
+    {
         "shortOperatorName": "dvg-dessau",
         "contributors": [
             {


### PR DESCRIPTION
The lines of the Koebenhavn S-Tog, source is the timetable pdf: https://www.dsb.dk/globalassets/pdf/koereplaner/s-tog/s25/s-tog-s25.pdf