### PR TITLE
feat: added most DELFI bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The `line-colors.csv` contains several columns:
   - `pill`: Rectangle with completely rounded corners
   - `trapezoid` A trapezoid shape with a broad top and a narrow bottom side
 - `wikidataQid`: Wikidata QID for the line (if available, can be empty)
+- `delfiAgencyID`: Agency ID (for example train operating company) that is used in the DELFI GTFS feed (if available, can be empty)
+- `delfiAgencyName`: Agency name that is used in the DELFI GTFS feed (if available, can be empty)
+
 
 ## Contributing
 

--- a/line-colors.csv
+++ b/line-colors.csv
@@ -1,2537 +1,2537 @@
-shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,borderColor,shape,wikidataQid
-agilis,RB 15,agilis,ag-rb15,#24b27d,#ffffff,,rectangle,Q130542089
-agilis,RB 17,agilis,ag-rb17,#90bf26,#ffffff,,rectangle,Q130542097
-agilis,RB 18,agilis,ag-rb18,#ff9999,#ffffff,,rectangle,Q104149638
-agilis,RB 21,agilis,ag-rb21,#e5a05c,#ffffff,,rectangle,Q130542098
-agilis,RB 22,agilis,ag-rb22,#90bf26,#ffffff,,rectangle,Q115773398
-agilis,RB 24,agilis,ag-rb24,#00ace5,#ffffff,,rectangle,Q130542099
-agilis,RB 26,agilis,ag-rb26,#6cc3d9,#ffffff,,rectangle,Q130542100
-agilis,RB 34,agilis,ag-rb34,#bf73bf,#ffffff,,rectangle,Q130542101
-agilis,RB 51,agilis,ag-rb51,#bf73bf,#ffffff,,rectangle,Q130542102
-agilis,RB 95,agilis,ag-rb95,#ff6600,#ffffff,,rectangle,Q130542103
-agilis,RB 96,agilis,ag-rb96,#ff6600,#ffffff,,rectangle,Q130542104
-agilis,RB 97,agilis,ag-rb97,#90bf26,#ffffff,,rectangle,Q130542106
-agilis,RB 98,agilis,ag-rb98,#24b27d,#ffffff,,rectangle,Q130542107
-agilis,RB 99,agilis,ag-rb99,#ffb200,#ffffff,,rectangle,Q130542108
-agilis,RE 18,agilis,ag-re18,#006428,#ffffff,,rectangle,Q130542152
-alex-dlb,RE 23,alex-die-landerbahn-gmbh-dlb,re23,#ffffff,#006666,#006666,rectangle,Q130542294
-alex-dlb,RE 25,alex-die-landerbahn-gmbh-dlb,re25,#006666,#ffffff,,rectangle,Q130542295
-ams,S7,abellio-rail-mitteldeutschland-gmbh,4-ams-7,#0a579b,#ffffff,,pill,Q63217583
-arverio-bw,RE 1,arverio-baden-wurttemberg,re-1,#88c946,#ffffff,,rectangle,Q64504218
-arverio-bw,MEX 13,arverio-baden-wurttemberg,mex-13,#00b9f2,#ffffff,,rectangle,Q130542338
-arverio-bw,MEX 16,arverio-baden-wurttemberg,mex-16,#0073c0,#ffffff,,rectangle,Q130542339
-arverio-bw,RE 8,arverio-baden-wurttemberg,re-8,#b350a8,#ffffff,,rectangle,Q64512248
-arverio-bw,RB 8,arverio-baden-wurttemberg,rb-8,#b350a8,#ffffff,,rectangle,Q131583892
-arverio-bw,RE 90,arverio-baden-wurttemberg,re-90,#fd3083,#ffffff,,rectangle,Q64512220
-arverio-by,RB86,arverio-bayern,rb-86,#77aed2,#ffffff,,rectangle,Q130789113
-arverio-by,RB87,arverio-bayern,rb-87,#77aed2,#ffffff,,rectangle,Q130789121
-arverio-by,RB89,arverio-bayern,rb-89,#006da7,#ffffff,,rectangle,Q130789128
-arverio-by,RB92,arverio-bayern,rb-92,#f28f8e,#ffffff,,rectangle,Q130789133
-arverio-by,RE72,arverio-bayern,re-72,#ef7c00,#ffffff,,rectangle,Q130789094
-arverio-by,RE80,arverio-bayern,re-80,#006da7,#ffffff,,rectangle,Q116761629
-arverio-by,RE89,arverio-bayern,re-89,#006da7,#ffffff,,rectangle,Q130789100
-arverio-by,RE9,arverio-bayern,re-9,#006da7,#ffffff,,rectangle,Q130789102
-arverio-by,RE96,arverio-bayern,re-96,#f9b000,#ffffff,,rectangle,Q130789109
-bayerische-zugspitzbahn,RB 64,bayerische-zugspitzbahn,bzb-rb64,#6cc3d9,#ffffff,,rectangle,
-brb,RB 13,bayerische-regiobahn,brb-rb13,#ffb200,#ffffff,,rectangle,
-brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb200,#ffffff,,rectangle,
-brb,RB 53,bayerische-regiobahn,brb-rb53,#ff9999,#ffffff,,rectangle,
-brb,RB 54,bayerische-regiobahn,brb-rb54,#00ace5,#ffffff,,rectangle,
-brb,RB 55,bayerische-regiobahn,brb-rb55,#ff6600,#ffffff,,rectangle,
-brb,RB 56,bayerische-regiobahn,brb-rb56,#ff6600,#ffffff,,rectangle,
-brb,RB 57,bayerische-regiobahn,brb-rb57,#ff6600,#ffffff,,rectangle,
-brb,RB 58,bayerische-regiobahn,brb-rb58,#ffb200,#ffffff,,rectangle,
-brb,RB 67,bayerische-regiobahn,brb-rb67,#bf73bf,#ffffff,,rectangle,
-brb,RB 68,bayerische-regiobahn,brb-rb68,#ffffff,#90bf26,#90bf26,rectangle,
-brb,RB 69,bayerische-regiobahn,brb-rb69,#00ace5,#ffffff,,rectangle,
-brb,RB 77,bayerische-regiobahn,brb-rb77,#24b27d,#ffffff,,rectangle,
-brb,RB 83,bayerische-regiobahn,brb-rb83,#ffffff,#bf73bf,#bf73bf,rectangle,
-brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle,
-brb,S3,bayerische-regiobahn,4-l8-s3,#2aa335,#ffffff,,pill,
-brb,S4,bayerische-regiobahn,4-l8-s4,#a765a2,#ffffff,,pill,
-ceske-drahy,RE 25,ceske-drahy,ex-352,#006666,#ffffff,,rectangle,
-ceske-drahy,RE 25,ceske-drahy,ex-354,#006666,#ffffff,,rectangle,
-ceske-drahy,RE 25,ceske-drahy,ex-362,#006666,#ffffff,,rectangle,
-ceske-drahy,RE 25,ceske-drahy,ex-364,#006666,#ffffff,,rectangle,
-cfl,RE 11,cfl,re-11,#20b159,#ffffff,,rectangle,
-cfl,RB 83,cfl,rb-83,#20b159,#ffffff,,rectangle,
-db-fernverkehr-ag,RE 87,db-fernverkehr-ag,re-87,#cc0066,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 2,db-regio-ag-baden-wurttemberg,re-2,#0069b4,#ffffff,,rectangle,Q88627355
-db-regio-ag-baden-wurttemberg,RE 3,db-regio-ag-baden-wurttemberg,re-3,#e5007d,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 4,db-regio-ag-baden-wurttemberg,re-4,#a05a2c,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 5,db-regio-ag-baden-wurttemberg,re-5,#724019,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 6,db-regio-ag-baden-wurttemberg,re-6,#4d4d4d,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 7,db-regio-ag-baden-wurttemberg,re-7,#ed6e19,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 14a,db-regio-ag-baden-wurttemberg,re-14a,#f39794,#000000,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 14b,db-regio-ag-baden-wurttemberg,re-14b,#02aa9e,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,MEX 19,db-regio-ag-baden-wurttemberg,mex-19,#999999,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 26,db-regio-ag-baden-wurttemberg,rb-26,#009fe3,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 27,db-regio-ag-baden-wurttemberg,rb-27,#008c3c,#ffffff,,rectangle,Q130280632
-db-regio-ag-baden-wurttemberg,RB 28,db-regio-ag-baden-wurttemberg,rb-28,#724019,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 30,db-regio-ag-baden-wurttemberg,rb-30,#571d70,#ffffff,,rectangle,Q130280647
-db-regio-ag-baden-wurttemberg,RB 31,db-regio-ag-baden-wurttemberg,rb-31,#00a99d,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 32,db-regio-ag-baden-wurttemberg,rb-32,#008c3c,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 37,db-regio-ag-baden-wurttemberg,rb-37,#aec90a,#ffffff,,rectangle,Q130283617
-db-regio-ag-baden-wurttemberg,RE 50,db-regio-ag-baden-wurttemberg,re-50,#b5931c,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 52,db-regio-ag-baden-wurttemberg,rb-52,#00a99d,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 53,db-regio-ag-baden-wurttemberg,rb-53,#561c6f,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 55,db-regio-ag-baden-wurttemberg,re-55,#b0599e,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 63,db-regio-ag-baden-wurttemberg,rb-63,#d30730,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 72,db-regio-ag-baden-wurttemberg,rb-72,#008c3c,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 74,db-regio-ag-baden-wurttemberg,rb-74,#0a69b2,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RB 93,db-regio-ag-baden-wurttemberg,rb-93,#009fe3,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 93,db-regio-ag-baden-wurttemberg,re-93,#009fe3,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,MEX 90,db-regio-ag-baden-wurttemberg,mex-90,#e5007d,#ffffff,,rectangle,
-db-regio-ag-baden-wurttemberg,RE 200,db-regio-ag-baden-wurttemberg,re-200,#aa0344,#ffffff,,rectangle,Q114680512
-db-regio-bayern,RB 6,db-regio-ag-bayern,rb-6,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RB 10,db-regio-ag-bayern,rb-10,#90bf26,#ffffff,,rectangle,
-db-regio-bayern,RB 11,db-regio-ag-bayern,rb-11,#00ace5,#ffffff,,rectangle,
-db-regio-bayern,RB 12,db-regio-ag-bayern,rb-12,#6cc3d9,#ffffff,,rectangle,
-db-regio-bayern,RB 16,db-regio-ag-bayern,rb-16,#ff9999,#ffffff,,rectangle,
-db-regio-bayern,RB 21,db-regio-ag-bayern,rb-21,#e5a05c,#ffffff,,rectangle,
-db-regio-bayern,RB 25,db-regio-ag-bayern,rb-25,#ffa0a0,#ffffff,,rectangle,
-db-regio-bayern,RB 30,db-regio-ag-bayern,rb-30,#bf73bf,#ffffff,,rectangle,
-db-regio-bayern,RB 31,db-regio-ag-bayern,rb-31,#ff9999,#ffffff,,rectangle,
-db-regio-bayern,RB 33,db-regio-ag-bayern,rb-33,#bf73bf,#ffffff,,rectangle,
-db-regio-bayern,RB 53,db-regio-ag-bayern,rb-53,#bf73bf,#ffffff,,rectangle,
-db-regio-bayern,RB 60,db-regio-ag-bayern,rb-60,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RB 61,db-regio-ag-bayern,rb-61,#bf73bf,#ffffff,,rectangle,
-db-regio-bayern,RB 62,db-regio-ag-bayern,rb-62,#90bf26,#ffffff,,rectangle,
-db-regio-bayern,RB 63,db-regio-ag-bayern,rb-63,#ffb200,#ffffff,,rectangle,
-db-regio-bayern,RB 65,db-regio-ag-bayern,rb-65,#ff9999,#ffffff,,rectangle,
-db-regio-bayern,RB 66,db-regio-ag-bayern,rb-66,#ff9999,#ffffff,,rectangle,
-db-regio-bayern,RB 73,db-regio-ag-bayern,rb-73,#6cc3d9,#ffffff,,rectangle,
-db-regio-bayern,RB 74,db-regio-ag-bayern,rb-74,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RB 78,db-regio-ag-bayern,rb-78,#ff9999,#ffffff,,rectangle,
-db-regio-bayern,RB 79,db-regio-ag-bayern,rb-79,#ffffff,#90bf26,#90bf26,rectangle,
-db-regio-bayern,RB 80,db-regio-ag-bayern,rb-80,#ffffff,#008fbf,#008fbf,rectangle,
-db-regio-bayern,RB 81,db-regio-ag-bayern,rb-81,#24b27d,#ffffff,,rectangle,
-db-regio-bayern,RB 82,db-regio-ag-bayern,rb-82,#00ace5,#ffffff,,rectangle,
-db-regio-bayern,RB 85,db-regio-ag-bayern,rb-85,#009fe3,#ffffff,,rectangle,
-db-regio-bayern,RB 91,db-regio-ag-bayern,rb-91,#6cc3d9,#ffffff,,rectangle,
-db-regio-bayern,RB 94,db-regio-ag-bayern,rb-94,#ffffff,#90bf26,#90bf26,rectangle,
-db-regio-bayern,RE 1,db-regio-ag-bayern,re-1,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 2,db-regio-ag-bayern,re-2,#00b2b2,#ffffff,,rectangle,
-db-regio-bayern,RE 3,db-regio-ag-bayern,re-3,#800080,#ffffff,,rectangle,
-db-regio-bayern,RE 7,db-regio-ag-bayern,re-7,#992e00,#ffffff,,rectangle,
-db-regio-bayern,RE 10,db-regio-ag-bayern,re-10,#006428,#ffffff,,rectangle,
-db-regio-bayern,RE 14,db-regio-ag-bayern,re-14,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 16,db-regio-ag-bayern,re-16,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 17,db-regio-ag-bayern,re-17,#992e00,#ffffff,,rectangle,
-db-regio-bayern,RE 19,db-regio-ag-bayern,re-19,#ff6600,#ffffff,,rectangle,
-db-regio-bayern,RE 20,db-regio-ag-bayern,re-20,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 22,db-regio-ag-bayern,re-22,#ff6600,#ffffff,,rectangle,
-db-regio-bayern,RE 28,db-regio-ag-bayern,re-28,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 29,db-regio-ag-bayern,re-29,#ffffff,#ff6600,#ff6600,rectangle,
-db-regio-bayern,RE 30,db-regio-ag-bayern,re-30,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 31,db-regio-ag-bayern,re-31,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 32,db-regio-ag-bayern,re-32,#004080,#ffffff,,rectangle,
-db-regio-bayern,RE 33,db-regio-ag-bayern,re-33,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 35,db-regio-ag-bayern,re-35,#004080,#ffffff,,rectangle,
-db-regio-bayern,RE 38,db-regio-ag-bayern,re-38,#008fbf,#ffffff,,rectangle,
-db-regio-bayern,RE 40,db-regio-ag-bayern,re-40,#992e00,#ffffff,,rectangle,
-db-regio-bayern,RE 41,db-regio-ag-bayern,re-41,#992e00,#ffffff,,rectangle,
-db-regio-bayern,RE 43,db-regio-ag-bayern,re-43,#ffffff,#992e00,#992e00,rectangle,
-db-regio-bayern,RE 47,db-regio-ag-bayern,re-47,#ffffff,#992e00,#992e00,rectangle,
-db-regio-bayern,RE 50,db-regio-ag-bayern,re-50,#804080,#ffffff,,rectangle,
-db-regio-bayern,RE 54,db-regio-ag-bayern,re-54,#800080,#ffffff,,rectangle,
-db-regio-bayern,RE 55,db-regio-ag-bayern,re-55,#800080,#ffffff,,rectangle,
-db-regio-bayern,RE 60,db-regio-ag-bayern,re-60,#ffffff,#800080,#800080,rectangle,
-db-regio-bayern,RE 61,db-regio-ag-bayern,re-61,#ffffff,#992e00,#992e00,rectangle,
-db-regio-bayern,RE 62,db-regio-ag-bayern,re-62,#ffffff,#992e00,#992e00,rectangle,
-db-regio-bayern,RE 70,db-regio-ag-bayern,re-70,#006629,#ffffff,,rectangle,
-db-regio-bayern,RE 71,db-regio-ag-bayern,re-71,#e5a05c,#ffffff,,rectangle,
-db-regio-bayern,RE 73,db-regio-ag-bayern,re-73,#e5a05c,#ffffff,,rectangle,
-db-regio-bayern,RE 75,db-regio-ag-bayern,re-75,#e50000,#ffffff,,rectangle,
-db-regio-bayern,RE 76,db-regio-ag-bayern,re-76,#006629,#ffffff,,rectangle,
-db-regio-bayern,RE 79,db-regio-ag-bayern,re-79,#800080,#ffffff,,rectangle,
-db-regio-mitte,RE1,db-regio-ag-mitte-suwex,re-1,#be1b40,#ffffff,,rectangle-rounded-corner,Q112773387
-db-regio-mitte,RE2,db-regio-ag-mitte-suwex,re-2,#e3a023,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RE4,db-regio-ag-mitte-suwex,re-4,#970c7e,#ffffff,,rectangle-rounded-corner,Q112996721
-db-regio-mitte,RE6,db-regio-ag-mitte,re-6,#f15921,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RE 11,db-regio-ag-mitte-suwex,re-11,#20b159,#ffffff,,rectangle,
-db-regio-mitte,RE14,db-regio-ag-mitte-suwex,re-14,#970c7e,#ffffff,,rectangle-rounded-corner,Q112996572
-db-regio-mitte,RE20,db-regio-ag-mitte,re-20,#ee1d23,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RE25,db-regio-ag-mitte,re-25,#007ec5,#ffffff,,rectangle-rounded-corner,Q98104051
-db-regio-mitte,RB22,db-regio-ag-mitte,rb-22,#ee1d23,#ffffff,,rectangle-rounded-corner,Q130342880
-db-regio-mitte,RB23,db-regio-ag-mitte,rb-23,#15c0f2,#ffffff,,rectangle-rounded-corner,Q96474187
-db-regio-mitte,RE30,db-regio-ag-mitte,re-30,#e30019,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB45,db-regio-ag-mitte,rb-45,#8bc63f,#ffffff,,rectangle-rounded-corner,Q98152720
-db-regio-mitte,RB46,db-regio-ag-mitte,rb-46,#00805f,#ffffff,,rectangle-rounded-corner,Q98152733
-db-regio-mitte,RE50,db-regio-ag-mitte,re-50,#e30019,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB51,db-regio-ag-mitte,rb-51,#00805f,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB53,db-regio-ag-mitte,rb-53,#40ae49,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB55,db-regio-ag-mitte,rb-55,#005824,#ffffff,,rectangle-rounded-corner,Q108435213
-db-regio-mitte,RE40,db-regio-ag-mitte,re-40,#ff9027,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB41,db-regio-ag-mitte,rb-41,#00ab4f,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB44,db-regio-ag-mitte,rb-44,#7ac547,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RE45,db-regio-ag-mitte,re-45,#cf631a,#ffffff,,rectangle-rounded-corner,Q126890289
-db-regio-mitte,RE60,db-regio-ag-mitte,re-60,#d03831,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB67,db-regio-ag-mitte,rb-67,#406bb1,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB68,db-regio-ag-mitte,rb-68,#406bb1,#ffffff,,rectangle-rounded-corner,Q68930888
-db-regio-mitte,RE70,db-regio-ag-mitte,re-70,#d03831,#ffffff,,rectangle-rounded-corner,Q80105383
-db-regio-mitte,RE73,db-regio-ag-mitte,re-73,#ff2e17,#ffffff,,rectangle-rounded-corner,
-db-regio-mitte,RB 83,db-regio-ag-mitte,rb-83,#20b159,#ffffff,,rectangle,
-db-regio-mitte,SE14,db-regio-ag-mitte-suwex,se14,#90268f,#ffffff,,rectangle-rounded-corner,
-db-regio-nordost,FEX,db-regio-ag-nordost,fex19829,#79122f,#ffffff,,rectangle,Q100533383
-db-regio-nordost,RB10,db-regio-ag-nordost,rb-10,#66aa22,#ffffff,,rectangle,Q15195695
-db-regio-nordost,RB11,db-regio-ag-nordost,rb-11,#ed1c24,#ffffff,,rectangle,
-db-regio-nordost,RB12,db-regio-ag-nordost,rb-12,#399fdf,#ffffff,,rectangle,Q42383940
-db-regio-nordost,RB14,db-regio-ag-nordost,rb-14,#a5027d,#ffffff,,rectangle,Q15119376
-db-regio-nordost,RB17,db-regio-ag-nordost,rb-17,#dd4daf,#ffffff,,rectangle,
-db-regio-nordost,RB18,db-regio-ag-nordost,rb-18,#399fdf,#ffffff,,rectangle,
-db-regio-nordost,RB20,db-regio-ag-nordost,rb-20,#007734,#ffffff,,rectangle,Q68007873
-db-regio-nordost,RB21,db-regio-ag-nordost,rb-21,#501689,#ffffff,,rectangle,Q105947745
-db-regio-nordost,RB22,db-regio-ag-nordost,rb-22,#009bd5,#ffffff,,rectangle,Q68006335
-db-regio-nordost,RB23,db-regio-ag-nordost,3-800165-23,#eb7405,#ffffff,,rectangle,
-db-regio-nordost,RB23,db-regio-ag-nordost,rb-23,#0066ad,#ffffff,,rectangle,
-db-regio-nordost,RB24,db-regio-ag-nordost,3-800165-24,#da6ba2,#ffffff,,rectangle,
-db-regio-nordost,RB24,db-regio-ag-nordost,rb-24,#e2001a,#ffffff,,rectangle,
-db-regio-nordost,RB25,db-regio-ag-nordost,rb-25,#00a998,#ffffff,,rectangle,Q63484785
-db-regio-nordost,RB28,db-regio-ag-nordost,rb-28,#ee7000,#ffffff,,rectangle,
-db-regio-nordost,RB31,db-regio-ag-nordost,rb-31,#66aa22,#ffffff,,rectangle,Q66439830
-db-regio-nordost,RB32,db-regio-ag-nordost,rb-32,#697c8a,#ffffff,,rectangle,Q112802971
-db-regio-nordost,RB43,db-regio-ag-nordost,rb-43,#009bd5,#ffffff,,rectangle,Q84429153
-db-regio-nordost,RB49,db-regio-ag-nordost,rb-49,#992746,#ffffff,,rectangle,Q84436359
-db-regio-nordost,RB55,db-regio-ag-nordost,rb-55,#eb7405,#ffffff,,rectangle,Q63224617
-db-regio-nordost,RB92,db-regio-ag-nordost,rb-92,#eb7405,#ffffff,,rectangle,
-db-regio-nordost,RB93,db-regio-ag-nordost,rb-93,#eb7405,#ffffff,,rectangle,
-db-regio-nordost,RE1,db-regio-ag-nordost,re-1,#108449,#ffffff,,rectangle,
-db-regio-nordost,RE2,db-regio-ag-nordost,re-2,#ffd502,#000000,,rectangle,
-db-regio-nordost,RE3,db-regio-ag-nordost,re-3,#eb7405,#ffffff,,rectangle,
-db-regio-nordost,RE4,db-regio-ag-nordost,3-800158-4,#992746,#ffffff,,rectangle,
-db-regio-nordost,RE4,db-regio-ag-nordost,re-4,#66aa22,#ffffff,,rectangle,
-db-regio-nordost,RE5,db-regio-ag-nordost,re-5,#0066ad,#ffffff,,rectangle,
-db-regio-nordost,RE6,db-regio-ag-nordost,re-6,#da6ba2,#ffffff,,rectangle,
-db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#007734,#ffffff,,rectangle,
-db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#da6ba2,#ffffff,,rectangle,
-db-regio-nordost,RE10,db-regio-ag-nordost,re-10,#5e5e5d,#ffffff,,rectangle,
-db-regio-nordost,RE11,db-regio-ag-nordost,re-11,#da6ba2,#ffffff,,rectangle,
-db-regio-nordost,RE13,db-regio-ag-nordost,re-13,#009686,#ffffff,,rectangle,
-db-regio-nordost,RE15,db-regio-ag-nordost,re-15,#ffd502,#000000,,rectangle,
-db-regio-nordost,RE18,db-regio-ag-nordost,re-18,#eb7405,#ffffff,,rectangle,
-db-regio-nordost,RE50,db-regio-ag-nordost,re-50,#2785d0,#ffffff,,rectangle,
-db-regio-nordost,RE51,db-regio-ag-nordost,re-51,#00998a,#ffffff,,rectangle,
-db-regio-nordost,S1,db-regio-ag-nordost,4-800156-1,#00a998,#ffffff,,rectangle,
-db-regio-nordost,S2,db-regio-ag-nordost,4-800156-2,#a0138e,#ffffff,,rectangle,
-db-regio-nordost,S2X,db-regio-ag-nordost,4-800156-2x,#a0138e,#ffffff,,rectangle,
-db-regio-nordost,S3,db-regio-ag-nordost,4-800156-3,#a64c35,#ffffff,,rectangle,
-db-regio-sudost,RB 51,db-regio-ag-sudost,rb-51,#469cd7,#ffffff,,rectangle,
-db-regio-sudost,RE 7,db-regio-ag-sudost,re-7,#992e00,#ffffff,,rectangle,Q1885609
-db-regio-sudost,RE 13,db-regio-ag-sudost,re-13,#ebaa3b,#ffffff,,rectangle,Q113505112
-db-regio-sudost,RE 14,db-regio-ag-sudost,re-14,#a98956,#ffffff,,rectangle,
-db-regio-sudost,RE 57,db-regio-ag-sudost,re-57,#992e00,#ffffff,,rectangle,
-db-regio-sudost,S1,db-regio-ag-sudost,4-800486-1,#f5de2b,#000000,,pill,
-db-regio-sudost,S2,db-regio-ag-sudost,4-8004a9-2,#18a2e3,#ffffff,,pill,
-db-regio-sudost,S3,db-regio-ag-sudost,4-800486-3,#e1001e,#ffffff,,pill,
-db-regio-sudost,S4,db-regio-ag-sudost,4-800486-4,#109644,#ffffff,,pill,
-db-regio-sudost,S5,db-regio-ag-sudost,4-800486-5,#ed7c1c,#ffffff,,pill,
-db-regio-sudost,S5X,db-regio-ag-sudost,4-800486-5x,#fdce5c,#ffffff,,pill,
-db-regio-sudost,S6,db-regio-ag-sudost,4-800486-6,#5c1239,#ffffff,,pill,
-db-regio-sudost,S8,db-regio-ag-sudost,4-8004a9-8,#5c2582,#ffffff,,pill,
-db-regio-sudost,S9,db-regio-ag-sudost,4-8004a9-9,#be006b,#ffffff,,pill,
-db-regio-sudost,S10,db-regio-ag-sudost,4-800486-10,#ffffff,#000000,#f5de2b,pill,
-db-regio-sudost,S47,db-regio-ag-sudost,4-8004a9-47,#53af4c,#ffffff,,pill,
-db-regionetz-sudostbayernbahn,RE 4,db-regionetz-verkehrs-gmbh-sudostbayernbahn,re-4,#ffffff,#992e00,#992e00,rectangle,
-db-regionetz-sudostbayernbahn,RB 32,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-32,#e5a05c,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 40,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-40,#e5a05c,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 41,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-41,#bf73bf,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 42,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-42,#00ace5,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 44,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-44,#90bf26,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 45,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-45,#6cc3d9,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 46,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-46,#24b27d,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 47,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-47,#ffb200,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 48,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-48,#bf73bf,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 49,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-49,#ffb200,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 52,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-52,#bf73bf,#ffffff,,rectangle,
-db-regionetz-sudostbayernbahn,RB 59,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-59,#e5a05c,#ffffff,,rectangle,
-db-regionetz-westfrankenbahn,RB 56,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-56,#fab23c,#ffffff,,rectangle,
-db-regionetz-westfrankenbahn,RB 83,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-83,#fdd245,#000000,,rectangle,
-db-regionetz-westfrankenbahn,RB 84,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-84,#e29c57,#ffffff,,rectangle,
-db-regionetz-westfrankenbahn,RB 88,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-88,#47359c,#ffffff,,rectangle,
-db-regionetz-westfrankenbahn,RE 80,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-80,#423f41,#ffffff,,rectangle,
-db-regionetz-westfrankenbahn,RE 87,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-87,#ff2e17,#ffffff,,rectangle,
-ding-swu,1,,8-ald087-1,#e52329,#ffffff,,rectangle,
-ding-swu,2,,8-ald087-2,#3fad56,#ffffff,,rectangle,
-dsb-s-tog,A,dsb-s-tog,4-860022-a,#00a8e7,#ffffff,,rectangle-rounded-corner,Q2323144
-dsb-s-tog,B,dsb-s-tog,4-860022-b,#52ae32,#ffffff,,rectangle-rounded-corner,Q1903862
-dsb-s-tog,Bx,dsb-s-tog,4-860022-bx,#adce6d,#ffffff,,rectangle-rounded-corner,Q2127863
-dsb-s-tog,C,dsb-s-tog,4-860022-c,#f39200,#ffffff,,rectangle-rounded-corner,Q4452746
-dsb-s-tog,E,dsb-s-tog,4-860022-e,#7c6eb0,#ffffff,,rectangle-rounded-corner,Q4624816
-dsb-s-tog,F,dsb-s-tog,4-860022-f,#fdc300,#ffffff,,rectangle-rounded-corner,Q2133631
-dsb-s-tog,H,dsb-s-tog,4-860022-h,#e74011,#ffffff,,rectangle-rounded-corner,Q1891933
-dvg-dessau,1,,8-nasdvg-1,#f59c00,#ffffff,,rectangle,
-dvg-dessau,3,,8-nasdvg-3,#f59c00,#ffffff,,rectangle,
-dvg-dessau,10,,5-nas001-10,#2e76bb,#ffffff,,pill,
-dvg-dessau,11,,5-nas001-11,#95d2f1,#ffffff,,pill,
-dvg-dessau,12,,5-nas001-12,#529bb9,#ffffff,,pill,
-dvg-dessau,13,,5-nas001-13,#9ec753,#ffffff,,pill,
-dvg-dessau,14,,5-nas001-14,#e3000b,#ffffff,,pill,
-dvg-dessau,15,,5-nas001-15,#a80126,#ffffff,,pill,
-dvg-dessau,16,,5-nas001-16,#941680,#ffffff,,pill,
-dvg-dessau,17,,5-nas001-16,#ffcc00,#ffffff,,pill,
-dvg-dessau,21,,5-nas001-16,#ee722e,#ffffff,,pill,
-dvg-dessau,22,,5-nas001-16,#0f3f93,#ffffff,,pill,
-dvg-dessau,N1,,5-nas001-n1,#000000,#ffffff,,pill,
-dvg-dessau,N2,,5-nas001-n2,#000000,#ffffff,,pill,
-dvg-dessau,N3,,5-nas001-n3,#000000,#ffffff,,pill,
-dvg-dessau,Rufbus N4,,9-nas001-n4,#000000,#ffffff,,pill,
-dvg-dessau,N5,,5-nas001-n5,#000000,#ffffff,,pill,
-dvg-dessau,N6,,5-nas001-n6,#000000,#ffffff,,pill,
-dwe-dessau,DWE,dessau-worlitzer-eisenbahn,dwe,#ffffff,#000000,#000000,rectangle,
-erfurter-bahn,RB 13,erfurter-bahn-gmbh,rb-13,#24b27d,#ffffff,,rectangle,
-erfurter-bahn,RB 40,erfurter-bahn-gmbh,rb-40,#24b27d,#ffffff,,rectangle,
-erfurter-bahn,RB 50,erfurter-bahn-gmbh,rb-50,#24b27d,#ffffff,,rectangle,
-hans,RB16,hanseatische-eisenbahn-gmbh,rb-16,#775fb0,#ffffff,,rectangle,
-hans,RB33,hanseatische-eisenbahn-gmbh,rb-33,#ed1c24,#ffffff,,rectangle,
-hans,RB34,hanseatische-eisenbahn-gmbh,rb-34,#0066ad,#ffffff,,rectangle,
-hans,RB73,hanseatische-eisenbahn-gmbh,rb-73,#009686,#ffffff,,rectangle,
-hans,RB74,hanseatische-eisenbahn-gmbh,rb-74,#0066ad,#ffffff,,rectangle,
-hans,RE27,hanseatische-eisenbahn-gmbh,re27,#399fdf,#ffffff,,rectangle,
-hlb,RB21,hlb-hessenbahn-gmbh,hlb-rb21,#007ec5,#ffffff,,rectangle-rounded-corner,
-hlb,RB29,hlb-hessenbahn-gmbh,hlb-rb29,#c77db4,#ffffff,,rectangle-rounded-corner,
-hlb,RB37,hlb-hessenbahn-gmbh,hlb-rb37,#970c7e,#ffffff,,rectangle-rounded-corner,
-hlb,RB40,hlb-hessenbahn-gmbh,hlb-rb40,#970c7e,#ffffff,,rectangle-rounded-corner,
-hlb,RB41,hlb-hessenbahn-gmbh,hlb-rb41,#970c7e,#ffffff,,rectangle-rounded-corner,
-hlb,RB45,hlb-hessenbahn-gmbh,hlb-rb45,#007ec5,#ffffff,,rectangle-rounded-corner,Q125770469
-hlb,RB46,hlb-hessenbahn-gmbh,hlb-rb46,#94522e,#ffffff,,rectangle-rounded-corner,
-hlb,RB47,hlb-hessenbahn-gmbh,hlb-rb47,#cf7db2,#ffffff,,rectangle-rounded-corner,
-hlb,RB48,hlb-hessenbahn-gmbh,hlb-rb48,#e3a02e,#ffffff,,rectangle-rounded-corner,
-hlb,RB49,hlb-hessenbahn-gmbh,hlb-rb49,#2175bb,#ffffff,,rectangle-rounded-corner,
-hlb,RB52,hlb-hessenbahn-gmbh,hlb-rb52,#e3a02e,#ffffff,,rectangle-rounded-corner,
-hlb,RB58,hlb-hessenbahn-gmbh,hlb-rb58,#970c7e,#ffffff,,rectangle-rounded-corner,
-hlb,RB61,hlb-hessenbahn-gmbh,hlb-rb61,#2175bb,#ffffff,,rectangle-rounded-corner,
-hlb,RB75,hlb-hessenbahn-gmbh,hlb-rb75,#2175bb,#ffffff,,rectangle-rounded-corner,
-hlb,RB90,hlb-hessenbahn-gmbh,hlb-rb90,#90268f,#ffffff,,rectangle-rounded-corner,
-hlb,RE9,hlb-hessenbahn-gmbh,hlb-re9,#e3a02e,#ffffff,,rectangle-rounded-corner,
-hlb,RE59,hlb-hessenbahn-gmbh,hlb-re59,#970c7e,#ffffff,,rectangle-rounded-corner,
-hlb,RE24,hlb-hessenbahn-gmbh,hlb-re24,#007ec5,#ffffff,,rectangle-rounded-corner,
-hlb,RE98,hlb-hessenbahn-gmbh,hlb-re98,#e3a02e,#ffffff,,rectangle-rounded-corner,
-hlb,RE99,hlb-hessenbahn-gmbh,hlb-re99,#e3a02e,#ffffff,,rectangle-rounded-corner,
-hvv-akn,A 1,akn-eisenbahn-gmbh,akn-a1,#f7931d,#ffffff,,pill,
-hvv-akn,A 2,akn-eisenbahn-gmbh,akn-a2,#f7931d,#ffffff,,pill,
-hvv-akn,A 3,akn-eisenbahn-gmbh,akn-a3,#f7931d,#ffffff,,pill,
-hvv-db-sbhh,S 1,s-bahn-hamburg,4-0s-1,#4da553,#ffffff,,pill,
-hvv-db-sbhh,S 2,s-bahn-hamburg,4-0s-2,#95334a,#ffffff,,pill,
-hvv-db-sbhh,S 3,s-bahn-hamburg,4-0s-3,#512c75,#ffffff,,pill,
-hvv-db-sbhh,S 5,s-bahn-hamburg,4-0s-5,#3b87a9,#ffffff,,pill,
-hvv-had,61,,6-hvvhad-61,#009bb6,#ffffff,,trapezoid,
-hvv-had,62,,6-hvvhad-62,#009bb6,#ffffff,,trapezoid,
-hvv-had,64,,6-hvvhad-64,#009bb6,#ffffff,,trapezoid,
-hvv-had,72,,6-hvvhad-72,#009bb6,#ffffff,,trapezoid,
-hvv-had,73,,6-hvvhad-73,#009bb6,#ffffff,,trapezoid,
-hvv-had,75,,6-hvvhad-75,#009bb6,#ffffff,,trapezoid,
-hvv-hha,U 1,,7-hvv001-1,#0072bc,#ffffff,,rectangle,
-hvv-hha,U 2,,7-hvv001-2,#ee1d23,#ffffff,,rectangle,
-hvv-hha,U 3,,7-hvv001-3,#ffdc01,#ffffff,,rectangle,
-hvv-hha,U 4,,7-hvv001-4,#00aaad,#ffffff,,rectangle,
-hvv-hha,5,,5-hvvhha-5,#eb4630,#ffffff,,hexagon,
-hvv-hha,6,,5-hvvhha-6,#18257b,#ffffff,,hexagon,
-hvv-hha,8,,5-hvvhha-8,#c49569,#ffffff,,hexagon,
-hvv-hha,9,,5-hvvhha-9,#5fb358,#ffffff,,hexagon,
-hvv-hha,10,,5-hvvhha-10,#ed753a,#ffffff,,hexagon,
-hvv-hha,11,,5-hvvhha-11,#903634,#ffffff,,hexagon,
-hvv-hha,13,,5-hvvhha-13,#712f91,#ffffff,,hexagon,
-hvv-hha,14,,5-hvvhha-14,#dc424d,#ffffff,,hexagon,
-hvv-hha,16,,5-hvvhha-16,#571445,#ffffff,,hexagon,
-hvv-hha,17,,5-hvvhha-17,#62685f,#ffffff,,hexagon,
-hvv-hha,18,,5-hvvhha-18,#6b80be,#ffffff,,hexagon,
-hvv-hha,19,,5-hvvhha-19,#f4ba4f,#ffffff,,hexagon,
-hvv-hha,20,,5-hvvhha-20,#519bd2,#ffffff,,hexagon,
-hvv-hha,23,,5-hvvhha-23,#e74796,#ffffff,,hexagon,
-hvv-hha,24,,5-hvvhha-24,#f8d258,#ffffff,,hexagon,
-hvv-hha,25,,5-hvvhha-25,#0c653c,#ffffff,,hexagon,
-hvv-hha,26,,5-hvvhha-26,#bcd25d,#ffffff,,hexagon,
-hvv-hha,27,,5-hvvhha-27,#11adde,#ffffff,,hexagon,
-hvv-hha,28,,5-hvvhha-28,#7e9bb4,#ffffff,,hexagon,
-hvv-hha,603,,5-hvvhha-603,#000000,#ffffff,,hexagon,
-hvv-hha,604,,5-hvvhha-604,#000000,#ffffff,,hexagon,
-hvv-hha,605,,5-hvvhha-605,#000000,#ffffff,,hexagon,
-hvv-hha,606,,5-hvvhha-606,#000000,#ffffff,,hexagon,
-hvv-hha,607,,5-hvvhha-607,#000000,#ffffff,,hexagon,
-hvv-hha,608,,5-hvvhha-608,#000000,#ffffff,,hexagon,
-hvv-hha,617,,5-hvvhha-617,#000000,#ffffff,,hexagon,
-hvv-hha,618,,5-hvvhha-618,#000000,#ffffff,,hexagon,
-hvv-hha,640,,5-hvvhha-640,#000000,#ffffff,,hexagon,
-hvv-hha,641,,5-hvvhha-641,#000000,#ffffff,,hexagon,
-hvv-hha,X11,,5-hvvhha-x11,#5fb358,#ffffff,,hexagon,
-hvv-hha,X22,,5-hvvhha-x22,#5fb358,#ffffff,,hexagon,
-hvv-hha,X35,,5-hvvhha-x35,#eb452e,#ffffff,,hexagon,
-hvv-hha,X40,,5-hvvhha-x40,#73c4a2,#ffffff,,hexagon,
-hvv-hha,X61,,5-hvvhha-x61,#ed7339,#ffffff,,hexagon,
-hvv-hha,X65,,5-hvvhha-x65,#52b4dc,#ffffff,,hexagon,
-hvv-hha,X86,,5-hvvhha-x65,#ebc353,#ffffff,,hexagon,
-hvv-kvi,X66,,5-hvvkvi-x66,#6780bf,#ffffff,,hexagon,
-hvv-kvi,X89,,5-hvvkvi-x89,#8cc359,#ffffff,,hexagon,
-hvv-kvi,X99,,5-hvvkvi-x99,#bc3c95,#ffffff,,hexagon,
-hvv-vhh,1,,5-hvvvhh-1,#bcd25d,#ffffff,,hexagon,
-hvv-vhh,2,,5-hvvvhh-2,#f4b94f,#ffffff,,hexagon,
-hvv-vhh,3,,5-hvvvhh-3,#bc3d95,#ffffff,,hexagon,
-hvv-vhh,12,,5-hvvvhh-12,#522a90,#ffffff,,hexagon,
-hvv-vhh,15,,5-hvvvhh-15,#4bbf9d,#ffffff,,hexagon,
-hvv-vhh,21,,5-hvvvhh-21,#234ea3,#ffffff,,hexagon,
-hvv-vhh,22,,5-hvvvhh-22,#712f91,#ffffff,,hexagon,
-hvv-vhh,29,,5-hvvvhh-29,#522a90,#ffffff,,hexagon,
-hvv-vhh,601,,5-hvvvhh-601,#000000,#ffffff,,hexagon,
-hvv-vhh,602,,5-hvvvhh-602,#000000,#ffffff,,hexagon,
-hvv-vhh,609,,5-hvvvhh-609,#000000,#ffffff,,hexagon,
-hvv-vhh,610,,5-hvvvhh-610,#000000,#ffffff,,hexagon,
-hvv-vhh,619,,5-hvvvhh-619,#000000,#ffffff,,hexagon,
-hvv-vhh,621,,5-hvvvhh-621,#000000,#ffffff,,hexagon,
-hvv-vhh,627,,5-hvvvhh-627,#000000,#ffffff,,hexagon,
-hvv-vhh,629,,5-hvvvhh-629,#000000,#ffffff,,hexagon,
-hvv-vhh,638,,5-hvvvhh-638,#000000,#ffffff,,hexagon,
-hvv-vhh,639,,5-hvvvhh-639,#000000,#ffffff,,hexagon,
-hvv-vhh,649,,5-hvvvhh-649,#000000,#ffffff,,hexagon,
-hvv-vhh,658,,5-hvvvhh-658,#000000,#ffffff,,hexagon,
-hvv-vhh,668,,5-hvvvhh-668,#000000,#ffffff,,hexagon,
-hvv-vhh,669,,5-hvvvhh-669,#000000,#ffffff,,hexagon,
-hvv-vhh,X3,,5-hvvvhh-x3,#722f91,#ffffff,,hexagon,
-hvv-vhh,X30,,5-hvvvhh-x30,#8e332a,#ffffff,,hexagon,
-hvv-vhh,X32,,5-hvvvhh-x32,#bf9466,#ffffff,,hexagon,
-hvv-vhh,X33,,5-hvvvhh-x32,#1c448f,#ffffff,,hexagon,
-hvv-vhh,X80,,5-hvvvhh-x80,#ebc353,#ffffff,,hexagon,
-hvv-vhh,X81,,5-hvvvhh-x81,#30653c,#ffffff,,hexagon,
-hvv-vhh,X95,,5-hvvvhh-x95,#c06936,#ffffff,,hexagon,
-kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S6,albtal-verkehrs-gesellschaft-mbh,4-a6s6-6,#282268,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,,rectangle-rounded-corner,
-kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S11,albtal-verkehrs-gesellschaft-mbh,4-a6s11-11,#00a76d,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S12,albtal-verkehrs-gesellschaft-mbh,4-a6s12-12,#00a76d,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S31,albtal-verkehrs-gesellschaft-mbh,4-a6s31-31,#00a99d,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S32,albtal-verkehrs-gesellschaft-mbh,4-a6s32-32,#00a99d,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S41,albtal-verkehrs-gesellschaft-mbh,4-a6s41-41,#bed730,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S42,albtal-verkehrs-gesellschaft-mbh,4-a6s42-42,#0097bb,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S51,albtal-verkehrs-gesellschaft-mbh,4-a6s51-51,#f69795,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S52,albtal-verkehrs-gesellschaft-mbh,4-a6s52-52,#f69795,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S71,albtal-verkehrs-gesellschaft-mbh,4-a6s71-71,#fff200,#000000,,rectangle-rounded-corner,
-kvv-avg,S81,albtal-verkehrs-gesellschaft-mbh,4-a6s81-81,#6e692a,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S FEX,albtal-verkehrs-gesellschaft-mbh,4-a6s1-fex,#00a76d,#ffffff,,rectangle-rounded-corner,
-kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#ffffff,#000000,,rectangle-rounded-corner,
-kvv-regionalbus,X34,,5-kvv015-x34,#d71920,#ffffff,,pill,
-kvv-regionalbus,X44,,5-kvv002-x44,#007239,#ffffff,,pill,
-kvv-regionalbus,X45,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-x45,#00aaad,#ffffff,,pill,
-kvv-regionalbus,X63,regionalverkehr-alb-bodensee,5-rabrab-x63,#00aaad,#ffffff,,pill,
-kvv-regionalbus,107,,5-kvv006-107,#006ba2,#ffffff,,pill,
-kvv-regionalbus,125,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-125,#a87b50,#ffffff,,pill,
-kvv-regionalbus,158,,5-kvv025-158,#f5821f,#ffffff,,pill,
-kvv-regionalbus,222,,5-kvv030-222,#c3529e,#ffffff,,pill,
-kvv-vbk,E,,8-kvv021-e,#ffffff,#000000,,rectangle,
-kvv-vbk,NL1,,8-kvv021-nl1,#ed1c24,#ffffff,,rectangle,
-kvv-vbk,NL2,,8-kvv021-nl2,#0071bc,#ffffff,,rectangle,
-kvv-vbk,NL3,,5-kvv003-nl3,#806a50,#ffffff,,pill,
-kvv-vbk,NL11,,9-kvv004-nl11,#00aeef,#ffffff,,rectangle,
-kvv-vbk,NL12,,9-kvv004-nl12,#2e3092,#ffffff,,rectangle,
-kvv-vbk,NL13,,9-kvv004-nl13,#9b95c9,#ffffff,,rectangle,
-kvv-vbk,NL14,,9-kvv004-nl14,#a25641,#ffffff,,rectangle,
-kvv-vbk,NL15,,9-kvv004-nl15,#80c342,#ffffff,,rectangle,
-kvv-vbk,NL16,,9-kvv004-nl16,#177752,#ffffff,,rectangle,
-kvv-vbk,NL17,,9-kvv004-nl17,#574187,#ffffff,,rectangle,
-kvv-vbk,S2,,4-kvv021-2,#a066aa,#ffffff,,rectangle-rounded-corner,
-kvv-vbk,1,,8-kvv021-1,#ed1c24,#ffffff,,rectangle,
-kvv-vbk,2,,8-kvv021-2,#0071bc,#ffffff,,rectangle,
-kvv-vbk,3,,8-kvv021-3,#947139,#ffffff,,rectangle,
-kvv-vbk,4,,8-kvv021-4,#ffcb04,#000000,,rectangle,
-kvv-vbk,5,,8-kvv021-5,#00c0f3,#ffffff,,rectangle,
-kvv-vbk,6,,8-kvv021-6,#85bc22,#ffffff,,rectangle,
-kvv-vbk,8,,8-kvv021-8,#f7931d,#000000,,rectangle,
-kvv-vbk,9,,8-kvv021-9,#b3a5a1,#ffffff,,rectangle,
-kvv-vbk,10,,8-kvv021-10,#a4d7bb,#000000,,rectangle,
-kvv-vbk,16,,8-kvv021-16,#db2475,#ffffff,,rectangle,
-kvv-vbk,17,,8-kvv021-17,#660000,#ffffff,,rectangle,
-kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,,rectangle,
-kvv-vbk,21,,5-kvv024-21,#177752,#ffffff,,pill,
-kvv-vbk,22,,5-kvv024-22,#62bb46,#ffffff,,pill,
-kvv-vbk,23,,5-kvv024-23,#adbc72,#ffffff,,pill,
-kvv-vbk,24,,5-kvv024-24,#004a21,#ffffff,,pill,
-kvv-vbk,26,,5-kvv024-26,#d7df23,#ffffff,,pill,
-kvv-vbk,27,,5-kvv024-27,#00a851,#ffffff,,pill,
-kvv-vbk,29,,5-kvv024-29,#90ab98,#ffffff,,pill,
-kvv-vbk,30,,5-kvv024-30,#00aeef,#ffffff,,pill,
-kvv-vbk,31,,5-kvv024-31,#a1d1e6,#ffffff,,pill,
-kvv-vbk,32,,5-kvv024-32,#485e88,#ffffff,,pill,
-kvv-vbk,42,,5-kvv024-42,#485e88,#ffffff,,pill,
-kvv-vbk,44,,5-kvv024-44,#a1d1e6,#ffffff,,pill,
-kvv-vbk,47,,5-kvv024-47,#00aeef,#ffffff,,pill,
-kvv-vbk,50,,5-kvv024-50,#874487,#ffffff,,pill,
-kvv-vbk,51,,5-kvv024-51,#b592b9,#ffffff,,pill,
-kvv-vbk,52,,5-kvv024-52,#874487,#ffffff,,pill,
-kvv-vbk,55,,5-kvv024-55,#574187,#ffffff,,pill,
-kvv-vbk,60,,5-kvv024-60,#574187,#ffffff,,pill,
-kvv-vbk,62,,5-kvv024-62,#9b95c9,#ffffff,,pill,
-kvv-vbk,70,,5-kvv024-70,#806a50,#ffffff,,pill,
-kvv-vbk,71,,5-kvv024-71,#b2a291,#ffffff,,pill,
-kvv-vbk,72,,5-kvv024-72,#d2ab67,#ffffff,,pill,
-kvv-vbk,73,,5-kvv024-73,#806a50,#ffffff,,pill,
-kvv-vbk,74,,5-kvv024-74,#d2ab67,#ffffff,,pill,
-kvv-vbk,75,,5-kvv024-75,#a25641,#ffffff,,pill,
-kvv-vbk,83,,5-kvv024-83,#808285,#ffffff,,pill,
-lavv-swl,1,,5-swlbus-1,#85bc22,#ffffff,,rectangle,
-lavv-swl,2,,5-swlbus-2,#fbba00,#000000,,rectangle,
-lavv-swl,3,,5-swlbus-3,#de007d,#ffffff,,rectangle,
-lavv-swl,4,,5-swlbus-4,#009ee3,#ffffff,,rectangle,
-lavv-swl,5,,5-swlbus-5,#007757,#ffffff,,rectangle,
-lavv-swl,6,,5-swlbus-6,#0070ba,#ffffff,,rectangle,
-lavv-swl,7,,5-swlbus-7,#00b2bb,#ffffff,,rectangle,
-lavv-swl,8,,5-swlbus-8,#ffed00,#000000,,rectangle,
-lavv-swl,9,,5-swlbus-9,#0b9a33,#ffffff,,rectangle,
-lavv-swl,10,,5-swlbus-10,#9d1680,#ffffff,,rectangle,
-lavv-swl,11,,5-swlbus-11,#e3000f,#ffffff,,rectangle,
-lavv-swl,12,,5-swlbus-12,#58348b,#ffffff,,rectangle,
-lavv-swl,14,,5-swlbus-14,#ee7100,#ffffff,,rectangle,
-lavv-swl,101,,5-swlbus-101,#85bc22,#ffffff,,rectangle,
-lavv-swl,102,,5-swlbus-102,#fbba00,#000000,,rectangle,
-lavv-swl,103,,5-swlbus-103,#de007d,#ffffff,,rectangle,
-lavv-swl,104,,5-swlbus-104,#009ee3,#ffffff,,rectangle,
-lavv-swl,105,,5-swlbus-105,#007757,#ffffff,,rectangle,
-lavv-swl,106,,5-swlbus-106,#0070ba,#ffffff,,rectangle,
-lavv-swl,107,,5-swlbus-107,#00b2bb,#ffffff,,rectangle,
-lavv-swl,108,,5-swlbus-108,#ffed00,#000000,,rectangle,
-lavv-swl,109,,5-swlbus-109,#0b9a33,#ffffff,,rectangle,
-lavv-swl,110,,5-swlbus-110,#9d1680,#ffffff,,rectangle,
-liege-s,S41,sncb,4-88-41,#0f6030,#ffffff,#ffffff,circle,
-mdv-lvb,1,,8-naslvt-1,#78b145,#ffffff,,rectangle,
-mdv-lvb,2,,8-naslvt-2,#f7ce46,#000000,,rectangle,
-mdv-lvb,3,,8-naslvt-3,#78b145,#ffffff,,rectangle,
-mdv-lvb,3E,,8-naslvt-3e,#78b145,#ffffff,,rectangle,
-mdv-lvb,4,,8-naslvt-4,#27398a,#ffffff,,rectangle,
-mdv-lvb,7,,8-naslvt-7,#27398a,#ffffff,,rectangle,
-mdv-lvb,8,,8-naslvt-8,#f7ce46,#000000,,rectangle,
-mdv-lvb,10,,8-naslvt-10,#d02e26,#ffffff,,rectangle,
-mdv-lvb,11,,8-naslvt-11,#d02e26,#ffffff,,rectangle,
-mdv-lvb,12,,8-naslvt-12,#27398a,#ffffff,,rectangle,
-mdv-lvb,15,,8-naslvt-15,#27398a,#ffffff,,rectangle,
-mdv-lvb,16,,8-naslvt-16,#d02e26,#ffffff,,rectangle,
-mdv-swh-havag,1,,8-nashat-1,#f4b84f,#ffffff,,rectangle,
-mdv-swh-havag,2,,8-nashat-2,#ee843e,#ffffff,,rectangle,
-mdv-swh-havag,3,,8-nashat-3,#469cd8,#ffffff,,rectangle,
-mdv-swh-havag,5,,8-nashat-5,#1d459f,#ffffff,,rectangle,
-mdv-swh-havag,7,,8-nashat-7,#ea67aa,#ffffff,,rectangle,
-mdv-swh-havag,8,,8-nashat-8,#7e471e,#ffffff,,rectangle,
-mdv-swh-havag,9,,8-nashat-9,#a7b150,#ffffff,,rectangle,
-mdv-swh-havag,10,,8-nashat-10,#3d682d,#ffffff,,rectangle,
-mdv-swh-havag,12,,8-nashat-12,#96c75a,#ffffff,,rectangle,
-mdv-swh-havag,16,,8-nashat-12,#a13671,#ffffff,,rectangle,
-metronom,RB31,metronom,me-rb31,#7f257b,#ffffff,,rectangle,
-metronom,RB41,metronom,me-rb41,#2eb273,#ffffff,,rectangle,
-metronom,RE2,metronom,me-re2,#b22236,#ffffff,,rectangle,
-metronom,RE3,metronom,me-re3,#7f257b,#ffffff,,rectangle,
-metronom,RE4,metronom,me-re4,#2eb273,#ffffff,,rectangle,
-mitteldeutsche-regiobahn,RE 3,mitteldeutsche-regiobahn,re-3,#0093d4,#ffffff,,rectangle-rounded-corner,
-mitteldeutsche-regiobahn,RE 6,mitteldeutsche-regiobahn,re-6,#9e60a4,#ffffff,,rectangle-rounded-corner,
-mitteldeutsche-regiobahn,RB 30,mitteldeutsche-regiobahn,rb-30,#ed9126,#ffffff,,rectangle-rounded-corner,
-mitteldeutsche-regiobahn,RB 45,mitteldeutsche-regiobahn,rb-45,#ed694a,#ffffff,,rectangle-rounded-corner,
-mitteldeutsche-regiobahn,RB 110,mitteldeutsche-regiobahn,rb-110,#a2cbba,#ffffff,,rectangle-rounded-corner,
-mvb-magdeburg,51,,5-nasmbb-51,#38529b,#ffffff,,pill,
-mvb-magdeburg,52,,5-nasmbb-52,#e8a038,#ffffff,,pill,
-mvb-magdeburg,53,,5-nasmbb-53,#f7ce46,#000000,,pill,
-mvb-magdeburg,54,,5-nasmbb-54,#86b645,#ffffff,,pill,
-mvb-magdeburg,56,,5-nasmbb-56,#d5bf3f,#ffffff,,pill,
-mvb-magdeburg,57,,5-nasmbb-57,#cc2b7c,#ffffff,,pill,
-mvb-magdeburg,58,,5-nasmbb-58,#44989b,#ffffff,,pill,
-mvb-magdeburg,59,,5-nasmbb-59,#2b6552,#ffffff,,pill,
-mvb-magdeburg,61,,5-nasmbb-61,#3880b9,#ffffff,,pill,
-mvb-magdeburg,66,,5-nasmbb-66,#a33f1d,#ffffff,,pill,
-mvb-magdeburg,69,,5-nasmbb-69,#43287e,#ffffff,,pill,
-mvb-magdeburg,71,,5-nasmbb-71,#c32e37,#ffffff,,pill,
-mvb-magdeburg,72,,5-nasmbb-72,#38529b,#ffffff,,pill,
-mvb-magdeburg,73,,5-nasmbb-73,#383a33,#ffffff,,pill,
-mvb-magdeburg,1,,8-nasmbt-1,#b72c5d,#ffffff,,rectangle,
-mvb-magdeburg,2,,8-nasmbt-2,#38529b,#ffffff,,rectangle,
-mvb-magdeburg,3,,8-nasmbt-3,#f7ce46,#000000,,rectangle,
-mvb-magdeburg,4,,8-nasmbt-4,#86b645,#ffffff,,rectangle,
-mvb-magdeburg,5,,8-nasmbt-5,#ae6f25,#ffffff,,rectangle,
-mvb-magdeburg,6,,8-nasmbt-6,#43287e,#ffffff,,rectangle,
-mvb-magdeburg,9,,8-nasmbt-9,#2b6552,#ffffff,,rectangle,
-mvb-magdeburg,10,,8-nasmbt-10,#3880b9,#ffffff,,rectangle,
-mvv-db-sbm,S1,db-regio-ag-s-bahn-munchen,4-800725-1,#1fbce6,#ffffff,,pill,
-mvv-db-sbm,S2,db-regio-ag-s-bahn-munchen,4-800725-2,#79b833,#ffffff,,pill,
-mvv-db-sbm,S3,db-regio-ag-s-bahn-munchen,4-800725-3,#962a85,#ffffff,,pill,
-mvv-db-sbm,S4,db-regio-ag-s-bahn-munchen,4-800725-4,#e41f28,#ffffff,,pill,
-mvv-db-sbm,S5,db-regio-ag-s-bahn-munchen,4-800725-5,#00527f,#ffffff,,pill,
-mvv-db-sbm,S6,db-regio-ag-s-bahn-munchen,4-800725-6,#008f5c,#ffffff,,pill,
-mvv-db-sbm,S7,db-regio-ag-s-bahn-munchen,4-800725-7,#8a372f,#ffffff,,pill,
-mvv-db-sbm,S8,db-regio-ag-s-bahn-munchen,4-800725-8,#2d2b29,#ffcd01,,pill,
-mvv-db-sbm,S20,db-regio-ag-s-bahn-munchen,4-800725-20,#f05972,#ffffff,,pill,
-mvv-mvg-tram,12,,8-swm002-12,#903f97,#ffffff,,rectangle,
-mvv-mvg-tram,16,,8-swm002-16,#006cb3,#ffffff,,rectangle,
-mvv-mvg-tram,17,,8-swm002-17,#875a46,#ffffff,,rectangle,
-mvv-mvg-tram,18,,8-swm002-18,#20b14a,#ffffff,,rectangle,
-mvv-mvg-tram,19,,8-swm002-19,#ee1c25,#ffffff,,rectangle,
-mvv-mvg-tram,20,,8-swm002-20,#16c0e9,#ffffff,,rectangle,
-mvv-mvg-tram,21,,8-swm002-21,#16c0e9,#ffffff,,rectangle,
-mvv-mvg-tram,23,,8-swm002-23,#b3d235,#ffffff,,rectangle,
-mvv-mvg-tram,25,,8-swm002-25,#f48f99,#ffffff,,rectangle,
-mvv-mvg-tram,27,,8-swm002-27,#fba61c,#ffffff,,rectangle,
-mvv-mvg-tram,28,,8-swm002-28,#ffffff,#fba822,#fba822,rectangle,
-mvv-mvg-tram,29,,8-swm002-29,#ffffff,#ec1622,#ec1622,rectangle,
-mvv-mvg-tram,E7,,8-swm002-e7,#ffffff,#000000,#ffffff,rectangle,
-mvv-mvg-ubahn,U1,,7-swm001-1,#52822f,#ffffff,,rectangle,
-mvv-mvg-ubahn,U2,,7-swm001-2,#c20831,#ffffff,,rectangle,
-mvv-mvg-ubahn,U3,,7-swm001-3,#ec6725,#ffffff,,rectangle,
-mvv-mvg-ubahn,U4,,7-swm001-4,#00a984,#ffffff,,rectangle,
-mvv-mvg-ubahn,U5,,7-swm001-5,#bc7a00,#ffffff,,rectangle,
-mvv-mvg-ubahn,U6,,7-swm001-6,#0065ae,#ffffff,,rectangle,
-mvv-regional-bus,501,,5-mvvrbu-501,#1b2645,#ffffff,,rectangle,
-mvv-regional-bus,511,,5-mvvrbu-511,#979032,#ffffff,,rectangle,
-mvv-regional-bus,601,,5-mvvrbu-601,#702e1a,#ffffff,,rectangle,
-mvv-regional-bus,602,,5-mvvrbu-602,#839dbb,#ffffff,,rectangle,
-mvv-regional-bus,603,,5-mvvrbu-603,#2f3858,#ffffff,,rectangle,
-mvv-regional-bus,614,,5-mvvrbu-614,#c0a339,#ffffff,,rectangle,
-mvv-regional-bus,615,,5-mvvrbu-615,#274469,#ffffff,,rectangle,
-mvv-regional-bus,616,,5-mvvrbu-616,#717156,#ffffff,,rectangle,
-mvv-regional-bus,617,,5-mvvrbu-617,#49719a,#ffffff,,rectangle,
-mvv-regional-bus,618,,5-mvvrbu-618,#49719a,#ffffff,,rectangle,
-mvv-regional-bus,619,,5-mvvrbu-619,#4c7ec8,#ffffff,,rectangle,
-mvv-regional-bus,635,,5-mvvrbu-635,#662a1c,#ffffff,,rectangle,
-mvv-regional-bus,680,,5-mvvrbu-680,#6c6775,#ffffff,,rectangle,
-mvv-regional-bus,681,,5-mvvrbu-681,#ab5479,#ffffff,,rectangle,
-mvv-regional-bus,682,,5-mvvrbu-682,#c29a44,#ffffff,,rectangle,
-mvv-regional-bus,683,,5-mvvrbu-683,#79312a,#ffffff,,rectangle,
-mvv-regional-bus,684,,5-mvvrbu-684,#377a5d,#ffffff,,rectangle,
-mvv-regional-bus,687,,5-mvvrbu-687,#6a6153,#ffffff,,rectangle,
-mvv-regional-bus,688,,5-mvvrbu-688,#b8ae36,#ffffff,,rectangle,
-mvv-regional-bus,691,,5-mvvrbu-691,#4d8240,#ffffff,,rectangle,
-mvv-regional-bus,851,,5-mvvrbu-851,#91431f,#ffffff,,rectangle,
-mvv-regional-bus,857,,5-mvvrbu-857,#5b66a9,#ffffff,,rectangle,
-mvv-regional-bus,858,,5-mvvrbu-858,#769851,#ffffff,,rectangle,
-mvv-regional-bus,859,,5-mvvrbu-859,#2f4b6b,#ffffff,,rectangle,
-mvv-regional-bus,X200,,5-mvvrbu-x200,#9b7839,#ffffff,,rectangle,
-mvv-regional-bus,X201,,5-mvvrbu-x201,#35794d,#ffffff,,rectangle,
-mvv-regional-bus,X202,,5-mvvrbu-x202,#883562,#ffffff,,rectangle,
-mvv-regional-bus,X203,,5-mvvrbu-x203,#4f7ab9,#ffffff,,rectangle,
-mvv-regional-bus,X204,,5-mvvrbu-x204,#897098,#ffffff,,rectangle,
-mvv-regional-bus,X205,,5-mvvrbu-x205,#3c5d5b,#ffffff,,rectangle,
-mvv-regional-bus,X206,,5-mvvrbu-x206,#545395,#ffffff,,rectangle,
-mvv-regional-bus,X320,,5-mvvrbu-x320,#56823d,#ffffff,,rectangle,
-mvv-regional-bus,X660,,5-mvvrbu-x660,#8e5c2e,#ffffff,,rectangle,
-mvv-regional-bus,X732,,5-mvvrbu-x732,#8a892c,#ffffff,,rectangle,
-mvv-regional-bus,X800,,5-mvvrbu-x800,#b57c3e,#ffffff,,rectangle,
-mvv-regional-bus,X850,,5-mvvrbu-x850,#7d662c,#ffffff,,rectangle,
-mvv-regional-bus,X900,,5-mvvrbu-x900,#455c95,#ffffff,,rectangle,
-mvv-regional-bus,X910,,5-mvvrbu-x910,#756543,#ffffff,,rectangle,
-mvv-regional-bus,X920,,5-mvvrbu-x920,#769754,#ffffff,,rectangle,
-mvv-regional-bus,X970,,5-mvvrbu-x970,#903939,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,716,,5-mvvrbu-716,#235798,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,717,,5-mvvrbu-717,#000080,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,718,,5-mvvrbu-718,#ffcc00,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,719,,5-mvvrbu-719,#00adef,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,720,,5-mvvrbu-720,#ef3120,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,722,,5-mvvrbu-722,#ef3120,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,726,,5-mvvrbu-726,#00a880,#ffffff,,rectangle,
-mvv-stadtwerke-dachau,744,,5-mvvrbu-744,#91c900,#ffffff,,rectangle,
-mvv-stadtwerke-freising,620,,5-mvvrbu-620,#ed1c24,#ffffff,,rectangle,
-mvv-stadtwerke-freising,621,,5-mvvrbu-621,#2e3092,#ffffff,,rectangle,
-mvv-stadtwerke-freising,622,,5-mvvrbu-622,#a6ce38,#ffffff,,rectangle,
-mvv-stadtwerke-freising,623,,5-mvvrbu-623,#738377,#ffffff,,rectangle,
-mvv-stadtwerke-freising,624,,5-mvvrbu-624,#ed1651,#ffffff,,rectangle,
-mvv-stadtwerke-freising,630,,5-mvvrbu-630,#ffcb03,#ffffff,,rectangle,
-mvv-stadtwerke-freising,631,,5-mvvrbu-631,#35734d,#ffffff,,rectangle,
-mvv-stadtwerke-freising,633,,5-mvvrbu-633,#f5821f,#ffffff,,rectangle,
-mvv-stadtwerke-freising,634,,5-mvvrbu-634,#a25642,#ffffff,,rectangle,
-mvv-stadtwerke-freising,637,,5-mvvrbu-637,#795e6e,#ffffff,,rectangle,
-mvv-stadtwerke-freising,638,,5-mvvrbu-638,#8dd8f8,#ffffff,,rectangle,
-mvv-stadtwerke-freising,639,,5-mvvrbu-639,#4072aa,#ffffff,,rectangle,
-mvv-stadtwerke-freising,640,,5-mvvrbu-640,#b3d334,#ffffff,,rectangle,
-mvv-stadtwerke-freising,641,,5-mvvrbu-641,#ffcc30,#ffffff,,rectangle,
-mvv-stadtwerke-freising,650,,5-mvvrbu-650,#17b35c,#ffffff,,rectangle,
-mvv-stadtwerke-freising,651,,5-mvvrbu-651,#008742,#ffffff,,rectangle,
-nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,,rectangle,
-nah-sh,RB 61,nordbahn,nbe-rb61,#174094,#ffffff,,rectangle,
-nah-sh,RB 62,db-regio-ag-nord,rb-62,#00aeca,#000000,,rectangle,
-nah-sh,RB 63,nordbahn,nbe-rb63,#ffdc00,#000000,,rectangle,
-nah-sh,RB 64,nordbahn,nbe-rb64,#ea899a,#000000,,rectangle,
-nah-sh,RB 65,norddeutsche-eisenbahn-gesellschaft,neg-rb65,#dedd00,#000000,,rectangle,
-nah-sh,RB 66,norddeutsche-eisenbahn-gesellschaft,neg-rb66,#798e0e,#ffffff,,rectangle,
-nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,,rectangle,
-nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,,rectangle,
-nah-sh,RB 71,nordbahn,nbe-rb71,#008bd2,#ffffff,,rectangle,
-nah-sh,RE 72,nordbahn,nbe-re72,#adce6d,#000000,,rectangle,
-nah-sh,RB 73,nordbahn,nbe-re73,#008c57,#ffffff,,rectangle,
-nah-sh,RE 74,nordbahn,nbe-re74,#693b58,#ffffff,,rectangle,
-nah-sh,RB 75,nordbahn,nbe-re75,#ba731a,#ffffff,,rectangle,
-nah-sh,RB 76,erixx,erx-rb76,#ffdc00,#000000,,rectangle,
-nah-sh,RE 8,db-regio-ag-nord,re-8,#a3d9f0,#000000,,rectangle,
-nah-sh,RE 80,db-regio-ag-nord,re-80,#d9338a,#ffffff,,rectangle,
-nah-sh,RB 81,db-regio-ag-nord,re-81,#798e0e,#ffffff,,rectangle,
-nah-sh,RB 82,nordbahn,nbe-rb82,#9c9c9c,#ffffff,,rectangle,
-nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,,rectangle,
-nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,,rectangle,
-nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,,rectangle,
-nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#a9b85d,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB12,neb-niederbarnimer-eisenbahn,rb-12,#a5027d,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB25,neb-niederbarnimer-eisenbahn,rb-25,#007cb0,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB26,neb-niederbarnimer-eisenbahn,rb-26,#009686,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB27,neb-niederbarnimer-eisenbahn,rb-27,#e2001a,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB35,neb-niederbarnimer-eisenbahn,rb-35,#816da6,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB36,neb-niederbarnimer-eisenbahn,rb-36,#ad5937,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB54,neb-niederbarnimer-eisenbahn,rb-54,#816da6,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB60,neb-niederbarnimer-eisenbahn,rb-60,#66aa22,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB61,neb-niederbarnimer-eisenbahn,rb-61,#992746,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB62,neb-niederbarnimer-eisenbahn,rb-62,#da6ba2,#ffffff,,rectangle,
-neb-niederbarnimer-eisenbahn,RB63,neb-niederbarnimer-eisenbahn,rb-63,#ffd502,#000000,,rectangle,
-neb-niederbarnimer-eisenbahn,TES,neb-niederbarnimer-eisenbahn,rb-tes,#d70000,#ffffff,,rectangle,
-nrw-regional,RE 1,national-express,re-1,#ff2d16,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 2,db-regio-ag-nrw,re-2,#00b8f1,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 3,eurobahn,re-3,#e46e25,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 4,national-express,re-4,#e88f24,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 5,national-express,re-5,#0182ba,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 6,national-express,re-6,#9e2a96,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 7,national-express,re-7,#052e69,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 8,db-regio-ag-nrw,re-8,#006bbb,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 9,db-regio-ag-nrw,re-9,#401446,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 10,rheinruhrbahn-transdev,rrb-re10,#e66caf,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 11,national-express,re-11,#5accc2,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 12,db-regio-ag-nrw,re-12,#ad294c,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 13,eurobahn,re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 14,rheinruhrbahn-transdev,rrb-re14,#003328,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 16,vias-rail-gmbh,via-re16,#0e5778,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 17,db-regio-ag-nrw,re-17,#489b40,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 18,db-arriva,re-18,#10b3b4,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 19,vias-rail-gmbh,via-re19,#2f652b,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 20,db-regio-ag-nrw,rb-20,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 21,rurtalbahn,rtb-rb21,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 22,db-regio-ag-nrw,re-22,#ffad3e,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 24,db-regio-ag-nrw,rb-24,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 25,db-regio-ag-nrw,rb-25,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 26,mittelrheinbahn-trans-regio,rb-26,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 27,db-regio-ag-nrw,rb-27,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 28,rurtalbahn,rtb-rb28,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 29,sncb,re-29,#d594c8,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 30,db-regio-ag-nrw,rb-30,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 31,rheinruhrbahn-transdev,rrb-rb31,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 32,db-regio-ag-nrw,rb-32,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 33,db-regio-ag-nrw,rb-33,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 34,db-fernverkehr-ag,re-34,#8c467d,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 34,db-regio-ag-nrw,re-34,#8c467d,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 34,hlb-hessenbahn-gmbh,hlb-re34,#8c467d,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 34,vias-rail-gmbh,via-rb34,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 35,vias-rail-gmbh,via-rb35,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 36,rheinruhrbahn-transdev,rrb-rb36,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 37,tri-train-rental-gmbh,tri-rb37,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 38,db-regio-ag-nrw,rb-38,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 39,vias-rail-gmbh,via-rb39,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 40,db-regio-ag-nrw,rb-40,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 41,db-regio-ag-nrw,re-41,#5844a4,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 42,db-regio-ag-nrw,re-42,#d9bf13,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 43,db-regio-ag-nrw,rb-43,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 44,rheinruhrbahn-transdev,rrb-re44,#6294b0,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 46,vias-rail-gmbh,via-rb46,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 47,regiobahn,r-re-47,#66cdec,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 48,national-express,rb-48,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 49,db-regio-ag-nrw,re-49,#c4836b,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 50,eurobahn,rb-50,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 51,db-regio-ag-nrw,rb-51,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 52,db-regio-ag-nrw,rb-52,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 53,db-regio-ag-nrw,rb-53,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 54,db-regio-ag-nrw,rb-54,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 57,db-regio-ag-nrw,re-57,#2e6da6,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 58,nordwestbahn,nwb-rb58,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 59,eurobahn,rb-59,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 61,eurobahn,rb-61,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 62,db-regio-ag-nord,re-62,#1f52a6,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 63,db-regio-ag-nrw,rb-63,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 64,db-regio-ag-nrw,rb-64,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 65,eurobahn,rb-65,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 66,eurobahn,rb-66,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 67,eurobahn,rb-67,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 69,eurobahn,rb-69,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 71,eurobahn,rb-71,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 72,eurobahn,rb-72,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 73,eurobahn,rb-73,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 74,nordwestbahn,nwb-rb74,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 75,nordwestbahn,nwb-rb75,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 77,regionalverkehre-start-deutschland-gmbh-start-niedersachsen-mitte,rb-77,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 78,eurobahn,re-78,#52b9ce,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 82,eurobahn,re-82,#489b40,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 84,nordwestbahn,nwb-rb84,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 85,nordwestbahn,nwb-rb85,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 89,eurobahn,rb-89,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 90,hlb-hessenbahn-gmbh,hlb-rb90,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 91,vias-rail-gmbh,via-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 91,hlb-hessenbahn-gmbh,hlb-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 92,hlb-hessenbahn-gmbh,hlb-rb92,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 93,hlb-hessenbahn-gmbh,hlb-rb93,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 94,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-94,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 95,hlb-hessenbahn-gmbh,hlb-rb95,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 96,hlb-hessenbahn-gmbh,hlb-rb96,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RB 97,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-97,#7a7c80,#ffffff,,rectangle-rounded-corner,
-nrw-regional,RE 99,hlb-hessenbahn-gmbh,hlb-re99,#28b34c,#ffffff,,rectangle-rounded-corner,
-nrw-sbahn,S 1,db-regio-ag-nrw,4-800337-1,#0cb14b,#ffffff,,pill,
-nrw-sbahn,S 2,db-regio-ag-nrw,4-8003l1-2,#0074bc,#ffffff,,pill,
-nrw-sbahn,S 3,db-regio-ag-nrw,4-8003l1-3,#fff200,#000000,,pill,
-nrw-sbahn,S 4,db-regio-ag-nrw,4-800337-4,#f5821f,#ffffff,,pill,
-nrw-sbahn,S 5,db-regio-ag-nrw,4-800354-5,#80c342,#ffffff,,pill,
-nrw-sbahn,S 6,db-regio-ag-nrw,4-8003s-6,#e21d3c,#ffffff,,pill,
-nrw-sbahn,S 7,rheinruhrbahn-transdev,4-tdrr-s7,#00afb5,#ffffff,,pill,
-nrw-sbahn,S 8,db-regio-ag-nrw,4-800354-8,#b23815,#ffffff,,pill,
-nrw-sbahn,S 9,db-regio-ag-nrw,4-8003l1-9,#c6168d,#ffffff,,pill,
-nrw-sbahn,S 11,db-regio-ag-nrw,4-8003s-11,#f26522,#ffffff,,pill,
-nrw-sbahn,S 12,db-regio-ag-nrw,4-8003s-12,#4db857,#ffffff,,pill,
-nrw-sbahn,S 19,db-regio-ag-nrw,4-8003s-19,#00658e,#ffffff,,pill,
-nrw-sbahn,S 23,db-regio-ag-nrw,4-800352-23,#8c2a77,#ffffff,,pill,
-nrw-sbahn,S 28,regiobahn,4-m2-28,#4a0b4d,#ffffff,,pill,
-nrw-sbahn,S 68,db-regio-ag-nrw,4-8003s-68,#00bfe8,#ffffff,,pill,
-nvs,1,,8-vwmstr-1,#e5007d,#ffffff,,rectangle,
-nvs,1,,5-vwmbus-1,#e5007d,#ffffff,,pill,
-nvs,2,,8-vwmstr-2,#e3000f,#ffffff,,rectangle,
-nvs,3,,8-vwmstr-3,#f08481,#ffffff,,rectangle,
-nvs,4,,8-vwmstr-4,#e5007d,#ffffff,,rectangle,
-nvs,5,,5-vwmbus-5,#ef7c00,#ffffff,,pill,
-nvs,6,,5-vwmbus-6,#6f5b6f,#ffffff,,pill,
-nvs,7,,5-vwmbus-7,#ffcc00,#ffffff,,pill,
-nvs,8,,5-vwmbus-8,#2f2483,#ffffff,,pill,
-nvs,9,,5-vwmbus-9,#847258,#ffffff,,pill,
-nvs,10,,5-vwmbus-10,#008bd2,#ffffff,,pill,
-nvs,11,,5-vwmbus-11,#52a6b2,#ffffff,,pill,
-nvs,12,,5-vwmbus-12,#d0a9d0,#ffffff,,pill,
-nvs,13,,5-vwmbus-13,#b1ac7e,#ffffff,,pill,
-nvs,14,,5-vwmbus-14,#a61380,#ffffff,,pill,
-nvs,16,,5-vwmbus-16,#a65a44,#ffffff,,pill,
-nvs,17,,5-vwmbus-17,#afca05,#ffffff,,pill,
-nvs,18,,5-vwmbus-18,#00963f,#ffffff,,pill,
-nvs,19,,5-vwmbus-19,#f7a940,#ffffff,,pill,
-oberpfalzbahn-dlb,RB 23,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb23,#6cc3d9,#ffffff,,rectangle,
-oberpfalzbahn-dlb,RB 27,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb27,#ffb200,#ffffff,,rectangle,
-oberpfalzbahn-dlb,RB 28,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb28,#90bf26,#ffffff,,rectangle,
-oberpfalzbahn-dlb,RB 29,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb29,#ff6600,#ffffff,,rectangle,
-odeg,RB13,ostdeutsche-eisenbahn-gmbh,rb-13,#3f4545,#ffffff,,rectangle,
-odeg,RB14,ostdeutsche-eisenbahn-gmbh,rb-14,#196e76,#ffffff,,rectangle,
-odeg,RB15,ostdeutsche-eisenbahn-gmbh,rb-15,#00a998,#ffffff,,rectangle,
-odeg,RB17,ostdeutsche-eisenbahn-gmbh,rb-17,#dd4daf,#ffffff,,rectangle,
-odeg,RB18,ostdeutsche-eisenbahn-gmbh,rb-18,#399fdf,#ffffff,,rectangle,
-odeg,RB19,ostdeutsche-eisenbahn-gmbh,rb-19,#f46717,#ffffff,,rectangle,
-odeg,RB33,ostdeutsche-eisenbahn-gmbh,rb-33,#a5027d,#ffffff,,rectangle,
-odeg,RB37,ostdeutsche-eisenbahn-gmbh,rb-37,#ad5937,#ffffff,,rectangle,
-odeg,RB46,ostdeutsche-eisenbahn-gmbh,rb-46,#da6ba2,#ffffff,,rectangle,
-odeg,RB51,ostdeutsche-eisenbahn-gmbh,rb-51,#da6ba2,#ffffff,,rectangle,
-odeg,RB64,ostdeutsche-eisenbahn-gmbh,rb-64,#006552,#ffffff,,rectangle,
-odeg,RB65,ostdeutsche-eisenbahn-gmbh,rb-65,#0066ad,#ffffff,,rectangle,
-odeg,RE1,ostdeutsche-eisenbahn-gmbh,re-1,#e2001a,#ffffff,,rectangle,
-odeg,RE8,ostdeutsche-eisenbahn-gmbh,re-8,#775fb0,#ffffff,,rectangle,
-odeg,RE9,ostdeutsche-eisenbahn-gmbh,re-9,#b51d48,#ffffff,,rectangle,
-odeg,RE10,ostdeutsche-eisenbahn-gmbh,re-10,#775fb0,#ffffff,,rectangle,
-ooevv-linz-linien,3,linz-linien-ag-strassenbahn-stadt-linz,8-810031-3,#a3238e,#ffffff,,rectangle,
-ooevv-linz-linien,4,linz-linien-ag-strassenbahn-stadt-linz,8-810031-4,#c40352,#ffffff,,rectangle,
-ooevv-oebb,S1,osterreichische-bundesbahnen,4-81-1-1589920-5372014,#ee7f00,#ffffff,,rectangle-rounded-corner,
-ooevv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1589920-5372014,#0098a1,#ffffff,,rectangle-rounded-corner,
-ooevv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1589920-5372014,#342980,#ffffff,,rectangle-rounded-corner,
-ooevv-oebb,S4,osterreichische-bundesbahnen,4-81-4-1589920-5372014,#a4ba00,#ffffff,,rectangle-rounded-corner,
-ooevv-stern-hafferl,S5,stern-hafferl-verkehrs-gmbh,4-810008-5,#e2007a,#ffffff,,rectangle-rounded-corner,
-ostalb-mobil-ovg-goeppingen,931,,5-vvs031-931,#fbc707,#000000,,rectangle,
-ostalb-mobil-ovg-goeppingen,932,,5-vvs031-932,#785f42,#ffffff,,rectangle,
-ostalb-mobil-ovk-betz,21,,5-ova050-21,#2e3192,#ffffff,,rectangle,
-ostalb-mobil-ovk-dannenmann,266,,5-vvs031-266,#0994dc,#ffffff,,rectangle,
-ostalb-mobil-ovk-dannenmann,268,,5-vvs031-268,#f47216,#ffffff,,rectangle,
-ostalb-mobil-ovk-domhan,71,,5-ova002-71,#2e3192,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,1,,5-ova002-1,#ed1c24,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,2,,5-ova002-2,#6e87cd,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,3,,5-ova002-3,#fff200,#000000,,rectangle,
-ostalb-mobil-stadtbus-gmuend,4,,5-ova002-4,#00adef,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,5,,5-ova002-5,#f47216,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,5b,,5-ova002-5b,#f47216,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,6,,5-ova002-6,#99d420,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,7,,5-ova002-7,#ca93d0,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,40,,5-ova002-40,#00adef,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,50,,5-ova002-50,#f47216,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,66,,5-ova002-66,#00a650,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,70,,5-ova002-70,#2e3192,#ffffff,,rectangle,
-ostalb-mobil-stadtbus-gmuend,73,,5-ova002-73,#00adef,#ffffff,,rectangle,
-pid-prague,1,dopravni-podnik-hl-m-prahy,8-540001-1,#ffffff,#a2cf62,#a2cf62,rectangle,
-pid-prague,2,dopravni-podnik-hl-m-prahy,8-540001-2,#ffffff,#f6c955,#f6c955,rectangle,
-pid-prague,3,dopravni-podnik-hl-m-prahy,8-540001-3,#ffffff,#4ca859,#4ca859,rectangle,
-pid-prague,4,dopravni-podnik-hl-m-prahy,8-540001-4,#ffffff,#a5d7b4,#a5d7b4,rectangle,
-pid-prague,5,dopravni-podnik-hl-m-prahy,8-540001-5,#ffffff,#f3b1b3,#f3b1b3,rectangle,
-pid-prague,6,dopravni-podnik-hl-m-prahy,8-540001-6,#ffffff,#d6ae72,#d6ae72,rectangle,
-pid-prague,7,dopravni-podnik-hl-m-prahy,8-540001-7,#ffffff,#ee843e,#ee843e,rectangle,
-pid-prague,8,dopravni-podnik-hl-m-prahy,8-540001-8,#ffffff,#ec6575,#ec6575,rectangle,
-pid-prague,9,dopravni-podnik-hl-m-prahy,8-540001-9,#ffffff,#eb452e,#eb452e,rectangle,
-pid-prague,10,dopravni-podnik-hl-m-prahy,8-540001-10,#ffffff,#469cd8,#469cd8,rectangle,
-pid-prague,11,dopravni-podnik-hl-m-prahy,8-540001-11,#ffffff,#e74696,#e74696,rectangle,
-pid-prague,12,dopravni-podnik-hl-m-prahy,8-540001-12,#ffffff,#9278b7,#9278b7,rectangle,
-pid-prague,13,dopravni-podnik-hl-m-prahy,8-540001-13,#ffffff,#f0a0c7,#f0a0c7,rectangle,
-pid-prague,14,dopravni-podnik-hl-m-prahy,8-540001-14,#ffffff,#c27b63,#c27b63,rectangle,
-pid-prague,15,dopravni-podnik-hl-m-prahy,8-540001-15,#ffffff,#fae25d,#fae25d,rectangle,
-pid-prague,16,dopravni-podnik-hl-m-prahy,8-540001-16,#ffffff,#68c9f1,#68c9f1,rectangle,
-pid-prague,17,dopravni-podnik-hl-m-prahy,8-540001-17,#ffffff,#802015,#802015,rectangle,
-pid-prague,18,dopravni-podnik-hl-m-prahy,8-540001-18,#ffffff,#f2b3d3,#f2b3d3,rectangle,
-pid-prague,19,dopravni-podnik-hl-m-prahy,8-540001-19,#ffffff,#884d27,#884d27,rectangle,
-pid-prague,20,dopravni-podnik-hl-m-prahy,8-540001-20,#ffffff,#682678,#682678,rectangle,
-pid-prague,21,dopravni-podnik-hl-m-prahy,8-540001-21,#ffffff,#dec750,#dec750,rectangle,
-pid-prague,22,dopravni-podnik-hl-m-prahy,8-540001-22,#ffffff,#16268f,#16268f,rectangle,
-pid-prague,23,dopravni-podnik-hl-m-prahy,8-540001-23,#ffffff,#7c85bf,#7c85bf,rectangle,
-pid-prague,24,dopravni-podnik-hl-m-prahy,8-540001-24,#ffffff,#97989b,#97989b,rectangle,
-pid-prague,25,dopravni-podnik-hl-m-prahy,8-540001-25,#ffffff,#81c059,#81c059,rectangle,
-pid-prague,26,dopravni-podnik-hl-m-prahy,8-540001-26,#ffffff,#a0dff6,#a0dff6,rectangle,
-pid-prague,A,dopravni-podnik-hl-m-prahy,7-540001-a,#00a54f,#ffffff,,rectangle,
-pid-prague,B,dopravni-podnik-hl-m-prahy,7-540001-b,#feca0a,#293219,,rectangle,
-pid-prague,C,dopravni-podnik-hl-m-prahy,7-540001-c,#ee1d23,#ffffff,,rectangle,
-polregio,RB91,polregio,r-91,#eb7405,#ffffff,,rectangle,
-regio-s-bahn-donau-iller,RS 2,db-regio-ag-baden-wurttemberg,rs2,#901411,#ffffff,,pill,
-regio-s-bahn-donau-iller,RS 21,db-regio-ag-baden-wurttemberg,rs21,#e92a1c,#ffffff,,pill,
-regio-s-bahn-donau-iller,RS 3,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs3,#62358a,#ffffff,,pill,
-regio-s-bahn-donau-iller,RS 5,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs5,#00622e,#ffffff,,pill,
-regio-s-bahn-donau-iller,RS 51,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs51,#43aa2c,#ffffff,,pill,
-regio-s-bahn-donau-iller,RS 7,db-regio-ag-bayern,rs7,#234997,#ffffff,,pill,
-regio-s-bahn-donau-iller,RS 71,db-regio-ag-bayern,rs71,#1398d3,#ffffff,,pill,
-regiobus-hannover,170,,5-webrbg-170,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,300,,5-webrbg-300,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,301,,5-webrbg-301,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,310,,5-webrbg-310,#ffffff,#2c2e35,#af2a21,pill,
-regiobus-hannover,320,,5-webrbg-320,#ffffff,#2c2e35,#0155ae,pill,
-regiobus-hannover,360,,5-webrbg-360,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,365,,5-webrbg-365,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,366,,5-webrbg-366,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,367,,5-webrbg-367,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,380,,5-webrbg-380,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,381,,5-webrbg-381,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,382,,5-webrbg-382,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,383,,5-webrbg-383,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,385,,5-webrbg-385,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,400,,5-webrbg-400,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,404,,5-webrbg-404,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,410,,5-webrbg-410,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,421,,5-webrbg-421,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,430,,5-webrbg-430,#ffffff,#2c2e35,#af2a21,pill,
-regiobus-hannover,431,,5-webrbg-431,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,460,,5-webrbg-460,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,490,,5-webrbg-490,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,492,,5-webrbg-492,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,500,,5-webrbg-500,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,510,,5-webrbg-510,#ffffff,#2c2e35,#af2a21,pill,
-regiobus-hannover,520,,5-webrbg-520,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,521,,5-webrbg-521,#ffffff,#2c2e35,#8ce0f8,pill,
-regiobus-hannover,522,,5-webrbg-522,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,523,,5-webrbg-523,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,530,,5-webrbg-530,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,532,,5-webrbg-532,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,534,,5-webrbg-534,#ffffff,#2c2e35,#0155ae,pill,
-regiobus-hannover,540,,5-webrbg-540,#ffffff,#2c2e35,#9b2e4c,pill,
-regiobus-hannover,560,,5-webrbg-560,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,561,,5-webrbg-561,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,562,,5-webrbg-562,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,570,,5-webrbg-570,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,571,,5-webrbg-571,#ffffff,#2c2e35,#fc87bf,pill,
-regiobus-hannover,572,,5-webrbg-572,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,573,,5-webrbg-573,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,574,,5-webrbg-574,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,575,,5-webrbg-575,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,580,,5-webrbg-580,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,600,,5-webrbg-600,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,616,,5-webrbg-616,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,620,,5-webrbg-620,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,621,,5-webrbg-621,#ffffff,#2c2e35,#ffeb3d,pill,
-regiobus-hannover,630,,5-webrbg-630,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,635,,5-webrbg-635,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,636,,5-webrbg-636,#ffffff,#2c2e35,#0073c0,pill,
-regiobus-hannover,638,,5-webrbg-638,#ffffff,#2c2e35,#8ce0f8,pill,
-regiobus-hannover,639,,5-webrbg-639,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,651,,5-webrbg-651,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,652,,5-webrbg-652,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,690,,5-webrbg-690,#ffffff,#2c2e35,#af2a21,pill,
-regiobus-hannover,692,,5-webrbg-692,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,694,,5-webrbg-694,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,695,,5-webrbg-695,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,696,,5-webrbg-696,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,697,,5-webrbg-697,#ffffff,#2c2e35,#009edd,pill,
-regiobus-hannover,698,,5-webrbg-698,#ffffff,#2c2e35,#102694,pill,
-regiobus-hannover,700,,5-webrbg-700,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,701,,5-webrbg-701,#ffffff,#2c2e35,#9b2e4c,pill,
-regiobus-hannover,710,,5-webrbg-710,#ffffff,#2c2e35,#53afbb,pill,
-regiobus-hannover,711,,5-webrbg-711,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,715,,5-webrbg-715,#ffffff,#2c2e35,#fc87bf,pill,
-regiobus-hannover,740,,5-webrbg-740,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,741,,5-webrbg-741,#ffffff,#2c2e35,#102694,pill,
-regiobus-hannover,745,,5-webrbg-745,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,760,,5-webrbg-760,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,780,,5-webrbg-780,#ffffff,#2c2e35,#117b40,pill,
-regiobus-hannover,785,,5-webrbg-785,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,801,,5-webrbg-801,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,802,,5-webrbg-802,#ffffff,#2c2e35,#ffeb3d,pill,
-regiobus-hannover,820,,5-webrbg-820,#ffffff,#2c2e35,#0073c0,pill,
-regiobus-hannover,830,,5-webrbg-830,#ffffff,#2c2e35,#ffadb2,pill,
-regiobus-hannover,831,,5-webrbg-831,#ffffff,#2c2e35,#117b40,pill,
-regiobus-hannover,835,,5-webrbg-835,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,840,,5-webrbg-840,#ffffff,#2c2e35,#53afbb,pill,
-regiobus-hannover,850,,5-webrbg-850,#ffffff,#2c2e35,#9b2e4c,pill,
-regiobus-hannover,860,,5-webrbg-860,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,865,,5-webrbg-865,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,870,,5-webrbg-870,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,900,,5-webrbg-900,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,905,,5-webrbg-905,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,906,,5-webrbg-906,#ffffff,#2c2e35,#0073c0,pill,
-regiobus-hannover,907,,5-webrbg-907,#ffffff,#2c2e35,#af2a21,pill,
-regiobus-hannover,910,,5-webrbg-910,#ffffff,#2c2e35,#00ab4f,pill,
-regiobus-hannover,916,,5-webrbg-916,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,917,,5-webrbg-917,#ffffff,#2c2e35,#ff9027,pill,
-regiobus-hannover,920,,5-webrbg-920,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,926,,5-webrbg-926,#ffffff,#2c2e35,#903da0,pill,
-regiobus-hannover,927,,5-webrbg-927,#ffffff,#2c2e35,#35ccf6,pill,
-regiobus-hannover,930,,5-webrbg-930,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,938,,5-webrbg-938,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,946,,5-webrbg-946,#ffffff,#2c2e35,#fc87bf,pill,
-regiobus-hannover,948,,5-webrbg-948,#ffffff,#2c2e35,#117b40,pill,
-regiobus-hannover,949,,5-webrbg-949,#ffffff,#2c2e35,#9b2e4c,pill,
-regiobus-hannover,950,,5-webrbg-950,#ffffff,#2c2e35,#00ab4f,pill,
-regiobus-hannover,962,,5-webrbg-962,#ffffff,#2c2e35,#ff2e17,pill,
-regiobus-hannover,963,,5-webrbg-963,#ffffff,#2c2e35,#ffbe32,pill,
-regiobus-hannover,964,,5-webrbg-964,#ffffff,#2c2e35,#8ce0f8,pill,
-regiobus-hannover,965,,5-webrbg-965,#ffffff,#2c2e35,#3ebc6d,pill,
-regiobus-hannover,966,,5-webrbg-966,#ffffff,#2c2e35,#0073c0,pill,
-regiobus-hannover,967,,5-webrbg-967,#ffffff,#2c2e35,#95cc45,pill,
-regiobus-hannover,968,,5-webrbg-968,#ffffff,#2c2e35,#fb3199,pill,
-regiobus-hannover,N31,,5-webrbg-n31,#08345d,#ffffff,,pill,
-regiobus-hannover,N41,,5-webrbg-n41,#08345d,#ffffff,,pill,
-regiobus-hannover,N43,,5-webrbg-n43,#08345d,#ffffff,,pill,
-regiobus-hannover,N50,,5-webrbg-n50,#08345d,#ffffff,,pill,
-regiobus-hannover,N56,,5-webrbg-n56,#08345d,#ffffff,,pill,
-regiobus-hannover,N57,,5-webrbg-n57,#08345d,#ffffff,,pill,
-regiobus-hannover,N62,,5-webrbg-n62,#08345d,#ffffff,,pill,
-regiobus-hannover,N63,,5-webrbg-n63,#08345d,#ffffff,,pill,
-regiobus-hannover,N70,,5-webrbg-n70,#08345d,#ffffff,,pill,
-regiobus-hannover,N94,,5-webrbg-n94,#08345d,#ffffff,,pill,
-rmv-db-sbahn,S1,db-regio-ag-s-bahn-rhein-main,4-800528-1,#009edd,#ffffff,,pill,
-rmv-db-sbahn,S2,db-regio-ag-s-bahn-rhein-main,4-800528-2,#ff2e17,#ffffff,,pill,
-rmv-db-sbahn,S3,db-regio-ag-s-bahn-rhein-main,4-800528-3,#00b098,#ffffff,,pill,
-rmv-db-sbahn,S4,db-regio-ag-s-bahn-rhein-main,4-800528-4,#ffc734,#2c2e35,#2c2e35,pill,
-rmv-db-sbahn,S5,db-regio-ag-s-bahn-rhein-main,4-800528-5,#95542a,#ffffff,,pill,
-rmv-db-sbahn,S6,db-regio-ag-s-bahn-rhein-main,4-800528-6,#ff7322,#ffffff,,pill,
-rmv-db-sbahn,S7,db-regio-ag-s-bahn-rhein-main,4-800528-7,#214d36,#ffffff,,pill,
-rmv-db-sbahn,S8,db-regio-ag-s-bahn-rhein-main,4-800528-8,#88c946,#ffffff,,pill,
-rmv-db-sbahn,S9,db-regio-ag-s-bahn-rhein-main,4-800528-9,#872996,#ffffff,,pill,
-rmv-eswe-bus,1,,5-rmv001-1,#ee7203,#ffffff,,rectangle,
-rmv-eswe-bus,3,,5-rmv001-3,#8b5593,#ffffff,,rectangle,
-rmv-eswe-bus,4,,5-rmv001-4,#2fac66,#ffffff,,rectangle,
-rmv-eswe-bus,5,,5-rmv001-5,#e4032e,#ffffff,,rectangle,
-rmv-eswe-bus,6,,5-rmv001-6,#eb5e57,#ffffff,,rectangle,
-rmv-eswe-bus,8,,5-rmv001-8,#ee7203,#ffffff,,rectangle,
-rmv-eswe-bus,9,,5-rmv001-9,#477ec0,#ffffff,,rectangle,
-rmv-eswe-bus,14,,5-rmv001-14,#2fac66,#ffffff,,rectangle,
-rmv-eswe-bus,15,,5-rmv001-15,#e4032e,#ffffff,,rectangle,
-rmv-eswe-bus,16,,5-rmv001-16,#f39a8b,#000000,,rectangle,
-rmv-eswe-bus,17,,5-rmv001-17,#009fe3,#ffffff,,rectangle,
-rmv-eswe-bus,18,,5-rmv001-18,#8c9da6,#ffffff,,rectangle,
-rmv-eswe-bus,20,,5-rmv001-20,#e4032e,#ffffff,,rectangle,
-rmv-eswe-bus,21,,5-rmv001-21,#009641,#ffffff,,rectangle,
-rmv-eswe-bus,22,,5-rmv001-22,#009641,#ffffff,,rectangle,
-rmv-eswe-bus,23,,5-rmv001-23,#005da9,#ffffff,,rectangle,
-rmv-eswe-bus,24,,5-rmv001-24,#005da9,#ffffff,,rectangle,
-rmv-eswe-bus,26,,5-rmv001-26,#005da9,#ffffff,,rectangle,
-rmv-eswe-bus,27,,5-rmv001-27,#005da9,#ffffff,,rectangle,
-rmv-eswe-bus,28,,5-rmv001-28,#00b6ed,#ffffff,,rectangle,
-rmv-eswe-bus,33,,5-rmv001-33,#8b5593,#ffffff,,rectangle,
-rmv-eswe-bus,34,,5-rmv001-34,#918dbe,#ffffff,,rectangle,
-rmv-eswe-bus,37,,5-rmv001-37,#283583,#ffffff,,rectangle,
-rmv-eswe-bus,38,,5-rmv001-38,#009fe3,#ffffff,,rectangle,
-rmv-eswe-bus,39,,5-rmv001-39,#f4954a,#ffffff,,rectangle,
-rmv-eswe-bus,45,,5-rmv001-45,#cbce00,#000000,,rectangle,
-rmv-eswe-bus,46,,5-rmv001-46,#c75c9f,#ffffff,,rectangle,
-rmv-eswe-bus,47,,5-rmv001-47,#6b7c85,#ffffff,,rectangle,
-rmv-eswe-bus,48,,5-rmv001-48,#477ec0,#ffffff,,rectangle,
-rmv-eswe-bus,49,,5-rmv001-49,#8ec89a,#000000,,rectangle,
-rmv-eswe-bus,74,,5-rmv001-74,#e6007d,#ffffff,,rectangle,
-rmv-eswe-bus,N2,,5-rmv001-n2,#005da9,#ffffff,,rectangle,
-rmv-eswe-bus,N3,,5-rmv001-n3,#b80e80,#ffffff,,rectangle,
-rmv-eswe-bus,N3,,5-rmv001-n3,#b80e80,#ffffff,,rectangle,
-rmv-eswe-bus,N4,,5-rmv001-n4,#6fbc85,#ffffff,,rectangle,
-rmv-eswe-bus,N5,,5-rmv001-n5,#009641,#ffffff,,rectangle,
-rmv-eswe-bus,N7,,5-rmv001-n7,#009fe3,#ffffff,,rectangle,
-rmv-eswe-bus,N9,,5-rmv001-n9,#c868a6,#ffffff,,rectangle,
-rmv-eswe-bus,N10,,5-rmv001-n10,#fbba00,#000000,,rectangle,
-rmv-eswe-bus,N11,,5-rmv001-n11,#ce7e00,#ffffff,,rectangle,
-rmv-eswe-bus,N12,,5-rmv001-n12,#e30613,#ffffff,,rectangle,
-rmv-eswe-bus,N13,,5-rmv001-n13,#000000,#ffffff,,rectangle,
-rmv-express-bus,X72,,5-rmv408-x72,#e7007a,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,A,,5-rmvheb-a,#a97b50,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,AH,,5-rmvheb-ah,#603711,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,AIR,,5-rmvheb-air,#3f9199,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,BE1,,5-rmv289-be1,#2e3092,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,EB,,5-rmv289-eb,#8bc63e,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,F,,5-rmvheb-f,#be1d2c,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,FM,,5-rmvheb-fm,#be1d2c,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,G,,5-rmvheb-g,#fbb03f,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,H,,5-rmvheb-h,#652d91,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,K,,5-rmvheb-k,#1074bc,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,L,,5-rmvheb-l,#e984b6,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,N,,5-rmvheb-n,#9f1960,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,O,,5-rmvheb-o,#9f1960,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,P,,5-rmv289-p,#f7931d,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,PE,,5-rmv289-pe,#f7931d,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,PG,,5-rmv289-pg,#f7931d,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,R,,5-rmvheb-r,#3ab54a,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,WE1,,5-rmv289-we1,#63708c,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,WE2,,5-rmv289-we2,#63708c,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,WE3,,5-rmv289-we3,#f15929,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,WE4,,5-rmv289-we4,#f15929,#ffffff,,rectangle-rounded-corner,
-rmv-heag-bus,WX,,5-rmvheb-wx,#fbb03f,#ffffff,,rectangle-rounded-corner,
-rmv-heag-tram,1,,8-rmvhtr-1,#f77893,#ffffff,,pill,
-rmv-heag-tram,2,,8-rmvhtr-2,#00ab4f,#ffffff,,pill,
-rmv-heag-tram,3,,8-rmvhtr-3,#ffbe3c,#ffffff,,pill,
-rmv-heag-tram,4,,8-rmvhtr-4,#1e78c2,#ffffff,,pill,
-rmv-heag-tram,5,,8-rmvhtr-5,#3ab5e6,#ffffff,,pill,
-rmv-heag-tram,6,,8-rmvhtr-6,#fe782b,#ffffff,,pill,
-rmv-heag-tram,7,,8-rmvhtr-7,#fb3199,#ffffff,,pill,
-rmv-heag-tram,8,,8-rmvhtr-8,#f5381f,#ffffff,,pill,
-rmv-heag-tram,9,,8-rmvhtr-9,#7ac64d,#ffffff,,pill,
-rmv-heag-tram,10,,8-rmvhtr-10,#872996,#ffffff,,pill,
-rmv-hsb-bus,1,,5-rmv399-1,#ffffff,#000000,#8bc63e,rectangle-rounded-corner,
-rmv-hsb-bus,2,,5-rmv399-2,#ffffff,#000000,#ffdc01,rectangle-rounded-corner,
-rmv-hsb-bus,4,,5-rmv399-4,#ffffff,#000000,#875400,rectangle-rounded-corner,
-rmv-hsb-bus,5,,5-rmv399-5,#ffffff,#000000,#f48233,rectangle-rounded-corner,
-rmv-hsb-bus,6,,5-rmv399-6,#ffffff,#000000,#873e97,rectangle-rounded-corner,
-rmv-hsb-bus,7,,5-rmv399-7,#ffffff,#000000,#008cd0,rectangle-rounded-corner,
-rmv-hsb-bus,8,,5-rmv399-8,#ffffff,#000000,#d70c8c,rectangle-rounded-corner,
-rmv-hsb-bus,9,,5-rmv399-9,#ffffff,#000000,#ef4022,rectangle-rounded-corner,
-rmv-hsb-bus,10,,5-rmv399-10,#ffffff,#000000,#015aaa,rectangle-rounded-corner,
-rmv-hsb-bus,11,,5-rmv399-11,#ffffff,#000000,#77b6e4,rectangle-rounded-corner,
-rmv-hsb-bus,12,,5-rmv399-12,#ffffff,#000000,#f390b3,rectangle-rounded-corner,
-rmv-hsb-bus,20,,5-rmv399-20,#ffffff,#000000,#b00d1d,rectangle-rounded-corner,
-rmv-mm-bus,6,,5-rmvmmb-6,#ef7d00,#ffffff,,rectangle,
-rmv-mm-bus,9,,5-rmvmmb-9,#006e89,#ffffff,,rectangle,
-rmv-mm-bus,28,,5-rmvmmb-28,#dbe283,#000000,,rectangle,
-rmv-mm-bus,33,,5-rmvmmb-33,#008fcf,#ffffff,,rectangle,
-rmv-mm-bus,54,,5-rmvmmb-54,#408927,#ffffff,,rectangle,
-rmv-mm-bus,55,,5-rmvmmb-55,#408927,#ffffff,,rectangle,
-rmv-mm-bus,56,,5-rmvmmb-56,#95c11f,#000000,,rectangle,
-rmv-mm-bus,57,,5-rmvmmb-57,#00b1eb,#ffffff,,rectangle,
-rmv-mm-bus,58,,5-rmvmmb-58,#95c11f,#000000,,rectangle,
-rmv-mm-bus,60,,5-rmvmmb-60,#00afcb,#ffffff,,rectangle,
-rmv-mm-bus,62,,5-rmvmmb-62,#c22e0c,#ffffff,,rectangle,
-rmv-mm-bus,63,,5-rmvmmb-63,#00afcb,#ffffff,,rectangle,
-rmv-mm-bus,64,,5-rmvmmb-64,#f59c00,#000000,,rectangle,
-rmv-mm-bus,65,,5-rmvmmb-65,#f59c00,#000000,,rectangle,
-rmv-mm-bus,66,,5-rmvmmb-66,#ffd500,#000000,,rectangle,
-rmv-mm-bus,67,,5-rmvmmb-67,#e30613,#ffffff,,rectangle,
-rmv-mm-bus,68,,5-rmvmmb-68,#00803d,#ffffff,,rectangle,
-rmv-mm-bus,69,,5-rmvmmb-69,#e30613,#ffffff,,rectangle,
-rmv-mm-bus,70,,5-rmvmmb-70,#a71b71,#ffffff,,rectangle,
-rmv-mm-bus,71,,5-rmvmmb-71,#a71b71,#ffffff,,rectangle,
-rmv-mm-bus,74,,5-rmvmmb-74,#e6007d,#ffffff,,rectangle,
-rmv-mm-bus,76,,5-rmvmmb-76,#8a1002,#ffffff,,rectangle,
-rmv-mm-bus,78,,5-rmvmmb-78,#124a73,#ffffff,,rectangle,
-rmv-mm-bus,79,,5-rmvmmb-79,#00803d,#ffffff,,rectangle,
-rmv-mm-bus,80,,5-rmvmmb-80,#0061a7,#ffffff,,rectangle,
-rmv-mm-bus,81,,5-rmvmmb-81,#0061a7,#ffffff,,rectangle,
-rmv-mm-bus,90,,5-rmvmmb-90,#8d004c,#ffffff,,rectangle,
-rmv-mm-bus,91,,5-rmvmmb-91,#914f00,#ffffff,,rectangle,
-rmv-mm-bus,92,,5-rmvmmb-92,#006d8f,#ffffff,,rectangle,
-rmv-mm-bus,93,,5-rmvmmb-93,#5b7813,#ffffff,,rectangle,
-rmv-mm-tram,50,,8-rmvmmt-50,#000000,#ffffff,,rectangle,
-rmv-mm-tram,51,,8-rmvmmt-51,#4a4a49,#ffffff,,rectangle,
-rmv-mm-tram,52,,8-rmvmmt-52,#7c7b7b,#ffffff,,rectangle,
-rmv-mm-tram,53,,8-rmvmmt-53,#646363,#ffffff,,rectangle,
-rmv-mm-tram,59,,8-rmvmmt-59,#929292,#ffffff,,rectangle,
-rmv-vgf-tram,11,,8-rmv254-11,#fec10c,#ffffff,,pill,
-rmv-vgf-tram,12,,8-rmv254-12,#c64a1a,#ffffff,,pill,
-rmv-vgf-tram,14,,8-rmv254-14,#f05a22,#ffffff,,pill,
-rmv-vgf-tram,15,,8-rmv254-15,#fec10c,#ffffff,,pill,
-rmv-vgf-tram,16,,8-rmv254-16,#f5821f,#ffffff,,pill,
-rmv-vgf-tram,17,,8-rmv254-17,#f05a22,#ffffff,,pill,
-rmv-vgf-tram,18,,8-rmv254-18,#faa519,#ffffff,,pill,
-rmv-vgf-tram,20,,8-rmv254-20,#ffffff,#faa519,,pill,
-rmv-vgf-tram,21,,8-rmv254-21,#faa519,#ffffff,,pill,
-rmv-vgf-ubahn,U1,,7-rmv255-1,#c52b1e,#ffffff,,pill,
-rmv-vgf-ubahn,U2,,7-rmv255-2,#00ab4f,#ffffff,,pill,
-rmv-vgf-ubahn,U3,,7-rmv255-3,#345aaf,#ffffff,,pill,
-rmv-vgf-ubahn,U4,,7-rmv255-4,#fc5cac,#ffffff,,pill,
-rmv-vgf-ubahn,U5,,7-rmv255-5,#0c7d3e,#ffffff,,pill,
-rmv-vgf-ubahn,U6,,7-rmv255-6,#0082ca,#ffffff,,pill,
-rmv-vgf-ubahn,U7,,7-rmv255-7,#f19e2d,#ffffff,,pill,
-rmv-vgf-ubahn,U8,,7-rmv255-8,#ca7fbe,#ffffff,,pill,
-rmv-vgf-ubahn,U9,,7-rmv255-9,#ffd939,#2c2e35,#2c2e35,pill,
-rvf-sbahn,RE S1,db-regio-ag-baden-wurttemberg,re-s1,#d30630,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c6-1,#d30630,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c4-1,#d30630,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S2,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s2,#afca0b,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S3,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s3,#b15a9e,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S5,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s5,#0069b4,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S10,db-regio-ag-baden-wurttemberg,4-8006c6-10,#d30630,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c6-11,#f69795,#ffffff,,rectangle-rounded-corner,
-rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c4-11,#f69795,#ffffff,,rectangle-rounded-corner,
-rvf-sweg-sudwest,1,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb1,#a3238e,#ffffff,,rectangle,
-rvf-sweg-sudwest,1,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-1,#a3238e,#ffffff,,rectangle,
-rvf-sweg-sudwest,2,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb2,#fab383,#ffffff,,rectangle,
-rvf-sweg-sudwest,2,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-2,#fab383,#ffffff,,rectangle,
-rvf-sweg-sudwest,3,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb3,#f68b1e,#ffffff,,rectangle,
-rvf-sweg-sudwest,3,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-3,#f68b1e,#ffffff,,rectangle,
-rvf-sweg-sudwest,4,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-4,#009a4e,#ffffff,,rectangle,
-rvf-sweg-sudwest,5,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb5,#ed1c24,#ffffff,,rectangle,
-rvf-sweg-sudwest,5,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-5,#ed1c24,#ffffff,,rectangle,
-rvf-sweg-sudwest,6,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb6,#74714c,#ffffff,,rectangle,
-rvf-sweg-sudwest,6,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-6,#74714c,#ffffff,,rectangle,
-rvf-sweg-sudwest,7,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-7,#ffdd00,#ffffff,,rectangle,
-rvf-sweg-sudwest,9,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb9,#008a90,#ffffff,,rectangle,
-rvf-sweg-sudwest,9,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-9,#008a90,#ffffff,,rectangle,
-rvf-sweg-sudwest,10,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-10,#cf9c50,#ffffff,,rectangle,
-rvf-vag-stadtbahn,1,,8-vag002-1,#ed1c24,#ffffff,,rectangle,
-rvf-vag-stadtbahn,2,,8-vag002-2,#35af3f,#ffffff,,rectangle,
-rvf-vag-stadtbahn,3,,8-vag002-3,#f79210,#ffffff,,rectangle,
-rvf-vag-stadtbahn,4,,8-vag002-4,#f033a3,#ffffff,,rectangle,
-rvf-vag-stadtbahn,5,,8-vag002-5,#0994ce,#ffffff,,rectangle,
-s-bahn-bern-bls,S 1,bls-ag,4-850033-1,#50b447,#ffffff,,rectangle,
-s-bahn-bern-bls,S 2,bls-ag,4-850033-2,#1cb1e6,#ffffff,,rectangle,
-s-bahn-bern-bls,S 3,bls-ag,4-850033-3,#8868b3,#ffffff,,rectangle,
-s-bahn-bern-bls,S 31,bls-ag,4-850033-31,#b0aa38,#ffffff,,rectangle,
-s-bahn-bern-bls,S 4,bls-ag,4-850033-4,#53c4af,#ffffff,,rectangle,
-s-bahn-bern-bls,S 44,bls-ag,4-850033-44,#646026,#ffffff,,rectangle,
-s-bahn-bern-bls,S 5,bls-ag,4-850033-5,#881c3f,#ffffff,,rectangle,
-s-bahn-bern-bls,S 51,bls-ag,4-850033-51,#9cc843,#ffffff,,rectangle,
-s-bahn-bern-bls,S 52,bls-ag,4-850033-52,#f7cf39,#ffffff,,rectangle,
-s-bahn-bern-bls,S 6,bls-ag,4-850033-6-827562-5222797,#f84e4d,#ffffff,,rectangle,
-s-bahn-bern-rbs,S 7,regionalverkehr-bern-solothurn,4-850088-7,#ff812d,#ffffff,,rectangle,
-s-bahn-bern-rbs,S 8,regionalverkehr-bern-solothurn,4-850088-8,#191918,#ffffff,,rectangle,
-s-bahn-bern-rbs,S 9,regionalverkehr-bern-solothurn,4-850088-9,#fa2d18,#ffffff,,rectangle,
-s-bahn-hannover-transdev,S 1,s-bahn-hannover-transdev,4-tdhs-1,#846daa,#ffffff,,pill,
-s-bahn-hannover-transdev,S 2,s-bahn-hannover-transdev,4-tdhs-2,#007a3d,#ffffff,,pill,
-s-bahn-hannover-transdev,S 21,s-bahn-hannover-transdev,4-tdhs-21,#007a3d,#ffffff,,pill,
-s-bahn-hannover-transdev,S 3,s-bahn-hannover-transdev,4-tdhs-3,#cc69a6,#ffffff,,pill,
-s-bahn-hannover-transdev,S 4,s-bahn-hannover-transdev,4-tdhs-4,#9b2b48,#ffffff,,pill,
-s-bahn-hannover-transdev,S 5,s-bahn-hannover-transdev,4-tdhs-5,#f18700,#ffffff,,pill,
-s-bahn-hannover-transdev,S 51,s-bahn-hannover-transdev,4-tdhs-51,#f18700,#ffffff,,pill,
-s-bahn-hannover-transdev,S 6,s-bahn-hannover-transdev,4-tdhs-6,#004f9f,#ffffff,,pill,
-s-bahn-hannover-transdev,S 7,s-bahn-hannover-transdev,4-tdhs-7,#afcb27,#ffffff,,pill,
-s-bahn-hannover-transdev,S 8,s-bahn-hannover-transdev,4-tdhs-8,#1794ca,#ffffff,,pill,
-s-bahn-zentralschweiz-bls,S 6,bls-ag,4-850033-6-924462-5234071,#0165b6,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-bls,S 7,bls-ag,4-850033-7,#73c0e8,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-bls,S 77,bls-ag,4-850033-77,#7a84c4,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-sbb,S 1,sbb,4-85-1-924462-5234071,#1bb04d,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-sbb,S 2,sbb,4-85-2-947252-5247813,#f93f27,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-sbb,S 3,sbb,4-85-3-924462-5234071,#fe7d25,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-sbb,S 9,sbb,4-85-9-924462-5234071,#a3cf45,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-sbb,S 99,sbb,4-85-99,#95b15e,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-zb,S 4,zentralbahn,4-850086-4,#aa2a3f,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-zb,S 41,zentralbahn,4-850086-41,#055d80,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-zb,S 44,zentralbahn,4-850086-44,#d35d68,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-zb,S 5,zentralbahn,4-850086-5,#fb47a3,#ffffff,,rectangle-rounded-corner,
-s-bahn-zentralschweiz-zb,S 55,zentralbahn,4-850086-55,#fc87bf,#ffffff,,rectangle-rounded-corner,
-saarbahn,S1,saarbahn,8-vgssbs-1,#f39200,#ffffff,,rectangle,
-saarbahn,30,,5-vgssbb-30,#5c2483,#ffffff,,rectangle,
-saarbahn,101,,5-vgssbb-101,#e30613,#ffffff,,rectangle,
-saarbahn,102,,5-vgssbb-102,#e30613,#ffffff,,rectangle,
-saarbahn,103,,5-vgssbb-103,#e30613,#ffffff,,rectangle,
-saarbahn,104,,5-vgssbb-104,#e30613,#ffffff,,rectangle,
-saarbahn,105,,5-vgssbb-105,#e30613,#ffffff,,rectangle,
-saarbahn,106,,5-vgssbb-106,#e30613,#ffffff,,rectangle,
-saarbahn,107,,5-vgssbb-107,#e30613,#ffffff,,rectangle,
-saarbahn,108,,5-vgssbb-108,#e30613,#ffffff,,rectangle,
-saarbahn,109,,5-vgssbb-109,#e30613,#ffffff,,rectangle,
-saarbahn,110,,5-vgssbb-110,#5c2483,#ffffff,,rectangle,
-saarbahn,111,,5-vgssbb-111,#e30613,#ffffff,,rectangle,
-saarbahn,112,,5-vgssbb-112,#e30613,#ffffff,,rectangle,
-saarbahn,120,,5-vgssbb-120,#00a13a,#ffffff,,rectangle,
-saarbahn,121,,5-vgssbb-121,#00a13a,#ffffff,,rectangle,
-saarbahn,122,,5-vgssbb-122,#00a13a,#ffffff,,rectangle,
-saarbahn,123,,5-vgssbb-123,#00a13a,#ffffff,,rectangle,
-saarbahn,124,,5-vgssbb-124,#00a13a,#ffffff,,rectangle,
-saarbahn,125,,5-vgssbb-125,#00a13a,#ffffff,,rectangle,
-saarbahn,126,,5-vgssbb-126,#00a13a,#ffffff,,rectangle,
-saarbahn,128,,5-vgssbb-128,#00a13a,#ffffff,,rectangle,
-saarbahn,129,,5-vgssbb-129,#00a13a,#ffffff,,rectangle,
-saarbahn,130,,5-vgssbb-130,#008bd2,#ffffff,,rectangle,
-saarbahn,131,,5-vgssbb-131,#008bd2,#ffffff,,rectangle,
-saarbahn,133,,5-vgssbb-133,#008bd2,#ffffff,,rectangle,
-saarbahn,134,,5-vgssbb-134,#008bd2,#ffffff,,rectangle,
-saarbahn,135,,5-vgssbb-135,#008bd2,#ffffff,,rectangle,
-saarbahn,136,,5-vgssbb-136,#008bd2,#ffffff,,rectangle,
-saarbahn,137,,5-vgssbb-137,#008bd2,#ffffff,,rectangle,
-saarbahn,138,,5-vgssbb-138,#008bd2,#ffffff,,rectangle,
-saarbahn,139,,5-vgssbb-139,#008bd2,#ffffff,,rectangle,
-saarbahn,151,,5-vgssbb-151,#008bd2,#ffffff,,rectangle,
-saarbahn,152,,5-vgssbb-152,#008bd2,#ffffff,,rectangle,
-saarbahn,153,,5-vgssbb-153,#008bd2,#ffffff,,rectangle,
-saarbahn,154,,5-vgssbb-154,#008bd2,#ffffff,,rectangle,
-saarbahn,161,,5-vgssbb-161,#008bd2,#ffffff,,rectangle,
-saarbahn,163,,5-vgssbb-163,#008bd2,#ffffff,,rectangle,
-saarbahn,164,,5-vgssbb-164,#008bd2,#ffffff,,rectangle,
-saarbahn,165,,5-vgssbb-165,#008bd2,#ffffff,,rectangle,
-saarbahn,168,,5-vgssbb-168,#008bd2,#ffffff,,rectangle,
-schweiz-fernverkehr,RE 6,schweizerische-bundesbahnen,re-6,#4f1a4a,#ffffff,,rectangle-rounded-corner,
-schweiz-fernverkehr,RE 33,schweizerische-bundesbahnen,re-33,#076867,#ffffff,,rectangle-rounded-corner,
-schweiz-fernverkehr,RE 37,schweizerische-bundesbahnen,re-37,#ffaa90,#2c2e35,,rectangle-rounded-corner,
-schweiz-fernverkehr,RE 48,schweizerische-bundesbahnen,re-48,#b9a96f,#ffffff,,rectangle-rounded-corner,
-start,RB12,regionalverkehre-start-deutschland-gmbh-start-taunus,stn-rb12,#94522e,#ffffff,,rectangle-rounded-corner,
-start,RB15,regionalverkehre-start-deutschland-gmbh-start-taunus,stn-rb15,#e3a02e,#ffffff,,rectangle-rounded-corner,
-svv-brb,S3,bayerische-regiobahn,4-l8-s3,#3ab048,#ffffff,,rectangle-rounded-corner,
-svv-brb,S4,bayerische-regiobahn,4-l8-s4,#9764ac,#ffffff,,rectangle-rounded-corner,
-svv-oebb,R3,osterreichische-bundesbahnen,r-3,#99be41,#ffffff,,rectangle-rounded-corner,
-svv-oebb,R9,osterreichische-bundesbahnen,r-9,#e4be3d,#ffffff,,rectangle-rounded-corner,
-svv-oebb,R21,osterreichische-bundesbahnen,r-21,#44bccf,#ffffff,,rectangle-rounded-corner,
-svv-oebb,REX21,osterreichische-bundesbahnen,rex-21,#ff8124,#ffffff,,rectangle-rounded-corner,
-svv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1451275-5318936,#0077bd,#ffffff,,rectangle-rounded-corner,
-svv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1451275-5318936,#3ab048,#ffffff,,rectangle-rounded-corner,
-svv-slb,R33,salzburger-lokalbahnen,,#c22438,#ffffff,,rectangle-rounded-corner,
-svv-slb,S1,salzburger-lokalbahnen,4-810007-1,#c22438,#ffffff,,rectangle-rounded-corner,
-svv-slb,S11,salzburger-lokalbahnen,4-810007-11,#c22438,#ffffff,,rectangle-rounded-corner,
-sweg-stuttgart,RE 6,sweg-bahn-stuttgart-gmbh,re-6,#ebaf2d,#ffffff,,rectangle,Q131584411
-sweg-stuttgart,RE 10a,sweg-bahn-stuttgart-gmbh,re-10a,#014f9f,#ffffff,,rectangle,Q131584412
-sweg-stuttgart,RE 10b,sweg-bahn-stuttgart-gmbh,re-10b,#014f9f,#ffffff,,rectangle,Q131584450
-sweg-stuttgart,RE 71,sweg-bahn-stuttgart-gmbh,re-71,#7db83f,#ffffff,,rectangle,Q131584454
-sweg-stuttgart,MEX 12,sweg-bahn-stuttgart-gmbh,mex-12,#f27320,#ffffff,,rectangle,Q131584405
-sweg-stuttgart,MEX 17a,sweg-bahn-stuttgart-gmbh,mex-17a,#00a9df,#ffffff,,rectangle,Q131584401
-sweg-stuttgart,MEX 17c,sweg-bahn-stuttgart-gmbh,mex-17c,#ec2933,#ffffff,,rectangle,Q131584403
-sweg-stuttgart,MEX 18,sweg-bahn-stuttgart-gmbh,mex-18,#009c48,#ffffff,,rectangle,Q131584398
-sweg-stuttgart,RB 17a,sweg-bahn-stuttgart-gmbh,rb-17a,#00a9df,#ffffff,,rectangle,Q131584392
-sweg-stuttgart,RB 17c,sweg-bahn-stuttgart-gmbh,rb-17c,#ec2933,#ffffff,,rectangle,Q131584394
-sweg-stuttgart,RB 18,sweg-bahn-stuttgart-gmbh,rb-18,#009c48,#ffffff,,rectangle,Q131583989
-sweg-stuttgart,RE 18,sweg-bahn-stuttgart-gmbh,re-18,#009c48,#ffffff,,rectangle,Q131583931
-sweg-stuttgart,RB 10a,sweg-bahn-stuttgart-gmbh,rb-10a,#014f9f,#ffffff,,rectangle,Q131587496
-sweg-sudwest,RB 42,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb42,#088c3c,#ffffff,,rectangle,
-sweg-sudwest,RB 42a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb42a,#f06c1c,#ffffff,,rectangle,
-sweg-sudwest,RB 43,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb43,#089ce4,#ffffff,,rectangle,
-sweg-sudwest,RB 43a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb43a,#b8941c,#ffffff,,rectangle,
-sweg-sudwest,RB 59a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb59a,#ffc734,#ffffff,,rectangle,
-sweg-sudwest,RB 66,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb66,#014f9f,#ffffff,,rectangle,
-sweg-sudwest,RB 67,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb67,#00a9df,#ffffff,,rectangle,
-sweg-sudwest,RB 68,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb68,#ec2933,#ffffff,,rectangle,
-sweg-sudwest,RB 69,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb69,#f27320,#ffffff,,rectangle,
-sweg-sudwest,RS 1,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs1,#1d4e9e,#ffffff,,pill,
-sweg-sudwest,RS 11,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs11,#009ddb,#ffffff,,pill,
-sweg-sudwest,RS 12,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs12,#74ba24,#ffffff,,pill,
-sweg-sudwest,RS 2,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs2,#fbc707,#ffffff,,pill,
-sweg-sudwest,RS 4,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs4,#d91338,#ffffff,,pill,
-tlx,L2,trilex-die-landerbahn-gmbh-dlb,tl-l2,#0f7ec0,#ffffff,,rectangle-rounded-corner,
-tlx,L24,trilex-die-landerbahn-gmbh-dlb,tl-l24,#6eae47,#ffffff,,rectangle-rounded-corner,
-tlx,L4,trilex-die-landerbahn-gmbh-dlb,tl-l4,#242320,#ffffff,,rectangle-rounded-corner,
-tlx,L7,trilex-die-landerbahn-gmbh-dlb,tl-l7,#ea7b09,#ffffff,,rectangle-rounded-corner,
-tlx,RB60,trilex-die-landerbahn-gmbh-dlb,tl-rb60,#569b6d,#ffffff,,rectangle-rounded-corner,
-tlx,RB61,trilex-die-landerbahn-gmbh-dlb,tl-rb61,#438577,#ffffff,,rectangle-rounded-corner,
-tlx,RE1,trilex-express-die-landerbahn-gmbh-dlb,tlx-re1,#e97b3b,#ffffff,,rectangle-rounded-corner,
-tlx,RE2,trilex-express-die-landerbahn-gmbh-dlb,tlx-re2,#db031c,#ffffff,,rectangle-rounded-corner,
-tlx,T9,trilex-die-landerbahn-gmbh-dlb,tl-t9,#f6b90b,#ffffff,,rectangle-rounded-corner,
-tnw-blt,10,baselland-transport,8-850037-10,#fbc707,#000000,,rectangle-rounded-corner,
-tnw-blt,11,baselland-transport,8-850037-11,#ed1c24,#ffffff,,rectangle-rounded-corner,
-tnw-blt,E11,baselland-transport,8-850037-e11,#ed1c24,#ffffff,,rectangle-rounded-corner,
-tnw-blt,17,baselland-transport,8-850037-17,#00adef,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,1,basler-verkehrsbetriebe,8-85bvb-1,#7a4a30,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,2,basler-verkehrsbetriebe,8-85bvb-2,#9e7c46,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,3,basler-verkehrsbetriebe,8-85bvb-3,#3948a4,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,6,basler-verkehrsbetriebe,8-85bvb-6,#176fc1,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,8,basler-verkehrsbetriebe,8-85bvb-8,#f24dae,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,14,basler-verkehrsbetriebe,8-85bvb-14,#f47216,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,15,basler-verkehrsbetriebe,8-85bvb-15,#00a650,#ffffff,,rectangle-rounded-corner,
-tnw-bvb,16,basler-verkehrsbetriebe,8-85bvb-16,#99d420,#000000,,rectangle-rounded-corner,
-tnw-bvb,21,basler-verkehrsbetriebe,8-85bvb-21,#1ab19c,#ffffff,,rectangle-rounded-corner,
-uestra,1,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-1,#ffffff,#2c2e35,#ff2e3e,rectangle,
-uestra,2,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-2,#ffffff,#2c2e35,#ff2e3e,rectangle,
-uestra,3,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-3,#ffffff,#2c2e35,#0073c0,rectangle,
-uestra,4,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-4,#ffffff,#2c2e35,#ffac2e,rectangle,
-uestra,5,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-5,#ffffff,#2c2e35,#ffac2e,rectangle,
-uestra,6,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-6,#ffffff,#2c2e35,#ffac2e,rectangle,
-uestra,7,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-7,#ffffff,#2c2e35,#0073c0,rectangle,
-uestra,8,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-8,#ffffff,#2c2e35,#ff2e3e,rectangle,
-uestra,9,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-9,#ffffff,#2c2e35,#0073c0,rectangle,
-uestra,10,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-10,#ffffff,#2c2e35,#6dc248,rectangle,
-uestra,11,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-11,#ffffff,#2c2e35,#ffac2e,rectangle,
-uestra,12,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-12,#ffffff,#2c2e35,#6dc248,rectangle,
-uestra,13,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-13,#ffffff,#2c2e35,#0073c0,rectangle,
-uestra,17,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-17,#ffffff,#2c2e35,#6dc248,rectangle,
-uestra,100,,5-webueb-100,#ffffff,#2c2e35,#fb3199,pill,
-uestra,120,,5-webueb-120,#ffffff,#2c2e35,#ff9027,pill,
-uestra,121,,5-webueb-121,#ffffff,#2c2e35,#95cc45,pill,
-uestra,122,,5-webueb-122,#ffffff,#2c2e35,#95cc45,pill,
-uestra,123,,5-webueb-123,#ffffff,#2c2e35,#fc87bf,pill,
-uestra,124,,5-webueb-124,#ffffff,#2c2e35,#95cc45,pill,
-uestra,125,,5-webueb-125,#ffffff,#2c2e35,#ff2e17,pill,
-uestra,126,,5-webueb-126,#ffffff,#2c2e35,#ff2e17,pill,
-uestra,127,,5-webueb-127,#ffffff,#2c2e35,#ffbe32,pill,
-uestra,128,,5-webueb-128,#ffffff,#2c2e35,#af2a21,pill,
-uestra,129,,5-webueb-129,#ffffff,#2c2e35,#fc5cac,pill,
-uestra,130,,5-webueb-130,#ffffff,#2c2e35,#95cc45,pill,
-uestra,133,,5-webueb-133,#ffffff,#2c2e35,#ffbe32,pill,
-uestra,134,,5-webueb-134,#ffffff,#2c2e35,#3ebc6d,pill,
-uestra,135,,5-webueb-135,#ffffff,#2c2e35,#3ebc6d,pill,
-uestra,136,,5-webueb-136,#ffffff,#2c2e35,#af2a21,pill,
-uestra,137,,5-webueb-137,#ffffff,#2c2e35,#ff9027,pill,
-uestra,200,,5-webueb-200,#ffffff,#2c2e35,#fc87bf,pill,
-uestra,253,,5-webueb-253,#ffffff,#2c2e35,#ff9027,pill,
-uestra,254,,5-webueb-254,#ffffff,#2c2e35,#35ccf6,pill,
-uestra,267,,5-webueb-267,#ffffff,#2c2e35,#3ebc6d,pill,
-uestra,330,,5-webueb-330,#ffffff,#2c2e35,#ffbe32,pill,
-uestra,340,,5-webueb-340,#ffffff,#2c2e35,#ff2e17,pill,
-uestra,341,,5-webueb-341,#ffffff,#2c2e35,#3ebc6d,pill,
-uestra,345,,5-webueb-345,#ffffff,#2c2e35,#ffbe32,pill,
-uestra,346,,5-webueb-346,#ffffff,#2c2e35,#903da0,pill,
-uestra,347,,5-webueb-347,#ffffff,#2c2e35,#ff9027,pill,
-uestra,348,,5-webueb-348,#ffffff,#2c2e35,#fc87bf,pill,
-uestra,363,,5-webueb-363,#ffffff,#2c2e35,#ff9027,pill,
-uestra,371,,5-webueb-371,#ffffff,#2c2e35,#0155ae,pill,
-uestra,372,,5-webueb-372,#ffffff,#2c2e35,#35ccf6,pill,
-uestra,373,,5-webueb-373,#ffffff,#2c2e35,#ff9027,pill,
-uestra,390,,5-webueb-390,#ffffff,#2c2e35,#95cc45,pill,
-uestra,420,,5-webueb-420,#ffffff,#2c2e35,#fc87bf,pill,
-uestra,450,,5-webueb-450,#ffffff,#2c2e35,#ffbe32,pill,
-uestra,470,,5-webueb-470,#ffffff,#2c2e35,#fc87bf,pill,
-uestra,480,,5-webueb-480,#ffffff,#2c2e35,#3ebc6d,pill,
-uestra,581,,5-webueb-581,#ffffff,#2c2e35,#903da0,pill,
-uestra,610,,5-webueb-610,#ffffff,#2c2e35,#3ebc6d,pill,
-uestra,611,,5-webueb-611,#ffffff,#2c2e35,#af2a21,pill,
-uestra,631,,5-webueb-631,#ffffff,#2c2e35,#95cc45,pill,
-uestra,800,,5-webueb-800,#ffffff,#2c2e35,#35ccf6,pill,
-vbb-bvg-tram,M1,,8-vbbbvt-m1,#63b9e9,#ffffff,,rectangle,
-vbb-bvg-tram,M2,,8-vbbbvt-m2,#7ab929,#ffffff,,rectangle,
-vbb-bvg-tram,M4,,8-vbbbvt-m4,#ca1214,#ffffff,,rectangle,
-vbb-bvg-tram,M5,,8-vbbbvt-m5,#c8893b,#ffffff,,rectangle,
-vbb-bvg-tram,M6,,8-vbbbvt-m6,#005695,#ffffff,,rectangle,
-vbb-bvg-tram,M8,,8-vbbbvt-m8,#ee7203,#ffffff,,rectangle,
-vbb-bvg-tram,M10,,8-vbbbvt-m10,#007b3d,#ffffff,,rectangle,
-vbb-bvg-tram,M13,,8-vbbbvt-m13,#00a092,#ffffff,,rectangle,
-vbb-bvg-tram,M17,,8-vbbbvt-m17,#a6422a,#ffffff,,rectangle,
-vbb-bvg-tram,12,,8-vbbbvt-12,#8870ab,#ffffff,,rectangle,
-vbb-bvg-tram,16,,8-vbbbvt-16,#007fab,#ffffff,,rectangle,
-vbb-bvg-tram,18,,8-vbbbvt-18,#d6ad00,#ffffff,,rectangle,
-vbb-bvg-tram,21,,8-vbbbvt-21-1498437-5841048,#bc90c1,#ffffff,,rectangle,
-vbb-bvg-tram,27,,8-vbbbvt-27,#cb621a,#ffffff,,rectangle,
-vbb-bvg-tram,37,,8-vbbbvt-37,#815238,#ffffff,,rectangle,
-vbb-bvg-tram,50,,8-vbbbvt-50,#eb9000,#ffffff,,rectangle,
-vbb-bvg-tram,60,,8-vbbbvt-60,#009bd9,#ffffff,,rectangle,
-vbb-bvg-tram,61,,8-vbbbvt-61,#e30613,#ffffff,,rectangle,
-vbb-bvg-tram,62,,8-vbbbvt-62,#00512d,#ffffff,,rectangle,
-vbb-bvg-tram,63,,8-vbbbvt-63,#ee7203,#ffffff,,rectangle,
-vbb-bvg-tram,67,,8-vbbbvt-67,#dd6ca6,#ffffff,,rectangle,
-vbb-bvg-tram,68,,8-vbbbvt-68,#65b32e,#ffffff,,rectangle,
-vbb-bvg-ubahn,U1,,7-vbbbvu-1,#7dad4c,#ffffff,,rectangle,
-vbb-bvg-ubahn,U2,,7-vbbbvu-2,#da421e,#ffffff,,rectangle,
-vbb-bvg-ubahn,U3,,7-vbbbvu-3,#16683d,#ffffff,,rectangle,
-vbb-bvg-ubahn,U4,,7-vbbbvu-4,#f0d722,#ffffff,,rectangle,
-vbb-bvg-ubahn,U5,,7-vbbbvu-5,#7e5330,#ffffff,,rectangle,
-vbb-bvg-ubahn,U6,,7-vbbbvu-6,#8c6dab,#ffffff,,rectangle,
-vbb-bvg-ubahn,U7,,7-vbbbvu-7,#009bd5,#ffffff,,rectangle,
-vbb-bvg-ubahn,U8,,7-vbbbvu-8,#224f86,#ffffff,,rectangle,
-vbb-bvg-ubahn,U9,,7-vbbbvu-9,#f3791d,#ffffff,,rectangle,
-vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,,pill,
-vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,,pill,
-vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,,pill,
-vbb-db-sbahn,S26,s-bahn-berlin,4-08-26,#047939,#ffffff,,pill,
-vbb-db-sbahn,S3,s-bahn-berlin,4-08-3,#026597,#ffffff,,pill,
-vbb-db-sbahn,S41,s-bahn-berlin,4-08-41,#aa3c1f,#ffffff,,pill,
-vbb-db-sbahn,S42,s-bahn-berlin,4-08-42,#ba622d,#ffffff,,pill,
-vbb-db-sbahn,S45,s-bahn-berlin,4-08-45,#aa3c1f,#ffffff,,pill,
-vbb-db-sbahn,S46,s-bahn-berlin,4-08-46,#ca8539,#ffffff,,pill,
-vbb-db-sbahn,S47,s-bahn-berlin,4-08-47,#ca8539,#ffffff,,pill,
-vbb-db-sbahn,S5,s-bahn-berlin,4-08-5,#ea561c,#ffffff,,pill,
-vbb-db-sbahn,S7,s-bahn-berlin,4-08-7,#764d9a,#ffffff,,pill,
-vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,,pill,
-vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,,pill,
-vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,,pill,
-vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,,pill,
-vbb-vip-bus,603,,5-vbbvib-603,#fca13d,#ffffff,,pill,
-vbb-vip-bus,605,,5-vbbvib-605,#c1732a,#ffffff,,pill,
-vbb-vip-bus,609,,5-vbbvib-609,#907d32,#ffffff,,pill,
-vbb-vip-bus,612,,5-vbbvib-612,#842a26,#ffffff,,pill,
-vbb-vip-bus,616,,5-vbbvib-616,#0155ae,#ffffff,,pill,
-vbb-vip-bus,638,,5-vbbvib-638,#665fb1,#ffffff,,pill,
-vbb-vip-bus,639,,5-vbbvib-639,#f0eef6,#9e9ace,#9e9ace,pill,
-vbb-vip-bus,690,,5-vbbvib-690,#446080,#ffffff,,pill,
-vbb-vip-bus,691,,5-vbbvib-691,#feeedd,#ff9027,#ff9027,pill,
-vbb-vip-bus,692,,5-vbbvib-692,#00b9f2,#ffffff,,pill,
-vbb-vip-bus,693,,5-vbbvib-693,#e36eb5,#ffffff,,pill,
-vbb-vip-bus,694,,5-vbbvib-694,#70a4b8,#ffffff,,pill,
-vbb-vip-bus,695,,5-vbbvib-695,#bf2a4f,#ffffff,,pill,
-vbb-vip-bus,696,,5-vbbvib-696,#eb2d4c,#ffffff,,pill,
-vbb-vip-bus,697,,5-vbbvib-697,#772382,#ffffff,,pill,
-vbb-vip-bus,698,,5-vbbvib-698,#117b40,#ffffff,,pill,
-vbb-vip-bus,699,,5-vbbvib-699,#d9992f,#ffffff,,pill,
-vbb-vip-bus,X5,,5-vbbvib-x5,#f2e6f1,#b167b3,#b167b3,pill,
-vbb-vip-bus,X15,,5-vbbvib-x15,#ffffff,#49c07d,#49c07d,pill,
-vbb-vip-bus,N14,,5-vbbvib-n14,#ffa32b,#ffffff,,pill,
-vbb-vip-bus,N15,,5-vbbvib-n15,#ff7322,#ffffff,,pill,
-vbb-vip-bus,N16,,5-vbbvib-n16,#009edd,#ffffff,,pill,
-vbb-vip-bus,N17,,5-vbbvib-n17,#5fbf49,#ffffff,,pill,
-vbb-vip-tram,91,,8-vbbvit-91,#ff2e17,#ffffff,,rectangle,
-vbb-vip-tram,92,,8-vbbvit-92,#024890,#ffffff,,rectangle,
-vbb-vip-tram,93,,8-vbbvit-93,#ff7322,#ffffff,,rectangle,
-vbb-vip-tram,94,,8-vbbvit-94,#89969e,#ffffff,,rectangle,
-vbb-vip-tram,96,,8-vbbvit-96,#00b098,#ffffff,,rectangle,
-vbb-vip-tram,98,,8-vbbvit-98,#daedf9,#009edd,#009edd,rectangle,
-vbb-vip-tram,99,,8-vbbvit-99,#5fbf49,#ffffff,,rectangle,
-vbg,RB 1,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb1,#e30613,#ffffff,,rectangle-rounded-corner,
-vbg,RB 2,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb2,#0067b0,#ffffff,,rectangle-rounded-corner,
-vbg,RB 4,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb4,#954b3f,#ffffff,,rectangle-rounded-corner,
-vbg,RB 5,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb5,#009641,#ffffff,,rectangle-rounded-corner,
-vbn-bsag,1,bremer-strassenbahn-ag,8-webbtr-1,#00a54f,#ffffff,,rectangle,
-vbn-bsag,1E,bremer-strassenbahn-ag,8-webbtr-1e,#00a54f,#ffffff,,rectangle,
-vbn-bsag,1S,bremer-strassenbahn-ag,8-webbtr-1s,#00a54f,#ffffff,,rectangle,
-vbn-bsag,2,bremer-strassenbahn-ag,8-webbtr-2,#0166b3,#ffffff,,rectangle,
-vbn-bsag,3,bremer-strassenbahn-ag,8-webbtr-3,#00aeef,#ffffff,,rectangle,
-vbn-bsag,4,bremer-strassenbahn-ag,8-webbtr-4,#ee1d23,#ffffff,,rectangle,
-vbn-bsag,4S,bremer-strassenbahn-ag,8-webbtr-4s,#ee1d23,#ffffff,,rectangle,
-vbn-bsag,5,bremer-strassenbahn-ag,8-webbtr-5,#00aab8,#ffffff,,rectangle,
-vbn-bsag,5S,bremer-strassenbahn-ag,8-webbtr-5s,#00aab8,#ffffff,,rectangle,
-vbn-bsag,6,bremer-strassenbahn-ag,8-webbtr-6,#feca0a,#000000,,rectangle,
-vbn-bsag,6E,bremer-strassenbahn-ag,8-webbtr-6e,#feca0a,#000000,,rectangle,
-vbn-bsag,8,bremer-strassenbahn-ag,8-webbtr-8,#8bc63e,#ffffff,,rectangle,
-vbn-bsag,10,bremer-strassenbahn-ag,8-webbtr-10,#15258e,#ffffff,,rectangle,
-vbn-bsag,20,,5-webbbu-20,#8bc63e,#ffffff,,pill,
-vbn-bsag,21,,5-webbbu-21,#00aeef,#ffffff,,pill,
-vbn-bsag,22,,5-webbbu-22,#a69dcd,#ffffff,,pill,
-vbn-bsag,24,,5-webbbu-24,#951b81,#ffffff,,pill,
-vbn-bsag,25,,5-webbbu-25,#009640,#ffffff,,pill,
-vbn-bsag,26,,5-webbbu-26,#e30613,#ffffff,,pill,
-vbn-bsag,27,,5-webbbu-27,#ef7d00,#ffffff,,pill,
-vbn-bsag,28,,5-webbbu-28,#ffcc00,#000000,,pill,
-vbn-bsag,29,,5-webbbu-29,#95c11f,#ffffff,,pill,
-vbn-bsag,31,,5-webbbu-31,#95c11f,#ffffff,,pill,
-vbn-bsag,33,,5-webbbu-33,#ffcc00,#000000,,pill,
-vbn-bsag,34,,5-webbbu-34,#ffcc00,#000000,,pill,
-vbn-bsag,37,,5-webbbu-37,#951b81,#ffffff,,pill,
-vbn-bsag,38,,5-webbbu-38,#ffcc00,#000000,,pill,
-vbn-bsag,39,,5-webbbu-39,#ffcc00,#000000,,pill,
-vbn-bsag,40,,5-webbbu-40,#e30613,#ffffff,,pill,
-vbn-bsag,41,,5-webbbu-41,#e30613,#ffffff,,pill,
-vbn-bsag,41S,,5-webbbu-41s,#e30613,#ffffff,,pill,
-vbn-bsag,42,,5-webbbu-42,#ffcc00,#000000,,pill,
-vbn-bsag,44,,5-webbbu-44,#ef7d00,#ffffff,,pill,
-vbn-bsag,52,,5-webbbu-52,#94c01f,#ffffff,,pill,
-vbn-bsag,55,,5-webbbu-55,#ffcc00,#000000,,pill,
-vbn-bsag,57,,5-webbbu-57,#ef7d00,#ffffff,,pill,
-vbn-bsag,58,,5-webbbu-58,#ef7d00,#ffffff,,pill,
-vbn-bsag,61,,5-webbbu-61,#009fe3,#ffffff,,pill,
-vbn-bsag,62,,5-webbbu-62,#009640,#ffffff,,pill,
-vbn-bsag,63,,5-webbbu-63,#312783,#ffffff,,pill,
-vbn-bsag,63S,,5-webvol-63s,#312783,#ffffff,,pill,
-vbn-bsag,65,,5-webbbu-65,#94c01f,#ffffff,,pill,
-vbn-bsag,66,,5-webbbu-66,#94c01f,#ffffff,,pill,
-vbn-bsag,80,,5-webbbu-80,#94c01f,#ffffff,,pill,
-vbn-bsag,81,,5-webbbu-81,#009640,#ffffff,,pill,
-vbn-bsag,82,,5-webbbu-82,#ef7d00,#ffffff,,pill,
-vbn-bsag,90,,5-webbbu-90,#312783,#ffffff,,pill,
-vbn-bsag,91,,5-webbbu-91,#009fe3,#ffffff,,pill,
-vbn-bsag,92,,5-webbbu-92,#009fe3,#ffffff,,pill,
-vbn-bsag,93,,5-webbbu-93,#ffcc00,#000000,,pill,
-vbn-bsag,94,,5-webbbu-94,#e30613,#ffffff,,pill,
-vbn-bsag,95,,5-webbbu-95,#ef7d00,#ffffff,,pill,
-vbn-bsag,96,,5-webbbu-96,#951b81,#ffffff,,pill,
-vbn-bsag,98,,5-webbbu-98,#009640,#ffffff,,pill,
-vbn-nwb-regio-s-bahn,RS 1,nordwestbahn,4-n1-rs1,#00448b,#ffffff,,rectangle-rounded-corner,
-vbn-nwb-regio-s-bahn,RS 2,nordwestbahn,4-n1-rs2,#e89023,#ffffff,,rectangle-rounded-corner,
-vbn-nwb-regio-s-bahn,RS 3,nordwestbahn,4-n1-rs3,#93bf30,#ffffff,,rectangle-rounded-corner,
-vbn-nwb-regio-s-bahn,RS 30,nordwestbahn,4-n1-rs30,#4faf3b,#ffffff,,rectangle-rounded-corner,
-vbn-nwb-regio-s-bahn,RS 4,nordwestbahn,4-n1-rs4,#e2000b,#ffffff,,rectangle-rounded-corner,
-vbn-nwb-regio-s-bahn,RS 6,nordwestbahn,4-n1-rs6,#899bb9,#ffffff,,rectangle-rounded-corner,
-vgn-db-sbn,S 1,db-regio-ag-bayern,4-800721-1,#92292e,#ffffff,,rectangle,
-vgn-db-sbn,S 2,db-regio-ag-bayern,4-800721-2,#4dbd38,#ffffff,,rectangle,
-vgn-db-sbn,S 3,db-regio-ag-bayern,4-800721-3,#f1471d,#ffffff,,rectangle,
-vgn-db-sbn,S 4,db-regio-ag-bayern,4-800721-4,#2c3797,#ffffff,,rectangle,
-vgn-db-sbn,S 5,db-regio-ag-bayern,4-800721-5,#0c7bc1,#ffffff,,rectangle,
-vgn-db-sbn,S 6,db-regio-ag-bayern,4-800721-6,#95af33,#ffffff,,rectangle,
-vgn-estw-bus,280,,5-estbus-280,#68709b,#ffffff,,pill,
-vgn-estw-bus,281,,5-estbus-281,#9b853c,#ffffff,,pill,
-vgn-estw-bus,281T,,9-estbus-281t,#9b853c,#ffffff,,pill,
-vgn-estw-bus,283,,5-estbus-283,#bfde47,#ffffff,,pill,
-vgn-estw-bus,283T,,9-estbus-283t,#bfde47,#ffffff,,pill,
-vgn-estw-bus,284,,5-estbus-284,#722671,#ffffff,,pill,
-vgn-estw-bus,285,,5-estbus-285,#ca028c,#ffffff,,pill,
-vgn-estw-bus,285T,,9-estbus-285t,#ca028c,#ffffff,,pill,
-vgn-estw-bus,286,,5-estbus-286,#bf9e30,#ffffff,,pill,
-vgn-estw-bus,287,,5-estbus-287,#f5ec42,#ffffff,,pill,
-vgn-estw-bus,287T,,9-estbus-287t,#f5ec42,#ffffff,,pill,
-vgn-estw-bus,289,,5-estbus-289,#6ca6c5,#ffffff,,pill,
-vgn-estw-bus,290,,5-estbus-290,#405eaf,#ffffff,,pill,
-vgn-estw-bus,293,,5-estbus-293,#1e0061,#ffffff,,pill,
-vgn-estw-bus,293T,,9-estbus-293t,#1e0061,#ffffff,,pill,
-vgn-estw-bus,294,,5-estbus-294,#b15f9e,#ffffff,,pill,
-vgn-estw-bus,295,,5-estbus-295,#5b9ba3,#ffffff,,pill,
-vgn-estw-bus,296,,5-estbus-296,#7bbfef,#ffffff,,pill,
-vgn-estw-bus,298,,5-estbus-298,#4d8d50,#ffffff,,pill,
-vgn-estw-bus,299,,5-estbus-299,#cb2e32,#ffffff,,pill,
-vgn-infra-bus,171,,5-fuebus-171,#b61a58,#ffffff,,pill,
-vgn-infra-bus,172,,5-fuebus-172,#d57536,#ffffff,,pill,
-vgn-infra-bus,173,,5-fuebus-173,#a6c2e7,#ffffff,,pill,
-vgn-infra-bus,174,,5-fuebus-174,#94622f,#ffffff,,pill,
-vgn-infra-bus,175,,5-fuebus-175,#d15b89,#ffffff,,pill,
-vgn-infra-bus,176,,5-fuebus-176,#f0db61,#151515,,pill,
-vgn-infra-bus,177,,5-fuebus-177,#6b8eb2,#ffffff,,pill,
-vgn-infra-bus,178,,5-fuebus-178,#b189b5,#ffffff,,pill,
-vgn-infra-bus,179,,5-fuebus-179,#728239,#ffffff,,pill,
-vgn-infra-bus,189,,5-fuebus-189,#7c2b1a,#ffffff,,pill,
-vgn-swh-bus,1501,,5-hof004-1501,#914284,#ffffff,,pill,
-vgn-swh-bus,1502,,5-hof004-1502,#6ba8eb,#ffffff,,pill,
-vgn-swh-bus,1503,,5-hof004-1503,#36208e,#ffffff,,pill,
-vgn-swh-bus,1504,,5-hof004-1504,#cb2e32,#ffffff,,pill,
-vgn-swh-bus,1505,,5-hof004-1505,#ca028c,#ffffff,,pill,
-vgn-swh-bus,1506,,5-hof004-1506,#9a90c5,#ffffff,,pill,
-vgn-swh-bus,1507,,5-hof004-1507,#85c3cd,#ffffff,,pill,
-vgn-swh-bus,1508,,5-hof004-1508,#edd03e,#ffffff,,pill,
-vgn-swh-bus,1509,,5-hof004-1509,#d98838,#ffffff,,pill,
-vgn-swh-bus,1510,,5-hof004-1510,#dd9998,#ffffff,,pill,
-vgn-swh-bus,1511,,5-hof004-1511,#5ca755,#ffffff,,pill,
-vgn-swh-bus,1512,,5-hof004-1512,#b0d24d,#ffffff,,pill,
-vgn-swh-bus,1513,,5-hof004-1513,#dd9998,#ffffff,,pill,
-vgn-swh-bus,1514,,5-hof004-1514,#d98838,#ffffff,,pill,
-vgn-swh-bus,1515,,5-hof004-1515,#ca028c,#ffffff,,pill,
-vgn-swh-bus,1516,,5-hof004-1516,#a0cff3,#ffffff,,pill,
-vgn-swh-bus,1517,,5-hof004-1517,#edd14c,#ffffff,,pill,
-vgn-swh-bus,1518,,5-hof004-1518,#9086bf,#ffffff,,pill,
-vgn-vag-tram,4,,8-vanstr-4,#f46989,#ffffff,,rectangle,
-vgn-vag-tram,5,,8-vanstr-5,#8a3ea3,#ffffff,,rectangle,
-vgn-vag-tram,6,,8-vanstr-6,#fcf105,#151515,,rectangle,
-vgn-vag-tram,7,,8-vanstr-7,#9ba1d9,#ffffff,,rectangle,
-vgn-vag-tram,8,,8-vanstr-8,#32bdf2,#ffffff,,rectangle,
-vgn-vag-tram,11,,8-vanstr-11,#db994d,#ffffff,,rectangle,
-vgn-vag-tram,10,,8-vanstr-10,#c94f82,#ffffff,,rectangle,
-vgn-vag-ubahn,U 1,,7-vanuba-1,#1c62aa,#ffffff,,rectangle,
-vgn-vag-ubahn,U 2,,7-vanuba-2,#ed1c24,#ffffff,,rectangle,
-vgn-vag-ubahn,U 3,,7-vanuba-3,#4dc2bb,#ffffff,,rectangle,
-vias,RB10,vias-gmbh,via-rb10,#e3a02e,#ffffff,,rectangle-rounded-corner,
-vlexx,RE3,vlexx,re-3,#e3a023,#ffffff,,rectangle-rounded-corner,
-vlexx,RE17,vlexx,re-17,#c77db4,#ffffff,,rectangle-rounded-corner,
-vmt-evag-tram,1,,8-rmteva-1,#f18700,#ffffff,,rectangle,
-vmt-evag-tram,2,,8-rmteva-2,#e3000b,#ffffff,,rectangle,
-vmt-evag-tram,3,,8-rmteva-3,#67095f,#ffffff,,rectangle,
-vmt-evag-tram,4,,8-rmteva-4,#007ac3,#ffffff,,rectangle,
-vmt-evag-tram,5,,8-rmteva-5,#00883c,#ffffff,,rectangle,
-vmt-evag-tram,6,,8-rmteva-6,#78ac28,#ffffff,,rectangle,
-vmt-jena-bus,10,,5-rmtjnv-10,#77c3ee,#ffffff,,pill,
-vmt-jena-bus,11,,5-rmtjnv-11,#2f277e,#ffffff,,pill,
-vmt-jena-bus,12,,5-rmtjnv-12,#4295b9,#ffffff,,pill,
-vmt-jena-bus,14,,5-rmtjnv-14,#44995d,#ffffff,,pill,
-vmt-jena-bus,15,,5-rmtjnv-15,#3a847a,#ffffff,,pill,
-vmt-jena-bus,16,,5-rmtjnv-16,#80bc9c,#ffffff,,pill,
-vmt-jena-bus,17,,5-rmtjnv-17,#d8592b,#ffffff,,pill,
-vmt-jena-bus,18,,5-rmtjnv-18,#42944b,#ffffff,,pill,
-vmt-jena-bus,28,,5-rmtjnv-28,#85b64c,#ffffff,,pill,
-vmt-jena-bus,41,,5-rmtjnv-41,#bc587d,#ffffff,,pill,
-vmt-jena-bus,42,,5-rmtjnv-42,#931e41,#ffffff,,pill,
-vmt-jena-bus,43,,5-rmtjnv-43,#9ac9d4,#ffffff,,pill,
-vmt-jena-bus,43A,,5-rmtjnv-43a,#9ac9d4,#ffffff,,pill,
-vmt-jena-bus,44,,5-rmtjnv-44,#2f6d95,#ffffff,,pill,
-vmt-jena-bus,47,,5-rmtjnv-47,#665a9d,#ffffff,,pill,
-vmt-jena-bus,48,,5-rmtjnv-48,#c3c66d,#ffffff,,pill,
-vmt-jena-tram,1,,8-rmtjnv-1,#d8592b,#ffffff,,rectangle,
-vmt-jena-tram,2,,8-rmtjnv-2,#f0ba46,#ffffff,,rectangle,
-vmt-jena-tram,4,,8-rmtjnv-4,#c92d24,#ffffff,,rectangle,
-vmt-jena-tram,5,,8-rmtjnv-5,#633271,#ffffff,,rectangle,
-vor-oebb,S1,osterreichische-bundesbahnen,4-81-1-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S2,osterreichische-bundesbahnen,4-81-2-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S3,osterreichische-bundesbahnen,4-81-3-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S4,osterreichische-bundesbahnen,4-81-4-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S7,osterreichische-bundesbahnen,4-81-7,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S40,osterreichische-bundesbahnen,4-81-40,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S45,osterreichische-bundesbahnen,4-81-45,#c8d200,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S50,osterreichische-bundesbahnen,4-81-50,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S60,osterreichische-bundesbahnen,4-81-60,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-oebb,S80,osterreichische-bundesbahnen,4-81-80,#0097d5,#ffffff,,rectangle-rounded-corner,
-vor-wl,18,wiener-linien,8-810009-18,#c00808,#ffffff,,rectangle,
-vor-wl,U1,wiener-linien,7-810009-1,#e3000f,#ffffff,,rectangle,
-vor-wl,U2,wiener-linien,7-810009-2,#a862a4,#ffffff,,rectangle,
-vor-wl,U3,wiener-linien,7-810009-3,#ef7c00,#ffffff,,rectangle,
-vor-wl,U4,wiener-linien,7-810009-4,#00963f,#ffffff,,rectangle,
-vor-wl,U6,wiener-linien,7-810009-6,#9d6830,#ffffff,,rectangle,
-vos-osnabrueck,10,,5-webos1-10,#8c61a0,#ffffff,,rectangle,
-vos-osnabrueck,12,,5-web-os-12,#2c247d,#ffffff,,rectangle,
-vos-osnabrueck,13,,5-webvos-13,#469cde,#ffffff,,rectangle,
-vos-osnabrueck,14,,5-webos1-14,#dc6d2b,#ffffff,,rectangle,
-vos-osnabrueck,15,,5-webos1-15,#eba83b,#ffffff,,rectangle,
-vos-osnabrueck,16,,5-webos1-16,#347841,#ffffff,,rectangle,
-vos-osnabrueck,17,,5-webos1-17,#4aa563,#ffffff,,rectangle,
-vos-osnabrueck,18,,5-webosv-18,#3479bd,#ffffff,,rectangle,
-vos-osnabrueck,19,,5-webosv-19,#1f4d98,#ffffff,,rectangle,
-vos-osnabrueck,20,,5-webos1-20,#8c61a0,#ffffff,,rectangle,
-vos-osnabrueck,21,,5-webos1-21,#8c61a0,#ffffff,,rectangle,
-vos-osnabrueck,M1,,5-webos1-m1,#408f54,#ffffff,,rectangle,
-vos-osnabrueck,M2,,5-webos1-m2,#30277e,#ffffff,,rectangle,
-vos-osnabrueck,M3,,5-webos1-m3,#9ebf43,#ffffff,,rectangle,
-vos-osnabrueck,M4,,5-webos1-m4,#c42f26,#ffffff,,rectangle,
-vos-osnabrueck,M5,,5-webos1-m5,#d35b95,#ffffff,,rectangle,
-vr,A,vr,4-10-a,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874158
-vr,D,vr,4-10-d,#58a618,#ffffff,,rectangle-rounded-corner,Q118874955
-vr,E,vr,4-10-e,#8c4799,#ffffff,,rectangle-rounded-corner,Q118869683
-vr,G,vr,4-10-g,#58a618,#ffffff,,rectangle-rounded-corner,Q118923662
-vr,H,vr,4-10-h,#58a618,#ffffff,,rectangle-rounded-corner,Q130430491
-vr,I,vr,4-10-i,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874956
-vr,K,vr,4-10-k,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874957
-vr,L,vr,4-10-l,#8c4799,#ffffff,,rectangle-rounded-corner,Q118869556
-vr,M,vr,4-10-m,#58a618,#ffffff,,rectangle-rounded-corner,Q118902123
-vr,O,vr,4-10-o,#58a618,#ffffff,,rectangle-rounded-corner,Q118924451
-vr,P,vr,4-10-p,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874962
-vr,R,vr,4-10-r,#58a618,#ffffff,,rectangle-rounded-corner,Q118874959
-vr,T,vr,4-10-t,#58a618,#ffffff,,rectangle-rounded-corner,Q118874961
-vr,U,vr,4-10-u,#8c4799,#ffffff,,rectangle-rounded-corner,Q118869424
-vr,Y,vr,4-10-y,#8c4799,#ffffff,,rectangle-rounded-corner,Q118868930
-vr,Z,vr,4-10-z,#58a618,#ffffff,,rectangle-rounded-corner,Q118874964
-vrn-hetzler-pfadt,550,hetzler-pfadt,5-vrn028-550,#4f3599,#ffffff,,pill,
-vrn-hetzler-pfadt,552,hetzler-pfadt,5-vrn028-552,#fe3b85,#ffffff,,pill,
-vrn-hetzler-pfadt,553,hetzler-pfadt,5-vrn028-553,#ff5725,#ffffff,,pill,
-vrn-hetzler-pfadt,554,hetzler-pfadt,5-vrn028-554,#ff902c,#ffffff,,pill,
-vrn-hetzler-pfadt,555,hetzler-pfadt,5-vrn028-555,#102694,#ffffff,,pill,
-vrn-hetzler-pfadt,595,hetzler-pfadt,5-vrn028-595,#1c6836,#ffffff,,pill,
-vrn-palatinabus,507,palatinabus,5-vrn032-507,#ab6f42,#ffffff,,pill,
-vrn-palatinabus,591,palatinabus,5-vrn032-591,#2faf9f,#ffffff,,pill,
-vrn-qnv-queichtal-nahverkehr,539,qnv-queichtal-nahverkehr,5-vrn050-539,#c1b89d,#ffffff,,pill,
-vrn-qnv-queichtal-nahverkehr,540,qnv-queichtal-nahverkehr,5-vrn050-540,#6e6353,#ffffff,,pill,
-vrn-qnv-queichtal-nahverkehr,590,qnv-queichtal-nahverkehr,5-vrn050-590,#ffc53f,#ffffff,,pill,
-vrn-qnv-queichtal-nahverkehr,599,qnv-queichtal-nahverkehr,5-vrn050-599,#ff2f1a,#ffffff,,pill,
-vrn-regionalbus,625,,5-vrn033-625,#0e6e46,#ffffff,,pill,
-vrn-regionalbus,626,,5-vrn033-626,#509fc8,#ffffff,,pill,
-vrn-regionalbus,627,,5-vrn033-627,#6e1430,#ffffff,,pill,
-vrn-regionalbus,628,,5-vrn033-628,#007abe,#ffffff,,pill,
-vrn-regionalbus,629,,5-vrn033-629,#034c53,#ffffff,,pill,
-vrn-regionalbus,630,busverkehr-rhein-neckar,5-rbgbrn-630,#ff2e17,#ffffff,,pill,
-vrn-rheinpfalzbus,546,rheinpfalzbus,5-rbprpb-546,#45ba4b,#ffffff,,pill,
-vrn-rheinpfalzbus,547,rheinpfalzbus,5-rbprpb-547,#8e5a38,#ffffff,,pill,
-vrn-rheinpfalzbus,548,rheinpfalzbus,5-rbprpb-548,#3bb4e5,#ffffff,,pill,
-vrn-rheinpfalzbus,549,rheinpfalzbus,5-rbprpb-549,#ec7aba,#ffffff,,pill,
-vrn-rheinpfalzbus,556,rheinpfalzbus,5-rbprpb-556,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,557,rheinpfalzbus,5-rbprpb-557,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,558,rheinpfalzbus,5-rbprpb-558,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,559,rheinpfalzbus,5-rbprpb-559,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,593,rheinpfalzbus,5-rbprpb-593,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,594,rheinpfalzbus,5-rbprpb-594,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,596,rheinpfalzbus,5-rbprpb-596,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rheinpfalzbus,598,rheinpfalzbus,5-rbprpb-598,#7f9e6b,#ffffff,#5e6e6f,pill,
-vrn-rnv-bus,5,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,5-vrnoeg-5-967040-5496598,#00965e,#ffffff,,pill,
-vrn-rnv-bus,20,,5-vrn019-20,#e07500,#ffffff,,pill,
-vrn-rnv-bus,20A,,5-vrn019-20a,#e07500,#ffffff,,pill,
-vrn-rnv-bus,27,,5-vrn019-21,#91c46d,#ffffff,,pill,
-vrn-rnv-bus,28,,5-vrn019-28,#b09fcd,#ffffff,,pill,
-vrn-rnv-bus,28A,,5-vrn019-28a,#b09fcd,#ffffff,,pill,
-vrn-rnv-bus,29,,5-vrn019-29,#00bbef,#ffffff,,pill,
-vrn-rnv-bus,30,,5-vrn019-30,#b2a0ce,#ffffff,,pill,
-vrn-rnv-bus,31,,5-vrn019-31,#4794d1,#ffffff,,pill,
-vrn-rnv-bus,32,,5-vrn019-32,#580600,#ffffff,,pill,
-vrn-rnv-bus,33,,5-vrn019-33,#e3000b,#ffffff,,pill,
-vrn-rnv-bus,34,,5-vrn019-34,#139cd9,#ffffff,,pill,
-vrn-rnv-bus,35,,5-vrn019-35,#946b25,#ffffff,,pill,
-vrn-rnv-bus,36,,5-vrn019-36,#008f88,#ffffff,,pill,
-vrn-rnv-bus,36A,,5-vrn019-36a,#008f88,#ffffff,,pill,
-vrn-rnv-bus,37,,5-vrn019-37,#91c46d,#ffffff,,pill,
-vrn-rnv-bus,38,,5-vrn019-38,#0096b5,#ffffff,,pill,
-vrn-rnv-bus,39,,5-vrn019-39,#4c2183,#ffffff,,pill,
-vrn-rnv-bus,39A,,5-vrn019-39a,#4c2183,#ffffff,,pill,
-vrn-rnv-bus,40,,5-vrn017-40,#4c2182,#ffffff,,pill,
-vrn-rnv-bus,42,,5-vrn017-42,#a1c3d5,#ffffff,,pill,
-vrn-rnv-bus,43,,5-vrn017-43,#4896d2,#ffffff,,pill,
-vrn-rnv-bus,44,,5-vrn017-44,#009992,#ffffff,,pill,
-vrn-rnv-bus,45,,5-vrn017-45,#0068b4,#ffffff,,pill,
-vrn-rnv-bus,46,,5-vrn017-46,#a89ab1,#ffffff,,pill,
-vrn-rnv-bus,47,,5-vrn017-47,#82d0f5,#ffffff,,pill,
-vrn-rnv-bus,48,,5-vrn017-48,#009ee3,#ffffff,,pill,
-vrn-rnv-bus,49,,5-vrn017-49,#ffffff,#00963e,#00963e,pill,
-vrn-rnv-bus,50,,5-vrn017-50,#91c46d,#ffffff,,pill,
-vrn-rnv-bus,51,,5-vrn017-51,#0068b4,#ffffff,,pill,
-vrn-rnv-bus,52,,5-vrn017-52,#a89ab1,#ffffff,,pill,
-vrn-rnv-bus,53,,5-vrn017-53,#00bbee,#ffffff,,pill,
-vrn-rnv-bus,54,,5-vrn017-54,#b19fcd,#ffffff,,pill,
-vrn-rnv-bus,55,,5-vrn017-55,#4c2182,#ffffff,,pill,
-vrn-rnv-bus,56,,5-vrn017-56,#00bbee,#ffffff,,pill,
-vrn-rnv-bus,57,,5-vrn017-57,#5ac5f2,#ffffff,,pill,
-vrn-rnv-bus,58,,5-vrn017-58,#a1c3d5,#ffffff,,pill,
-vrn-rnv-bus,59,,5-vrn017-59,#a89ab1,#ffffff,,pill,
-vrn-rnv-bus,60,,5-vrn017-60,#4c2182,#ffffff,,pill,
-vrn-rnv-bus,61,,5-vrn017-61,#4896d2,#ffffff,,pill,
-vrn-rnv-bus,62,,5-vrn017-62,#a89ab1,#ffffff,,pill,
-vrn-rnv-bus,63,,5-vrn017-63,#a1c3d5,#ffffff,,pill,
-vrn-rnv-bus,64,,5-vrn017-64,#0090a5,#ffffff,,pill,
-vrn-rnv-bus,65,,5-vrn017-65,#8ac5bd,#ffffff,,pill,
-vrn-rnv-bus,66,,5-vrn017-66,#e5007c,#ffffff,,pill,
-vrn-rnv-bus,67,,5-vrn017-67,#e17500,#ffffff,,pill,
-vrn-rnv-tram,1,rhein-neckar-verkehr-gmbh,8-vrn008-1,#f39b9a,#ffffff,,rectangle,
-vrn-rnv-tram,2,rhein-neckar-verkehr-gmbh,8-vrn008-2,#b00044,#ffffff,,rectangle,
-vrn-rnv-tram,3,rhein-neckar-verkehr-gmbh,8-vrn008-3,#d5ad00,#ffffff,,rectangle,
-vrn-rnv-tram,4,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4,#e3000b,#ffffff,,rectangle,
-vrn-rnv-tram,4A,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4a,#e3000b,#ffffff,,rectangle,
-vrn-rnv-tram,5,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-5,#00965e,#ffffff,,rectangle,
-vrn-rnv-tram,5A,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-5a,#00965e,#ffffff,,rectangle,
-vrn-rnv-tram,6,rhein-neckar-verkehr-gmbh,8-vrn008-6,#956b25,#ffffff,,rectangle,
-vrn-rnv-tram,6A,rhein-neckar-verkehr-gmbh,8-vrn008-6a,#956b25,#ffffff,,rectangle,
-vrn-rnv-tram,6E,rhein-neckar-verkehr-gmbh,8-vrn008-e,#956b25,#ffffff,,rectangle,
-vrn-rnv-tram,7,rhein-neckar-verkehr-gmbh,8-vrn008-7,#ffcc00,#ffffff,,rectangle,
-vrn-rnv-tram,8,rhein-neckar-verkehr-gmbh,8-vrn008-8,#e17500,#ffffff,,rectangle,
-vrn-rnv-tram,9,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-9,#93c23b,#ffffff,,rectangle,
-vrn-rnv-tram,10,rhein-neckar-verkehr-gmbh,8-vrn008-10,#a60f80,#ffffff,,rectangle,
-vrn-rnv-tram,15,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-15,#f7ab63,#ffffff,,rectangle,
-vrn-rnv-tram,16,rhein-neckar-verkehr-gmbh,8-vrn008-16,#5e6baf,#ffffff,,rectangle,
-vrn-rnv-tram,21,rhein-neckar-verkehr-gmbh,8-vrn011-21,#e3000b,#ffffff,,rectangle,
-vrn-rnv-tram,22,rhein-neckar-verkehr-gmbh,8-vrn011-22,#fdc300,#ffffff,,rectangle,
-vrn-rnv-tram,23,rhein-neckar-verkehr-gmbh,8-vrn011-23,#e48e00,#ffffff,,rectangle,
-vrn-rnv-tram,24,rhein-neckar-verkehr-gmbh,8-vrn011-24,#8c1d75,#ffffff,,rectangle,
-vrn-rnv-tram,25,rhein-neckar-verkehr-gmbh,8-vrn011-25,#93c23b,#ffffff,,rectangle,
-vrn-rnv-tram,26,rhein-neckar-verkehr-gmbh,8-vrn011-26,#f39b9a,#ffffff,,rectangle,
-vrn-rnv-tram,X,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4x,#9d9d9d,#ffffff,,rectangle,
-vrn-sbahn-rn,S1,db-regio-ag-mitte,4-801539-1,#ed1c24,#ffffff,,pill,
-vrn-sbahn-rn,S1X,db-regio-ag-mitte,4-801539-1x,#ed1c24,#ffffff,,pill,
-vrn-sbahn-rn,S2,db-regio-ag-mitte,4-801539-2,#1575c5,#ffffff,,pill,
-vrn-sbahn-rn,S3,db-regio-ag-mitte,4-801539-3,#fddd04,#231f20,,pill,
-vrn-sbahn-rn,S4,db-regio-ag-mitte,4-801539-4,#00a650,#ffffff,,pill,
-vrn-sbahn-rn,S5,db-regio-ag-mitte,4-801518-5,#f68a25,#ffffff,,pill,
-vrn-sbahn-rn,S5X,db-regio-ag-mitte,4-801518-5x,#f68a25,#ffffff,,pill,
-vrn-sbahn-rn,S6,db-regio-ag-mitte,4-801518-6,#40c1f3,#ffffff,,pill,
-vrn-sbahn-rn,S7,db-regio-ag-mitte,4-801539-7,#ffffff,#ef249c,#ef249c,pill,
-vrn-sbahn-rn,S8,db-regio-ag-mitte,4-801518-8,#a25bad,#ffffff,,pill,
-vrn-sbahn-rn,S9,db-regio-ag-mitte,4-801518-9,#73c82c,#ffffff,,pill,
-vrn-sbahn-rn,S9X,db-regio-ag-mitte,4-801518-9x,#73c82c,#ffffff,,pill,
-vrn-sbahn-rn,S33,db-regio-ag-mitte,4-801539-33,#833aa1,#ffffff,,pill,
-vrn-sbahn-rn,S39,db-regio-ag-mitte,4-801539-39,#ffffff,#bf5810,#bf5810,pill,
-vrn-sbahn-rn,S44,db-regio-ag-mitte,4-801539-44,#ffffff,#00a650,#00a650,pill,
-vrn-sbahn-rn,S51,db-regio-ag-mitte,4-801518-51,#f68a25,#ffffff,,pill,
-vrr-bogestra,U35,,7-vrr032-35,#2350a9,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,301,,8-vrr033-301,#00a650,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,302,,8-vrr033-302,#86bbe0,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,305,,8-vrr033-305,#a865b9,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,306,,8-vrr030-306,#f0404c,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,308,,8-vrr033-308,#99d420,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,309,,8-vrr033-309,#2e3192,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,310,,8-vrr033-310,#aa3f7f,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,316,,8-vrr030-316,#e08417,#ffffff,,rectangle-rounded-corner,
-vrr-bogestra,318,,8-vrr033-318,#6aa99a,#ffffff,,rectangle-rounded-corner,
-vrr-dsw21,490,,5-vrr038-490,#831f82,#ffffff,,rectangle,
-vrr-dsw21,AirportExpress,,5-vrr038-airex,#53ae2e,#ffffff,,rectangle,
-vrr-dsw21,AirportShuttle,,5-vrr038-airsh,#53ae2e,#ffffff,,rectangle,
-vrr-dsw21,U41,,7-vrr036-41,#fee702,#7b7979,#7b7979,rectangle,
-vrr-dsw21,U42,,7-vrr036-42,#fab20b,#ffffff,,rectangle,
-vrr-dsw21,U43,,7-vrr036-43,#00a990,#ffffff,,rectangle,
-vrr-dsw21,U44,,7-vrr036-44,#66cde2,#ffffff,,rectangle,
-vrr-dsw21,U45,,7-vrr036-45,#ed1c24,#ffffff,,rectangle,
-vrr-dsw21,U46,,7-vrr036-46,#7264b8,#ffffff,,rectangle,
-vrr-dsw21,U47,,7-vrr036-47,#80cc28,#ffffff,,rectangle,
-vrr-dsw21,U49,,7-vrr036-49,#f799be,#ffffff,,rectangle,
-vrr-dsw21,H1,,8-vrr039-hb1,#ec008c,#ffffff,,rectangle,
-vrr-dsw21,H2,,8-vrr039-hb2,#ec008c,#ffffff,,rectangle,
-vrr-dsw21,H3,,8-vrr039-hb3,#ec008c,#ffffff,,rectangle,
-vrr-dsw21,H5,,8-vrr039-hb5,#ec008c,#ffffff,,rectangle,
-vrr-dsw21,H7,,8-vrr039-hb7,#ec008c,#ffffff,,rectangle,
-vrr-dvg,901,,8-vrr020-901,#009adf,#ffffff,,rectangle,
-vrr-dvg,903,,8-vrr020-903,#009adf,#ffffff,,rectangle,
-vrr-dvg,U79,,7-vrr020-79,#009a93,#ffffff,,rectangle,
-vrr-hst,CE51,,5-vrr050-ce51,#c10004,#ffffff,,rectangle-rounded-corner,
-vrr-hst,CE52,,5-vrr050-ce52,#e63758,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE1,,5-vrr050-ne1,#ff2a2a,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE2,,5-vrr050-ne2,#ff6600,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE3,,5-vrr050-ne3,#ffcc00,#000000,,rectangle-rounded-corner,
-vrr-hst,NE4,,5-vrr050-ne4,#2ca02c,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE5,,5-vrr050-ne5,#5f8dd3,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE6,,5-vrr050-ne6,#7137c8,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE9,,5-vrr088-ne9,#800080,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE11,,5-vrr050-ne11,#3737c8,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE12,,5-vrr050-ne12,#5fd35f,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE19,,5-vrr050-ne19,#a02c2c,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE21,,5-vrr050-ne21,#803300,#ffffff,,rectangle-rounded-corner,
-vrr-hst,NE32,,5-vrr050-ne32,#364a9c,#ffffff,,rectangle-rounded-corner,
-vrr-hst,510,,5-vrr050-510,#b06520,#ffffff,,rectangle-rounded-corner,
-vrr-hst,512,,5-vrr050-512,#b06520,#ffffff,,rectangle-rounded-corner,
-vrr-hst,513,,5-vrr050-513,#7f4984,#ffffff,,rectangle-rounded-corner,
-vrr-hst,514,,5-vrr050-514,#f49b00,#ffffff,,rectangle-rounded-corner,
-vrr-hst,515,,5-vrr050-515,#567b3e,#ffffff,,rectangle-rounded-corner,
-vrr-hst,516,,5-vrr050-516,#7eaf49,#ffffff,,rectangle-rounded-corner,
-vrr-hst,517,,5-vrr050-517,#619f4e,#ffffff,,rectangle-rounded-corner,
-vrr-hst,518,,5-vrr050-518,#007bc1,#ffffff,,rectangle-rounded-corner,
-vrr-hst,519,,5-vrr050-519,#007bc1,#ffffff,,rectangle-rounded-corner,
-vrr-hst,521,,5-vrr050-521,#df0008,#ffffff,,rectangle-rounded-corner,
-vrr-hst,522,,5-vrr050-522,#e63758,#ffffff,,rectangle-rounded-corner,
-vrr-hst,524,,5-vrr050-524,#7fceef,#ffffff,,rectangle-rounded-corner,
-vrr-hst,525,,5-vrr050-525,#df0008,#ffffff,,rectangle-rounded-corner,
-vrr-hst,527,,5-vrr050-527,#7c277d,#ffffff,,rectangle-rounded-corner,
-vrr-hst,528,,5-vrr050-528,#7fceef,#ffffff,,rectangle-rounded-corner,
-vrr-hst,534,,5-vrr050-534,#7c277d,#ffffff,,rectangle-rounded-corner,
-vrr-hst,535,,5-vrr050-535,#e14c25,#ffffff,,rectangle-rounded-corner,
-vrr-hst,537,,5-vrr050-537,#006cb6,#ffffff,,rectangle-rounded-corner,
-vrr-hst,538,,5-vrr050-538,#006cb6,#ffffff,,rectangle-rounded-corner,
-vrr-hst,539,,5-vrr050-539,#897300,#ffffff,,rectangle-rounded-corner,
-vrr-hst,540,,5-vrr050-540,#364a9c,#ffffff,,rectangle-rounded-corner,
-vrr-hst,541,,5-vrr050-541,#e63758,#ffffff,,rectangle-rounded-corner,
-vrr-hst,542,,5-vrr050-542,#71c837,#ffffff,,rectangle-rounded-corner,
-vrr-hst,543,,5-vrr050-543,#f49b00,#ffffff,,rectangle-rounded-corner,
-vrr-rheinbahn,U70,,7-vrr070-70,#71b2d0,#ffffff,,rectangle,
-vrr-rheinbahn,U71,,7-vrr070-71,#59c6f2,#ffffff,,rectangle,
-vrr-rheinbahn,U72,,7-vrr070-72,#25b8c5,#ffffff,,rectangle,
-vrr-rheinbahn,U73,,7-vrr070-73,#4465ad,#ffffff,,rectangle,
-vrr-rheinbahn,U75,,7-vrr070-75,#008fc2,#ffffff,,rectangle,
-vrr-rheinbahn,U76,,7-vrr070-76,#0063af,#ffffff,,rectangle,
-vrr-rheinbahn,U77,,7-vrr070-77,#7197cf,#ffffff,,rectangle,
-vrr-rheinbahn,U78,,7-vrr070-78,#009adf,#ffffff,,rectangle,
-vrr-rheinbahn,U79,,7-vrr070-79,#009a93,#ffffff,,rectangle,
-vrr-rheinbahn,U83,,7-vrr070-83,#1d3a8f,#ffffff,,rectangle,
-vrr-rheinbahn,701,,8-vrr071-701,#f07d00,#ffffff,,rectangle,
-vrr-rheinbahn,704,,8-vrr071-704,#bd1616,#ffffff,,rectangle,
-vrr-rheinbahn,705,,8-vrr071-705,#c0087f,#ffffff,,rectangle,
-vrr-rheinbahn,706,,8-vrr071-706,#e30613,#ffffff,,rectangle,
-vrr-rheinbahn,707,,8-vrr071-707,#7e1974,#ffffff,,rectangle,
-vrr-rheinbahn,708,,8-vrr071-708,#f29eb7,#ffffff,,rectangle,
-vrr-rheinbahn,709,,8-vrr071-709,#e94190,#ffffff,,rectangle,
-vrr-rheinbahn,721,,5-vrr072-721,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,722,,5-vrr072-722,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,723,,5-vrr072-723,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,724,,5-vrr072-724,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,725,,5-vrr072-725,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,726,,5-vrr072-726,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,727,,5-vrr072-727,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,728,,5-vrr072-728,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,729,,5-vrr072-729,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,730,,5-vrr072-730,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,731,,5-vrr072-731,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,732,,5-vrr072-732,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,733,,5-vrr072-733,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,734,,5-vrr072-734,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,735,,5-vrr072-735,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,736,,5-vrr072-736,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,737,,5-vrr072-737,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,738,,5-vrr072-738,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,741,,5-vrr072-741,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,742,,5-vrr072-742,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,743,,5-vrr072-743,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,745,,5-vrr072-745,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,746,,5-vrr072-746,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,747,,5-vrr072-747,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,748,,5-vrr072-748,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,749,,5-vrr072-749,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,751,,5-vrr072-751,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,752,,5-vrr072-752,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,753,,5-vrr072-753,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,754,,5-vrr072-754,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,756,,5-vrr072-756,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,757,,5-vrr072-757,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,758,,5-vrr072-758,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,759,,5-vrr072-759,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,760,,5-vrr072-760,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,761,,5-vrr072-761,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,770,,5-vrr072-770,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,771,,5-vrr072-771,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,772,,5-vrr072-772,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,773,,5-vrr072-773,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,774,,5-vrr072-774,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,776,,5-vrr072-776,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,777,,5-vrr072-777,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,778,,5-vrr072-778,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,779,,5-vrr072-779,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,780,,5-vrr072-780,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,781,,5-vrr072-781,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,782,,5-vrr072-782,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,783,,5-vrr072-783,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,784,,5-vrr072-784,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,785,,5-vrr072-785,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,786,,5-vrr072-786,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,787,,5-vrr072-787,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,788,,5-vrr072-788,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,789,,5-vrr072-789,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,790,,5-vrr072-790,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,791,,5-vrr072-791,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,792,,5-vrr072-792,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,805,,5-vrr072-805,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,807,,5-vrr072-807,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,810,,5-vrr072-810,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,812,,5-vrr072-812,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,815,,5-vrr072-815,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,817,,5-vrr072-817,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,827,,5-vrr072-827,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,828,,5-vrr072-828,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,829,,5-vrr072-829,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,830,,5-vrr072-830,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,831,,5-vrr072-831,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,832,,5-vrr072-832,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,833,,5-vrr072-833,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,834,,5-vrr072-834,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,835,,5-vrr072-835,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,836,,5-vrr072-836,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,839,,5-vrr072-839,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,863,,5-vrr072-863,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,891,,5-vrr072-891,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,896,,5-vrr072-896,#f1db68,#696969,#f1db68,rectangle,
-vrr-rheinbahn,M1,,5-vrr073-m1,#3bb954,#ffffff,,rectangle,
-vrr-rheinbahn,M2,,5-vrr073-m2,#3bb954,#ffffff,,rectangle,Q130545061
-vrr-rheinbahn,M3,,5-vrr073-m3,#3bb954,#ffffff,,rectangle,
-vrr-rheinbahn,SB19,,5-vrr072-sb19,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB50,,5-vrr072-sb50,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB51,,5-vrr072-sb51,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB52,,5-vrr072-sb52,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB53,,5-vrr072-sb53,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB55,,5-vrr072-sb55,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB57,,5-vrr072-sb57,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB59,,5-vrr072-sb59,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB68,,5-vrr072-sb68,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SB79,,5-vrr072-sb79,#40909c,#ffffff,#40909c,rectangle,
-vrr-rheinbahn,SkyTrain,,8-vrr077-skyt,#53b6ed,#ffffff,,rectangle,
-vrr-ruhrbahn,U11,,7-vrr010-11,#313390,#ffffff,,rectangle,
-vrr-ruhrbahn,U17,,7-vrr010-17,#6bb7e5,#ffffff,,rectangle,
-vrr-ruhrbahn,U18,,7-vrr013-18,#1187d2,#ffffff,,rectangle,
-vrr-ruhrbahn,101,,8-vrr011-101,#8b5c19,#ffffff,,rectangle,
-vrr-ruhrbahn,102,,8-vrr013-102,#f033a3,#ffffff,,rectangle,
-vrr-ruhrbahn,103,,8-vrr011-103,#fbc707,#ffffff,,rectangle,
-vrr-ruhrbahn,104,,8-vrr013-104,#bfb619,#ffffff,,rectangle,
-vrr-ruhrbahn,105,,8-vrr011-105,#a1d61e,#ffffff,,rectangle,
-vrr-ruhrbahn,106,,8-vrr011-106,#9a80b5,#ffffff,,rectangle,
-vrr-ruhrbahn,107,,8-vrr011-107,#d51f27,#ffffff,,rectangle,
-vrr-ruhrbahn,108,,8-vrr011-108,#ea9f0b,#ffffff,,rectangle,
-vrr-ruhrbahn,109,,8-vrr011-109,#1ca147,#ffffff,,rectangle,
-vrr-ruhrbahn,112,,8-vrr015-112,#9c0c79,#ffffff,,rectangle,
-vrr-swk,041,,8-vrr001-041,#fb2513,#ffffff,,rectangle-rounded-corner,
-vrr-swk,042,,8-vrr001-042,#fe8480,#ffffff,,rectangle-rounded-corner,
-vrr-swk,043,,8-vrr001-043,#d75ec0,#ffffff,,rectangle-rounded-corner,
-vrr-swk,044,,8-vrr001-044,#f95a01,#ffffff,,rectangle-rounded-corner,
-vrr-sws,681,,5-vrr018-681,#006839,#ffffff,,rectangle,
-vrr-sws,682,,5-vrr018-682,#008f6d,#ffffff,,rectangle,
-vrr-sws,683,,5-vrr018-683,#76b82b,#ffffff,,rectangle,
-vrr-sws,684,,5-vrr018-684,#038739,#ffffff,,rectangle,
-vrr-sws,685,,5-vrr018-685,#599029,#ffffff,,rectangle,
-vrr-sws,686,,5-vrr018-686,#afc40e,#ffffff,,rectangle,
-vrr-sws,687,,5-vrr018-687,#4565ad,#ffffff,,rectangle,
-vrr-sws,689,,5-vrr018-689,#945e43,#ffffff,,rectangle,
-vrr-sws,690,,5-vrr018-690,#0090c9,#ffffff,,rectangle,
-vrr-sws,691,,5-vrr018-691,#9c3632,#ffffff,,rectangle,
-vrr-sws,692,,5-vrr018-692,#783f91,#ffffff,,rectangle,
-vrr-sws,693,,5-vrr018-693,#a2837b,#ffffff,,rectangle,
-vrr-sws,694,,5-vrr018-694,#5f9bc6,#ffffff,,rectangle,
-vrr-sws,695,,5-vrr018-695,#c3436f,#ffffff,,rectangle,
-vrr-sws,696,,5-vrr018-696,#757bb6,#ffffff,,rectangle,
-vrr-sws,697,,5-vrr018-697,#02b1eb,#ffffff,,rectangle,
-vrr-sws,698,,5-vrr018-698,#494495,#ffffff,,rectangle,
-vrr-sws,699,,5-vrr018-699,#c77e18,#ffffff,,rectangle,
-vrr-sws,NE21,,5-vrr018-ne21,#05a8e1,#ffffff,,rectangle,
-vrr-sws,NE22,,5-vrr018-ne22,#004494,#ffffff,,rectangle,
-vrr-sws,NE23,,5-vrr018-ne23,#4a76ba,#ffffff,,rectangle,
-vrr-sws,NE24,,5-vrr018-ne24,#4896d2,#ffffff,,rectangle,
-vrr-sws,NE25,,5-vrr018-ne25,#0362ad,#ffffff,,rectangle,
-vrr-sws,NE28,,5-vrr018-ne28,#004e9e,#ffffff,,rectangle,
-vrr-wsw,600,,5-vrr066-600,#bd5695,#ffffff,,rectangle,
-vrr-wsw,601,,5-vrr066-601,#7e8b61,#ffffff,,rectangle,
-vrr-wsw,602,,5-vrr066-602,#7d96c4,#ffffff,,rectangle,
-vrr-wsw,603,,5-vrr066-603,#9f7456,#ffffff,,rectangle,
-vrr-wsw,604,,5-vrr066-604,#e59635,#ffffff,,rectangle,
-vrr-wsw,FreizeitBus 605,,5-vrr066-605,#aa974a,#ffffff,,rectangle,
-vrr-wsw,606,,5-vrr066-606,#7d3622,#ffffff,,rectangle,
-vrr-wsw,607,,5-vrr066-607,#709c47,#ffffff,,rectangle,
-vrr-wsw,608,,5-vrr066-608,#25594d,#ffffff,,rectangle,
-vrr-wsw,609,,5-vrr066-609,#6bac43,#ffffff,,rectangle,
-vrr-wsw,610,,5-vrr066-610,#d96077,#ffffff,,rectangle,
-vrr-wsw,611,,5-vrr066-611,#846b97,#ffffff,,rectangle,
-vrr-wsw,612,,5-vrr066-612,#c2802c,#ffffff,,rectangle,
-vrr-wsw,613,,5-vrr066-613,#432059,#ffffff,,rectangle,
-vrr-wsw,614,,5-vrr066-614,#4aa5bd,#ffffff,,rectangle,
-vrr-wsw,615,,5-vrr066-615,#924374,#ffffff,,rectangle,
-vrr-wsw,616,,5-vrr066-616,#d12d40,#ffffff,,rectangle,
-vrr-wsw,617,,5-vrr066-617,#88214c,#ffffff,,rectangle,
-vrr-wsw,618,,5-vrr066-618,#c48766,#ffffff,,rectangle,
-vrr-wsw,619,,5-vrr066-619,#374c97,#ffffff,,rectangle,
-vrr-wsw,620,,5-vrr066-620,#49a17d,#ffffff,,rectangle,
-vrr-wsw,621,,5-vrr066-621,#e59539,#ffffff,,rectangle,
-vrr-wsw,622,,5-vrr066-622,#adbc88,#ffffff,,rectangle,
-vrr-wsw,623,,5-vrr066-623,#cf5533,#ffffff,,rectangle,
-vrr-wsw,624,,5-vrr066-624,#449381,#ffffff,,rectangle,
-vrr-wsw,625,,5-vrr066-625,#85ac4d,#ffffff,,rectangle,
-vrr-wsw,627,,5-vrr066-627,#9e511d,#ffffff,,rectangle,
-vrr-wsw,628,,5-vrr066-628,#7e7543,#ffffff,,rectangle,
-vrr-wsw,630,,5-vrr066-630,#d75831,#ffffff,,rectangle,
-vrr-wsw,631,,5-vrr066-631,#64875d,#ffffff,,rectangle,
-vrr-wsw,632,,5-vrr066-632,#e1af53,#ffffff,,rectangle,
-vrr-wsw,633,,5-vrr066-633,#47247d,#ffffff,,rectangle,
-vrr-wsw,635,,5-vrr066-635,#bf713a,#ffffff,,rectangle,
-vrr-wsw,636,,5-vrr066-636,#ecaf63,#ffffff,,rectangle,
-vrr-wsw,637,,5-vrr066-637,#d5435c,#ffffff,,rectangle,
-vrr-wsw,638,,5-vrr066-638,#648c5e,#ffffff,,rectangle,
-vrr-wsw,640,,5-vrr066-640,#93b980,#ffffff,,rectangle,
-vrr-wsw,641,,5-vrr066-641,#bc653f,#ffffff,,rectangle,
-vrr-wsw,642,,5-vrr066-642,#5471a5,#ffffff,,rectangle,
-vrr-wsw,643,,5-vrr066-643,#43966b,#ffffff,,rectangle,
-vrr-wsw,644,,5-vrr066-644,#9e7626,#ffffff,,rectangle,
-vrr-wsw,645,,5-vrr066-645,#b0b93d,#ffffff,,rectangle,
-vrr-wsw,646,,5-vrr066-646,#3e8bb1,#ffffff,,rectangle,
-vrr-wsw,647,,5-vrr066-647,#dd7340,#ffffff,,rectangle,
-vrr-wsw,649,,5-vrr066-649,#94b483,#ffffff,,rectangle,
-vrr-wsw,650,,5-vrr066-650,#edbf41,#ffffff,,rectangle,
-vrr-wsw,666,,5-vrr066-666,#479fcd,#ffffff,,rectangle,
-vrr-wsw,669,,5-vrr066-669,#286035,#ffffff,,rectangle,
-vrr-wsw,670,,5-vrr066-670,#8d5c99,#ffffff,,rectangle,
-vrr-wsw,Schwebebahn,,8-vrr064-60,#4896d2,#ffffff,,rectangle-rounded-corner,
-vrr-wsw,SB66,,5-vrr088-sb66,#3f8f9b,#ffffff,,rectangle,
-vrr-wsw,SB67,,5-vrr045-sb67,#3f8f9b,#ffffff,,rectangle,
-vrr-wsw,SB69,,5-vrr066-sb69,#3f8f9b,#ffffff,,rectangle,
-vrr-wsw,CE61,,5-vrr066-ce61,#d12f2b,#ffffff,,rectangle,
-vrr-wsw,CE62,,5-vrr066-ce62,#d12f2b,#ffffff,,rectangle,
-vrr-wsw,CE64,,5-vrr066-ce64,#d12f2b,#ffffff,,rectangle,
-vrr-wsw,CE65,,5-vrr066-ce65,#d12f2b,#ffffff,,rectangle,
-vrr-wsw,UniExpress E800,,5-vrr066-uniex,#9c9d9d,#ffffff,,rectangle,
-vrr-wsw,E860,,5-vrr066-e860,#c27629,#ffffff,,rectangle,
-vrs-bus,106,,5-vrs001-106,#097cc1,#ffffff,,rectangle,
-vrs-bus,118,,5-vrs001-118-779149-5669228,#85d1f5,#ffffff,,rectangle,
-vrs-bus,120,,5-vrs001-120,#e30a18,#ffffff,,rectangle,
-vrs-bus,121,,5-vrs001-121,#a2c61e,#ffffff,,rectangle,
-vrs-bus,122,,5-vrs001-122,#0569b3,#ffffff,,rectangle,
-vrs-bus,123,,5-vrs001-123,#f29ec4,#706f6f,#878787,rectangle,
-vrs-bus,124,,5-vrs001-124,#00b3bb,#ffffff,,rectangle,
-vrs-bus,125,,5-vrs001-125,#f7a706,#ffffff,,rectangle,
-vrs-bus,126,,5-vrs001-126,#f29ec4,#ffffff,,rectangle,
-vrs-bus,127,,5-vrs001-127,#1c9cd8,#ffffff,,rectangle,
-vrs-bus,130,,5-vrs001-130,#43c0f0,#ffffff,,rectangle,
-vrs-bus,131,,5-vrs001-131,#a2c61e,#ffffff,,rectangle,
-vrs-bus,132,,5-vrs001-132,#f7a707,#ffffff,,rectangle,
-vrs-bus,133,,5-vrs001-133,#e30a18,#ffffff,,rectangle,
-vrs-bus,134,,5-vrs001-134,#1c9cd8,#ffffff,,rectangle,
-vrs-bus,135,,5-vrs001-135,#ec72a6,#ffffff,,rectangle,
-vrs-bus,136,,5-vrs001-136,#bc866d,#ffffff,,rectangle,
-vrs-bus,138,,5-vrs001-138,#caa2cc,#ffffff,,rectangle,
-vrs-bus,139,,5-vrs001-139,#bd7542,#ffffff,,rectangle,
-vrs-bus,140,,5-vrs001-140,#ffcc03,#ffffff,,rectangle,
-vrs-bus,141,,5-vrs001-141,#33b6b3,#ffffff,,rectangle,
-vrs-bus,142,,5-vrs001-142,#e5077d,#ffffff,,rectangle,
-vrs-bus,143,,5-vrs001-143,#c6d54f,#ffffff,,rectangle,
-vrs-bus,144,,5-vrs001-144,#f7a706,#ffffff,,rectangle,
-vrs-bus,145,,5-vrs001-145,#15bbee,#ffffff,,rectangle,
-vrs-bus,146,,5-vrs001-146,#e94f26,#ffffff,,rectangle,
-vrs-bus,147,,5-vrs001-147,#f29ec4,#ffffff,,rectangle,
-vrs-bus,148,,5-vrs001-148,#f095be,#ffffff,,rectangle,
-vrs-bus,149,,5-vrs001-149,#f9d612,#ffffff,,rectangle,
-vrs-bus,150,,5-vrs001-150,#13baee,#ffffff,,rectangle,
-vrs-bus,151,,5-vrs001-151,#f7a707,#ffffff,,rectangle,
-vrs-bus,152,,5-vrs001-152,#ffcc03,#ffffff,,rectangle,
-vrs-bus,153,,5-vrs001-153,#a795c7,#ffffff,,rectangle,
-vrs-bus,154,,5-vrs001-154,#ec6738,#ffffff,,rectangle,
-vrs-bus,155,,5-vrs001-155,#128acb,#ffffff,,rectangle,
-vrs-bus,156,,5-vrs001-156,#fdeb1a,#878787,#878787,rectangle,
-vrs-bus,157,,5-vrs001-157,#1cafe6,#ffffff,,rectangle,
-vrs-bus,158,,5-vrs001-158,#76b72d,#ffffff,,rectangle,
-vrs-bus,159,,5-vrs001-159,#e84990,#ffffff,,rectangle,
-vrs-bus,160,,5-vrs001-160,#76b72d,#ffffff,,rectangle,
-vrs-bus,161,,5-vrs001-161,#1cafe6,#ffffff,,rectangle,
-vrs-bus,162,,5-vrs001-162,#f095be,#ffffff,,rectangle,
-vrs-bus,165,,5-vrs001-165,#84d0f5,#878787,#878787,rectangle,
-vrs-bus,166,,5-vrs001-166,#c6d54f,#878787,#878787,rectangle,
-vrs-bus,167,,5-vrs001-167,#ffcc03,#878787,#878787,rectangle,
-vrs-bus,171,,5-vrs001-171,#00b3bb,#ffffff,,rectangle,
-vrs-bus,180,,5-vrs001-180,#9d9d9c,#ffffff,,pill,
-vrs-bus,181,,5-vrs001-181,#9d9d9c,#ffffff,,pill,
-vrs-bus,182,,5-vrs001-182,#9d9d9c,#ffffff,,pill,
-vrs-bus,183,,5-vrs001-183,#9d9d9c,#ffffff,,pill,
-vrs-bus,184,,5-vrs001-184,#706f6f,#ffffff,,rectangle,
-vrs-bus,185,,5-vrs001-185,#706f6f,#ffffff,,rectangle,
-vrs-bus,187,,5-vrs001-187,#706f6f,#ffffff,,rectangle,
-vrs-bus,188,,5-vrs001-188,#9d9d9c,#ffffff,,pill,
-vrs-bus,189,,5-vrs001-189,#706f6f,#ffffff,,rectangle,
-vrs-bus,191,,5-vrs001-191,#009982,#ffffff,,rectangle,
-vrs-bus,192,,5-vrs001-192,#1c9cd8,#ffffff,,rectangle,
-vrs-bus,193,,5-vrs001-193,#f39205,#ffffff,,rectangle,
-vrs-bus,195,,5-vrs001-195,#f29ec4,#ffffff,,rectangle,
-vrs-bus,196,,5-vrs001-196,#a85e24,#ffffff,,rectangle,
-vrs-bus,197,,5-vrs001-197,#929292,#ffffff,,rectangle,
-vrs-bus,201,,5-vrs003-201,#faad19,#ffffff,,rectangle,
-vrs-bus,202,,5-vrs003-202,#b8427d,#ffffff,,rectangle,
-vrs-bus,203,,5-vrs003-203,#f7abb2,#ffffff,,rectangle,
-vrs-bus,204,,5-vrs003-204,#1b81c4,#ffffff,,rectangle,
-vrs-bus,205,,5-vrs003-205,#1b81c4,#ffffff,,rectangle,
-vrs-bus,206,,5-vrs003-206,#00a956,#ffffff,,rectangle,
-vrs-bus,207,,5-vrs003-207,#f79832,#ffffff,,rectangle,
-vrs-bus,208,,5-vrs003-208,#d263a5,#ffffff,,rectangle,
-vrs-bus,209,,5-vrs003-209,#d263a5,#ffffff,,rectangle,
-vrs-bus,211,,5-vrs003-211,#ee1b2b,#ffffff,,rectangle,
-vrs-bus,212,,5-vrs003-212,#1cbfdf,#ffffff,,rectangle,
-vrs-bus,213,,5-vrs003-213,#aab2d9,#ffffff,,rectangle,
-vrs-bus,214,,5-vrs003-214,#1b81c4,#ffffff,,rectangle,
-vrs-bus,215,,5-vrs003-215,#835645,#ffffff,,rectangle,
-vrs-bus,217,,5-vrs003-217,#b56d38,#ffffff,,rectangle,
-vrs-bus,218,,5-vrs003-218,#7ea17b,#ffffff,,rectangle,
-vrs-bus,222,,5-vrs003-222,#00aaad,#ffffff,,rectangle,
-vrs-bus,227,,5-vrs003-227,#ac99c9,#ffffff,,rectangle,
-vrs-bus,229,,5-vrs003-229,#fec70c,#9c9c9c,,rectangle,
-vrs-bus,232,,5-vrs003-232,#f5864b,#ffffff,,rectangle,
-vrs-bus,244,,5-vrs003-244,#0090c6,#ffffff,,rectangle,
-vrs-bus,251,,5-vrs003-251,#c18ba5,#ffffff,,rectangle,
-vrs-bus,253,,5-vrs003-253,#91ce9a,#ffffff,,rectangle,
-vrs-bus,254,,5-vrs003-254,#faaa4a,#ffffff,,rectangle,
-vrs-bus,255,,5-vrs003-255,#007dad,#ffffff,,rectangle,
-vrs-bus,257,,5-vrs003-257,#a6565c,#ffffff,,rectangle,
-vrs-bus,258,,5-vrs003-258,#1ca852,#ffffff,,rectangle,
-vrs-bus,260,,5-vrs016-260,#86526b,#ffffff,,rectangle,
-vrs-bus,600,,5-vrs006-600,#6d7eb8,#ffffff,,rectangle,
-vrs-bus,601,,5-vrs006-601,#662d91,#ffffff,,rectangle,
-vrs-bus,602,,5-vrs006-602,#d475b2,#ffffff,,rectangle,
-vrs-bus,603,,5-vrs006-603,#e74696,#ffffff,,rectangle,
-vrs-bus,604,,5-vrs006-604,#53b174,#ffffff,,rectangle,
-vrs-bus,605,,5-vrs006-605,#3d864b,#ffffff,,rectangle,
-vrs-bus,606,,5-vrs006-606,#9ac356,#ffffff,,rectangle,
-vrs-bus,607,,5-vrs006-607,#72b554,#ffffff,,rectangle,
-vrs-bus,608,,5-vrs006-608,#f4b94f,#ffffff,,rectangle,
-vrs-bus,609,,5-vrs006-609,#ef8d40,#ffffff,,rectangle,
-vrs-bus,610,,5-vrs006-610,#6fccf2,#ffffff,,rectangle,
-vrs-bus,611,,5-vrs006-611,#4faee4,#ffffff,,rectangle,
-vrs-bus,612,,5-vrs006-612,#c8985f,#ffffff,,rectangle,
-vrs-bus,613,,5-vrs006-613,#703315,#ffffff,,rectangle,
-vrs-bus,614,,5-vrs006-614,#766c45,#ffffff,,rectangle,
-vrs-bus,630,,5-vrs006-630,#c33e58,#ffffff,,rectangle,
-vrs-bus,632,,5-vrs006-632,#64b659,#ffffff,,rectangle,
-vrs-bus,633,,5-vrs006-633,#8dd2c8,#ffffff,,rectangle,
-vrs-bus,634,,5-vrs006-634,#db5b60,#ffffff,,rectangle,
-vrs-bus,635,,5-vrs006-635,#c9c552,#ffffff,,rectangle,
-vrs-bus,636,,5-vrs006-636,#af3031,#ffffff,,rectangle,
-vrs-bus,637,,5-vrs006-637,#e86741,#ffffff,,rectangle,
-vrs-bus,638,,5-vrs006-638,#e86741,#ffffff,,rectangle,
-vrs-bus,639,,5-vrs006-637,#a65c41,#ffffff,,rectangle,
-vrs-bus,AST 227,,9-vrs003-227,#f36e31,#ffffff,,rectangle,
-vrs-bus,Berg. FahrradBus,,5-vrs016-bf,#000000,#ffffff,,rectangle,
-vrs-bus,SB20,,5-vrs003-sb20,#f36e31,#ffffff,,rectangle,
-vrs-bus,SB22,,5-vrs003-sb22,#a5612e,#ffffff,,rectangle,
-vrs-bus,SB23,,5-vrs003-sb23,#00a54f,#ffffff,,rectangle,
-vrs-bus,SB24,,5-vrs003-sb24,#008540,#ffffff,,rectangle,
-vrs-bus,SB25,,5-vrs003-sb25,#00a9e2,#ffffff,,rectangle,
-vrs-bus,SB33,,5-vrr076-sb33,#81c9ef,#ffffff,,rectangle,
-vrs-bus,SB42,,5-vrs003-sb25,#176438,#ffffff,,rectangle,
-vrs-bus,SB60,,5-vrs006-sb60,#859268,#ffffff,,rectangle,
-vrs-bus,SB69,,5-vrs006-sb69,#df6a3c,#ffffff,,rectangle,
-vrs-bus,X24,,5-vrs003-x24,#243d98,#ffffff,,rectangle,
-vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,5,,8-vrs001-5,#a69dc8,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,12,,8-vrs001-12,#98c01e,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,13,,8-vrs001-13,#aa8567,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,14,,8-vrs001-14,#b32499,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,15,,8-vrs001-15,#5aad31,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,16,,8-vrs001-16,#07ada5,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,17,,8-vrs001-17,#1e93d1,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,18,,8-vrs001-18,#85d1f5,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,19,,8-vrs001-19,#28523e,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,61,stadtwerke-bonn,8-s3-61,#9ab831,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,62,stadtwerke-bonn,8-s3-62,#65a53b,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,63,stadtwerke-bonn,8-s3-63,#8bccf3,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,65,stadtwerke-bonn,8-s3-65,#c6cc2a,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,66,stadtwerke-bonn,8-s3-66,#d4417d,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,67,stadtwerke-bonn,8-s3-67,#e7a8c4,#ffffff,,rectangle-rounded-corner,
-vrs-stadtbahn,68,stadtwerke-bonn,8-s3-68,#cbaece,#ffffff,,rectangle-rounded-corner,
-vst-oebb,S1,osterreichische-bundesbahnen,4-81-1-1714993-5236532,#0fa14a,#ffffff,,rectangle-rounded-corner,
-vst-oebb,S3,osterreichische-bundesbahnen,4-81-3-1714993-5236532,#ed028c,#ffffff,,rectangle-rounded-corner,
-vst-oebb,S5,osterreichische-bundesbahnen,4-81-5-1714993-5236532,#892890,#ffffff,,rectangle-rounded-corner,
-vst-oebb,S51,osterreichische-bundesbahnen,4-81-51,#892890,#ffffff,,rectangle-rounded-corner,
-vst-oebb,S8,osterreichische-bundesbahnen,4-81-8-1699752-5274525,#4fc4cf,#ffffff,,rectangle-rounded-corner,
-vst-oebb,S9,osterreichische-bundesbahnen,4-81-9,#957cb9,#ffffff,,rectangle-rounded-corner,
-vst-stb,S11,steiermarkbahn-und-bus-gmbh,4-3613-11,#0fa14a,#ffffff,,rectangle-rounded-corner,
-vst-stb,S31,steiermarkbahn-und-bus-gmbh,4-3613-31,#ed028c,#ffffff,,rectangle-rounded-corner,
-vvk-oebb,S1,osterreichische-bundesbahnen,4-81-1-1540573-5186063,#16489f,#ffffff,,rectangle-rounded-corner,
-vvk-oebb,S2,osterreichische-bundesbahnen,4-81-2-1540573-5186063,#3b8475,#ffffff,,rectangle-rounded-corner,
-vvk-oebb,S3,osterreichische-bundesbahnen,4-81-3-1592305-5185725,#e36f27,#ffffff,,rectangle-rounded-corner,
-vvk-oebb,S4,osterreichische-bundesbahnen,4-81-4-1540573-5186063,#ee1c25,#ffffff,,rectangle-rounded-corner,
-vvk-oebb,S5,osterreichische-bundesbahnen,4-81-5-1540573-5186063,#f3c836,#ffffff,,rectangle-rounded-corner,
-vvo-bus,EV11,,5-voe021-ev11,#c2ddaf,#000000,,pill,
-vvo-bus,61,,5-voe021-61,#0069b4,#ffffff,,pill,
-vvo-bus,62,,5-voe021-62,#008ace,#ffffff,,pill,
-vvo-bus,63,,5-voe021-63,#224193,#ffffff,,pill,
-vvo-bus,64,,5-voe021-64,#35a9e1,#ffffff,,pill,
-vvo-bus,65,,5-voe021-65,#1a70b8,#ffffff,,pill,
-vvo-bus,66,,5-voe021-66,#35a9e1,#ffffff,,pill,
-vvo-bus,68,,5-voe021-68,#008fba,#ffffff,,pill,
-vvo-bus,70,,5-voe021-70,#c99d66,#ffffff,,pill,
-vvo-bus,72,,5-voe021-72,#a4897a,#ffffff,,pill,
-vvo-bus,73,,5-voe021-73,#dbd186,#ffffff,,pill,
-vvo-bus,74,,9-voe021-74,#935e36,#ffffff,,pill,
-vvo-bus,76,,5-voe021-76,#a4897a,#ffffff,,pill,
-vvo-bus,76,,9-voe021-76,#a4897a,#ffffff,,pill,
-vvo-bus,77,,5-voe021-77,#bcae94,#ffffff,,pill,
-vvo-bus,77,,9-voe021-77,#bcae94,#ffffff,,pill,
-vvo-bus,78,,5-voe021-78,#dbd186,#ffffff,,pill,
-vvo-bus,79,,5-voe021-79,#bcae94,#ffffff,,pill,
-vvo-bus,79,,9-voe021-79,#bcae94,#ffffff,,pill,
-vvo-bus,80,,5-voe021-80,#683b0c,#ffffff,,pill,
-vvo-bus,81,,5-voe021-81,#935e36,#ffffff,,pill,
-vvo-bus,84,,5-voe021-84,#bcae94,#ffffff,,pill,
-vvo-bus,85,,5-voe021-85,#c99d66,#ffffff,,pill,
-vvo-bus,86,,5-voe021-86,#935e36,#ffffff,,pill,
-vvo-bus,87,,5-voe021-87,#a4897a,#ffffff,,pill,
-vvo-bus,88,,9-voe021-88,#a4897a,#ffffff,,pill,
-vvo-bus,89,,5-voe021-89,#bcae94,#ffffff,,pill,
-vvo-bus,90,,5-voe021-90,#bcae94,#ffffff,,pill,
-vvo-bus,91,,9-voe023-91,#c6be7a,#ffffff,,pill,
-vvo-bus,92,,9-voe021-92,#bcae94,#ffffff,,pill,
-vvo-bus,93,,9-voe023-93,#9c9661,#ffffff,,pill,
-vvo-bus,98A,,5-voe022-98a,#b1aa6e,#ffffff,,pill,
-vvo-bus,98B,,5-voe022-98b,#dbd186,#ffffff,,pill,
-vvo-bus,160,,5-voe023-160,#9c9d9d,#ffffff,,pill,
-vvo-bus,166,,5-voe023-166,#35a9e1,#ffffff,,pill,
-vvo-db-regio,U 28,db-regio-ag-sudost,rb-u28,#014d6f,#ffffff,,pill,
-vvo-db-regio,RB 33,db-regio-ag-sudost,rb-33,#ec7797,#ffffff,,rectangle,
-vvo-db-regio,RB 71,db-regio-ag-sudost,rb-71,#ad006f,#ffffff,,rectangle,
-vvo-db-regio,RB 72,db-regio-ag-sudost,rb-72,#9c321b,#ffffff,,rectangle,
-vvo-db-regio,RE 19,db-regio-ag-sudost,re-19,#00895d,#ffffff,,rectangle,
-vvo-db-regio,RE 20,db-regio-ag-sudost,re-20,#575756,#ffffff,,rectangle,
-vvo-db-regio,RE 50,db-regio-ag-sudost,re-50,#b60d1c,#ffffff,,rectangle,
-vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,,pill,
-vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,,pill,
-vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,,pill,
-vvo-db-sbd,S 8,db-regio-ag-sudost,4-8004l1-8,#2d92ad,#ffffff,,pill,
-vvo-ferry,F1,,6-voe091-f1,#00a5df,#ffffff,,rectangle-rounded-corner,
-vvo-ferry,F14,,6-voe091-f14,#00a5df,#ffffff,,rectangle-rounded-corner,
-vvo-ferry,F16,,6-voe091-f16,#00a5df,#ffffff,,rectangle-rounded-corner,
-vvo-ferry,F17,,6-voe091-f17,#00a5df,#ffffff,,rectangle-rounded-corner,
-vvo-tram,1,,8-voe011-1,#e30018,#ffffff,,rectangle-rounded-corner,
-vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,,rectangle-rounded-corner,
-vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,,rectangle-rounded-corner,
-vvo-tram,4,,8-voe011-4,#c9061a,#ffffff,,rectangle-rounded-corner,
-vvo-tram,6,,8-voe011-6,#ffdd00,#000000,,rectangle-rounded-corner,
-vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,,rectangle-rounded-corner,
-vvo-tram,8,,8-voe011-8,#229133,#ffffff,,rectangle-rounded-corner,
-vvo-tram,9,,8-voe011-9,#93c355,#ffffff,,rectangle-rounded-corner,
-vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,,rectangle-rounded-corner,
-vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner,
-vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner,
-vvo-tram,13,,8-voe011-13,#fdc300,#000000,,rectangle-rounded-corner,
-vvo-tram,44,,8-voe011-44,#a14c8d,#000000,,rectangle-rounded-corner,
-vvo-tram,46,,8-voe011-46,#eba507,#000000,,rectangle-rounded-corner,
-vvo-tram,20,,8-voe011-20,#000000,#ffffff,,rectangle-rounded-corner,
-vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,,rectangle,Q18946157
-vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,,rectangle,Q107020232
-vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,,rectangle,Q66537943
-vvs-db-sbs,S3,db-regio-ag-s-bahn-stuttgart,4-800643-3,#f36e31,#ffffff,,rectangle,Q67504621
-vvs-db-sbs,S4,db-regio-ag-s-bahn-stuttgart,4-800643-4,#0166b3,#ffffff,,rectangle,
-vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle,
-vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle,Q67501804
-vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle,Q63952011
-vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle,Q130343355
-vvs-db-sbs,RB11,db-regio-ag-s-bahn-stuttgart,rb-11,#02aa9e,#ffffff,,rectangle,
-vvs-db-sbs,RB64,db-regio-ag-s-bahn-stuttgart,rb-64,#b6931d,#ffffff,,rectangle,
-vvs-fmo,443,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-443,#009097,#ffffff,,rectangle,
-vvs-fmo,444,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-444,#415b70,#ffffff,,rectangle,
-vvs-fmo,444A,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-444a,#415b70,#ffffff,,rectangle,
-vvs-lvl,413,,5-vvs031-413,#96c2e9,#000000,,rectangle,
-vvs-lvl,415,,5-vvs031-415,#c6bd7f,#000000,,rectangle,
-vvs-lvl,420,,5-vvs031-420,#e94190,#ffffff,,rectangle,
-vvs-lvl,421,,5-vvs031-421,#969200,#ffffff,,rectangle,
-vvs-lvl,421A,,5-vvs031-421a,#969200,#ffffff,,rectangle,
-vvs-lvl,422,,5-vvs031-422,#69c0ac,#000000,,rectangle,
-vvs-lvl,422A,,5-vvs031-422a,#69c0ac,#000000,,rectangle,
-vvs-lvl,423,,5-vvs031-423,#fbba00,#000000,,rectangle,
-vvs-lvl,424,,5-vvs031-424,#009ed4,#ffffff,,rectangle,
-vvs-lvl,425,,5-vvs031-425,#60a92c,#ffffff,,rectangle,
-vvs-lvl,425A,,5-vvs031-425a,#60a92c,#ffffff,,rectangle,
-vvs-lvl,426,,5-vvs031-426,#005ca9,#ffffff,,rectangle,
-vvs-lvl,427,,5-vvs031-427,#bb6130,#ffffff,,rectangle,
-vvs-lvl,427A,,5-vvs031-427a,#bb6130,#ffffff,,rectangle,
-vvs-lvl,428,,5-vvs031-428,#a0cee7,#000000,,rectangle,
-vvs-lvl,429,,5-vvs031-429,#95c11f,#000000,,rectangle,
-vvs-lvl,430,,5-vvs031-430,#8164a9,#ffffff,,rectangle,
-vvs-lvl,430A,,5-vvs031-430a,#8164a9,#ffffff,,rectangle,
-vvs-lvl,431,,5-vvs031-431,#bb1d3c,#ffffff,,rectangle,
-vvs-lvl,433,,5-vvs031-433,#e3d100,#000000,,rectangle,
-vvs-lvl,433A,,5-vvs031-433a,#e3d100,#000000,,rectangle,
-vvs-lvl,451,,5-vvs031-451,#00b1eb,#ffffff,,rectangle,
-vvs-lvl,X43,,5-vvs031-x43,#ef7d00,#ffffff,,rectangle,
-vvs-osb,551,,5-vvs031-551,#e12b54,#ffffff,,rectangle,
-vvs-osb,551A,,5-vvs031-551a,#e12b54,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 1,,5-vvs033-n1,#3c389e,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 2,,5-vvs033-n2,#6fdaf8,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 3,,5-vvs033-n3,#6fdaf8,#06429a,,rectangle,
-vvs-ssb-nachtbus,N 4,,5-vvs033-n4,#00ad70,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 5,,5-vvs033-n5,#ffb530,#06429a,,rectangle,
-vvs-ssb-nachtbus,N 6,,5-vvs033-n6,#db711d,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 7,,5-vvs033-n7,#ff2e1d,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 8,,5-vvs033-n8,#2c2e35,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 9,,5-vvs033-n9,#bb298a,#ffffff,,rectangle,
-vvs-ssb-nachtbus,N 10,,5-vvs033-n10,#ff8ea5,#06429a,,rectangle,
-vvs-ssb-stadtbahn,SB,,3-vvs021-20,#ffb530,#24629d,,rectangle,
-vvs-ssb-stadtbahn,U 1,,8-vvs020-u1,#d39d70,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 11,,8-vvs020-u11,#9b9c9f,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 12,,8-vvs020-u12,#80c6ea,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 13,,8-vvs020-u13,#fea0ba,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 14,,8-vvs020-u14,#64c255,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 15,,8-vvs020-u15,#0155ae,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 16,,8-vvs020-u16,#c6c03b,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 19,,8-vvs020-u19,#ffb530,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 2,,8-vvs020-u2,#ff6a2f,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 3,,8-vvs020-u3,#925d39,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 4,,8-vvs020-u4,#6866b5,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 5,,8-vvs020-u5,#18c5f4,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 6,,8-vvs020-u6,#fb3199,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 7,,8-vvs020-u7,#2bbb8f,#ffffff,,rectangle,
-vvs-ssb-stadtbahn,U 8,,8-vvs020-u8,#c8b97b,#000000,,rectangle,
-vvs-ssb-stadtbahn,U 9,,8-vvs020-u9,#ffd036,#000000,,rectangle,
-vvs-ssb-stadtbahn,Zacke,,8-vvs021-10,#ffb530,#24629d,,rectangle,
-vvs-wbg,508,,5-vvs031-508,#875300,#ffffff,,rectangle,
-vvs-wbg,532,,5-vvs031-532,#5e8694,#ffffff,,rectangle,
-vvs-wbg,532A,,5-vvs031-532a,#5e8694,#ffffff,,rectangle,
-vvs-wbg,533,,5-vvs031-533,#d3a170,#000000,,rectangle,
-vvs-wbg,533A,,5-vvs031-533a,#d3a170,#000000,,rectangle,
-vvs-wbg,534,,5-vvs031-534,#007b3d,#ffffff,,rectangle,
-vvs-wbg,534A,,5-vvs031-534a,#007b3d,#ffffff,,rectangle,
-vvs-wbg,535,,5-vvs031-535,#c597b7,#000000,,rectangle,
-vvs-wbg,536,,5-vvs031-536,#f3a4b9,#000000,,rectangle,
-vvs-wbg,536A,,5-vvs031-536a,#f3a4b9,#000000,,rectangle,
-vvs-weg,RB 46,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb46,#561c6f,#ffffff,,rectangle,
-vvs-weg,RB 47,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb47,#b0599e,#ffffff,,rectangle,
-vvs-weg,RB 61,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb61,#561c6f,#ffffff,,rectangle,
-vvs-weg,RB 65,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb65,#b0599e,#ffffff,,rectangle,
-vvt-db-regio-bayern,S7,db-regio-ag-bayern,4-800790-7,#d09eba,#ffffff,,rectangle,
-vvt-oebb,cjx1,osterreichische-bundesbahnen,cjx-1,#48c9f2,#ffffff,,rectangle,
-vvt-oebb,S2,osterreichische-bundesbahnen,4-81-2-1365196-5198757,#f45f98,#ffffff,,rectangle,
-vvt-oebb,S3,osterreichische-bundesbahnen,4-81-3-1268243-5257783,#b0b6c8,#ffffff,,rectangle,
-vvt-oebb,S4,osterreichische-bundesbahnen,4-81-4-1268243-5257783,#4a205d,#ffffff,,rectangle,
-vvt-oebb,S6,osterreichische-bundesbahnen,4-81-6,#b01319,#ffffff,,rectangle,
-vvt-oebb,S8,osterreichische-bundesbahnen,4-81-8-1341673-5283199,#25aae1,#ffffff,,rectangle,
-vvv-montafoner-bahn,S4,montafoner-bahn,4-810003-4,#ffcb06,#ffffff,,rectangle,
-vvv-oebb,S1,osterreichische-bundesbahnen,4-81-1-1079437-5289939,#dd1936,#ffffff,,rectangle,
-vvv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1054446-5247224,#dd1936,#ffffff,,rectangle,
-vvv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1072203-5278907,#dd1936,#ffffff,,rectangle,
-vvv-oebb,R1,osterreichische-bundesbahnen,r-1,#dd1936,#ffffff,,rectangle,
-vvv-oebb,R2,osterreichische-bundesbahnen,r-2,#dd1936,#ffffff,,rectangle,
-vvv-oebb,R5,osterreichische-bundesbahnen,r-5,#dd1936,#ffffff,,rectangle,
-waldbahn-dlb,RB 35,waldbahn-die-landerbahn-gmbh-dlb,rb35,#006629,#ffffff,,rectangle,
-waldbahn-dlb,RB 36,waldbahn-die-landerbahn-gmbh-dlb,rb36,#90bf26,#ffffff,,rectangle,
-waldbahn-dlb,RB 37,waldbahn-die-landerbahn-gmbh-dlb,rb37,#ffb200,#ffffff,,rectangle,
-waldbahn-dlb,RB 38,waldbahn-die-landerbahn-gmbh-dlb,rb38,#ff6600,#ffffff,,rectangle,
-westfalenbahn,RE 15,westfalenbahn,wfb-re15,#ea9d22,#ffffff,,rectangle,
-westfalenbahn,RE 60,westfalenbahn,wfb-re60,#00a3de,#ffffff,,rectangle,
-westfalenbahn,RE 70,westfalenbahn,wfb-re70,#005174,#ffffff,,rectangle,
-wt-bvo,349,,5-owl021-349,#e20079,#ffffff,,pill,
-wt-bvo,350,,5-owl021-350,#004e2d,#ffffff,,pill,
-wt-bvo,351,,5-owl021-351,#97bf0d,#002650,,pill,
-wt-bvo,S60,,5-vph082-s60,#0089cf,#ffffff,,rectangle,
-wt-bvo,S85,,5-vph077-s85,#0089cf,#ffffff,,rectangle,
-wt-bvo,S90,,5-vph082-s90,#0089cf,#ffffff,,rectangle,
-wt-bvo,R10,,5-vph076-r10,#ed2927,#ffffff,,rectangle,
-wt-bvo,R11,,5-vph076-r11,#ed2927,#ffffff,,rectangle,
-wt-bvo,R61,,5-vph082-r61,#ed2927,#ffffff,,rectangle,
-wt-bvo,R70,,5-vph076-r70,#ed2927,#ffffff,,rectangle,
-wt-bvo,R71,,5-vph076-r71,#ed2927,#ffffff,,rectangle,
-wt-bvo,R72,,5-vph076-r72,#ed2927,#ffffff,,rectangle,
-wt-bvo,R81,,5-vph077-r81,#ed2927,#ffffff,,rectangle,
-wt-bvo,480,,5-vph077-480,#36b64b,#ffffff,,rectangle,
-wt-bvo,481,,5-vph077-481,#36b64b,#ffffff,,rectangle,
-wt-bvo,485,,5-vph077-485,#36b64b,#ffffff,,rectangle,
-wt-bvo,487,,5-vph077-487,#36b64b,#ffffff,,rectangle,
-wt-bvo,488,,5-vph077-488,#36b64b,#ffffff,,rectangle,
-wt-bvo,489,,5-vph077-489,#36b64b,#ffffff,,rectangle,
-wt-go-on,R20,,5-vph072-r20,#ed2927,#ffffff,,rectangle,
-wt-go-on,R41,,5-vph071-r41,#ed2927,#ffffff,,rectangle,
-wt-go-on,R45,,5-vph071-r45,#ed2927,#ffffff,,rectangle,
-wt-go-on,R50,,5-vph072-r50,#ed2927,#ffffff,,rectangle,
-wt-go-on,R51,,5-vph077-r51,#ed2927,#ffffff,,rectangle,
-wt-go-on,S30,,5-vph080-s30,#0089cf,#ffffff,,rectangle,
-wt-go-on,S40,,5-vph071-s40,#0089cf,#ffffff,,rectangle,
-wt-mobiel,1,mobiel-gmbh,8-owl031-1,#009fe0,#ffffff,,rectangle,
-wt-mobiel,2,mobiel-gmbh,8-owl031-2,#008f36,#ffffff,,rectangle,
-wt-mobiel,3,mobiel-gmbh,8-owl031-3,#ffed00,#00264f,,rectangle,
-wt-mobiel,4,mobiel-gmbh,8-owl031-4,#e3001b,#ffffff,,rectangle,
-wt-mobiel,N1,,5-owl032-n1,#002f6b,#ffffff,,rectangle,
-wt-mobiel,N2,,5-owl032-n2,#e20040,#ffffff,,rectangle,
-wt-mobiel,N3,,5-owl032-n3,#89ba17,#ffffff,,rectangle,
-wt-mobiel,N4,,5-owl032-n4,#006ab3,#ffffff,,rectangle,
-wt-mobiel,N5,,5-owl032-n5,#93191e,#ffffff,,rectangle,
-wt-mobiel,N6,,5-owl032-n6,#eb690b,#ffffff,,rectangle,
-wt-mobiel,N7,,5-owl032-n7,#00501f,#ffffff,,rectangle,
-wt-mobiel,N8,,5-owl032-n8,#009ee0,#ffffff,,rectangle,
-wt-mobiel,N11,,5-owl032-n11,#00acb6,#ffffff,,rectangle,
-wt-mobiel,N12,,5-owl032-n12,#96427f,#ffffff,,rectangle,
-wt-mobiel,N14,,5-owl032-n14,#c50a33,#ffffff,,rectangle,
-wt-mobiel,N15,,5-owl032-n15,#93191e,#ffffff,,rectangle,
-wt-mobiel,N18,,5-owl032-n18,#45c0eb,#ffffff,,rectangle,
-wt-mobiel,SEV 1,,5-owl032-ev1,#ef93ba,#002650,,pill,
-wt-mobiel,S15,,5-owl032-s15,#002650,#ffffff,,pill,
-wt-mobiel,21,,5-owl032-21,#d75163,#ffffff,,pill,
-wt-mobiel,22,,5-owl032-22,#d75163,#ffffff,,pill,
-wt-mobiel,23,,5-owl032-23,#e85b98,#002650,,pill,
-wt-mobiel,24,,5-owl032-24,#655a9f,#ffffff,,pill,
-wt-mobiel,25,,5-owl032-25,#97bf0d,#002650,,pill,
-wt-mobiel,26,,5-owl032-26,#97bf0d,#002650,,pill,
-wt-mobiel,27,,5-owl032-27,#f19fc1,#002650,,pill,
-wt-mobiel,28,,5-owl032-28,#004178,#ffffff,,pill,
-wt-mobiel,29,,5-owl032-29,#f39400,#002650,,pill,
-wt-mobiel,30,,5-owl032-30,#007dc4,#ffffff,,pill,
-wt-mobiel,31,,5-owl032-31,#655a9f,#ffffff,,pill,
-wt-mobiel,32,,5-owl032-32,#97bf0d,#002650,,pill,
-wt-mobiel,33,,5-owl032-33,#fbbc00,#002650,,pill,
-wt-mobiel,34,,5-owl032-34,#ffe500,#002650,,pill,
-wt-mobiel,36,,5-owl032-36,#a53723,#ffffff,,pill,
-wt-mobiel,37,,5-owl032-37,#f19fc1,#002650,,pill,
-wt-mobiel,38,,5-owl032-38,#004178,#ffffff,,pill,
-wt-mobiel,39,,5-owl032-39,#004e2d,#ffffff,,pill,
-wt-mobiel,46,,5-owl032-46,#655a9f,#ffffff,,pill,
-wt-mobiel,47,,5-owl032-47,#655a9f,#ffffff,,pill,
-wt-mobiel,51,,5-owl032-51,#ad8dbc,#002650,,pill,
-wt-mobiel,54,,5-owl032-54,#e20079,#ffffff,,pill,
-wt-mobiel,55,,5-owl032-55,#a53723,#ffffff,,pill,
-wt-mobiel,56,,5-owl032-56,#fbbc00,#002650,,pill,
-wt-mobiel,57,,5-owl032-57,#009037,#ffffff,,pill,
-wt-mobiel,58,,5-owl032-58,#009037,#ffffff,,pill,
-wt-mobiel,63,,5-owl032-63,#172983,#ffffff,,pill,
-wt-mobiel,64,,5-owl032-64,#172983,#ffffff,,pill,
-wt-mobiel,87,,5-owl032-87,#004e2d,#ffffff,,pill,
-wt-mobiel,94,,5-owl032-94,#ad8dbc,#002650,,pill,
-wt-mobiel,95,,5-owl032-95,#009037,#ffffff,,pill,
-wt-mobiel,101,,5-owl032-101,#e85b98,#002650,,pill,
-wt-mobiel,121,,5-owl032-121,#b09d1e,#002650,,pill,
-wt-mobiel,122,,5-owl032-122,#007dc4,#ffffff,,pill,
-wt-mobiel,123,,5-owl032-123,#007dc4,#ffffff,,pill,
-wt-mobiel,128,,5-owl032-128,#f39400,#002650,,pill,
-wt-mobiel,131,,5-owl032-131,#d75163,#ffffff,,pill,
-wt-mobiel,135,,5-owl032-135,#e20079,#ffffff,,pill,
-wt-mobiel,136,,5-owl032-136,#e2001a,#ffffff,,pill,
-wt-mobiel,138,,5-owl032-138,#004178,#ffffff,,pill,
-wt-mobiel,142,,5-owl032-142,#d75163,#ffffff,,pill,
-wt-mobiel,154,,5-owl032-154,#004178,#ffffff,,pill,
-wt-mobiel,155,,5-owl032-155,#39a9dc,#002650,,pill,
-wt-mobiel,228,,5-owl032-228,#41a62b,#ffffff,,pill,
-wt-mobiel,236,,5-owl032-236,#004178,#ffffff,,pill,
-wt-mobiel,352,,5-owl032-352,#e2001a,#ffffff,,pill,
-wt-mobiel,369,,5-owl032-369,#ad8dbc,#002650,,pill,
-wt-padersprinter,N2,,5-vph063-n2,#37ac47,#ffffff,,rectangle,
-wt-padersprinter,N4,,5-vph063-n4,#00b9f2,#ffffff,,rectangle,
-wt-padersprinter,1,,5-vph063-1,#f6c954,#ffffff,,rectangle,
-wt-padersprinter,2,,5-vph063-2,#4eac91,#ffffff,,rectangle,
-wt-padersprinter,3,,5-vph063-3,#9c69af,#ffffff,,rectangle,
-wt-padersprinter,4,,5-vph063-4,#a16335,#ffffff,,rectangle,
-wt-padersprinter,5,,5-vph063-5,#98273b,#ffffff,,rectangle,
-wt-padersprinter,6,,5-vph063-6,#8ad7f4,#ffffff,,rectangle,
-wt-padersprinter,7,,5-vph063-7,#e29042,#ffffff,,rectangle,
-wt-padersprinter,8,,5-vph063-8,#95c65a,#ffffff,,rectangle,
-wt-padersprinter,9,,5-vph063-9,#e98bbd,#ffffff,,rectangle,
-wt-padersprinter,10,,5-vph063-10,#7fba91,#ffffff,,rectangle,
-wt-padersprinter,11,,5-vph063-11,#5d201d,#ffffff,,rectangle,
-wt-padersprinter,12,,5-vph063-12,#18367d,#ffffff,,rectangle,
-wt-padersprinter,13,,5-vph063-13,#5fb458,#ffffff,,rectangle,
-wt-padersprinter,14,,5-vph063-14,#7b4586,#ffffff,,rectangle,
-wt-padersprinter,16,,5-vph063-16,#469cd8,#ffffff,,rectangle,
-wt-padersprinter,20,,5-vph063-20,#7fba91,#ffffff,,rectangle,
-wt-padersprinter,23,,5-vph063-23,#5fb458,#ffffff,,rectangle,
-wt-padersprinter,42,,5-vph063-42,#9b9c9f,#ffffff,,rectangle,
-wt-padersprinter,43,,5-vph063-43,#9b9c9f,#ffffff,,rectangle,
-wt-padersprinter,44,,5-vph063-44,#9b9c9f,#ffffff,,rectangle,
-wt-padersprinter,45,,5-vph063-45,#9b9c9f,#ffffff,,rectangle,
-wt-padersprinter,ALF46,,9-vph063-46alf,#ffffff,#9b9c9f,#9b9c9f,rectangle,
-wt-padersprinter,47,,5-vph063-47,#9b9c9f,#ffffff,,rectangle,
-wt-padersprinter,48,,5-vph063-48,#9b9c9f,#ffffff,,rectangle,
-wt-padersprinter,100,,5-vph063-100,#469cd8,#ffffff,,rectangle,
-wt-rvm,R51,,5-vgm023-r51,#006fb9,#ffffff,,rectangle-rounded-corner,
-wt-rvm,S50,,5-vgm020-s50,#c24636,#ffffff,,rectangle-rounded-corner,
-wt-twv,N19,,5-owl051-n19,#f7a600,#ffffff,,rectangle,
-wt-twv,48,,5-owl051-48,#39a9dc,#002650,,pill,
-wt-twv,59,,5-owl051-59,#e2001a,#ffffff,,pill,
-wt-twv,61,,5-owl051-61,#39a9dc,#002650,,pill,
-wt-twv,62,,5-owl051-62,#39a9dc,#002650,,pill,
-wt-twv,80.2,,5-owl050-80-2,#e2001a,#ffffff,,pill,
-wt-twv,88,,5-owl051-88,#e85b98,#002650,,pill,
-zvnl-bus,60,,5-naslvb-60,#a61580,#ffffff,,pill,
-zvnl-bus,65,,5-naslvb-65,#a61580,#ffffff,,pill,
-zvnl-bus,70,,5-naslvb-70,#a61580,#ffffff,,pill,
-zvnl-bus,72,,5-naslvb-72,#a61580,#ffffff,,pill,
-zvnl-bus,73,,5-naslvb-73,#a61580,#ffffff,,pill,
-zvnl-bus,74,,5-naslvb-74,#a61580,#ffffff,,pill,
-zvnl-bus,80,,5-naslvb-80,#a61580,#ffffff,,pill,
-zvnl-bus,81,,5-naslvb-81,#a61580,#ffffff,,pill,
-zvnl-bus,82,,5-naslvb-82,#a61580,#ffffff,,pill,
-zvnl-bus,89,,5-naslvb-89,#a61580,#ffffff,,pill,
-zvnl-bus,90,,5-naslvb-90,#a61580,#ffffff,,pill,
-zvnl-bus,N1,,5-naslvb-n1,#f5a522,#000000,,pill,
-zvnl-bus,N2,,5-naslvb-n2,#fee38e,#000000,,pill,
-zvnl-bus,N3,,5-naslvb-n3,#fed92b,#000000,,pill,
-zvnl-bus,N4,,5-naslvb-n4,#fed92b,#000000,,pill,
-zvnl-bus,N5,,5-naslvb-n5,#f5a522,#000000,,pill,
-zvnl-bus,N6,,5-naslvb-n6,#fed92b,#000000,,pill,
-zvnl-bus,N7,,5-naslvb-n7,#fee38e,#000000,,pill,
-zvnl-bus,N8,,5-naslvb-n8,#f5a522,#000000,,pill,
-zvnl-bus,N9,,5-naslvb-n9,#fed92b,#000000,,pill,
-zvnl-bus,N60,,5-naslvb-n60,#a61580,#000000,,pill,
-zvnl-tram,1,,8-naslvt-1,#67b337,#ffffff,,rectangle,
-zvnl-tram,2,,8-naslvt-2,#fecb29,#000000,,rectangle,
-zvnl-tram,3,,8-naslvt-3,#67b337,#ffffff,,rectangle,
-zvnl-tram,4,,8-naslvt-4,#233b8d,#ffffff,,rectangle,
-zvnl-tram,7,,8-naslvt-7,#233b8d,#ffffff,,rectangle,
-zvnl-tram,8,,8-naslvt-8,#fecb29,#000000,,rectangle,
-zvnl-tram,9,,8-naslvt-9,#fecb29,#000000,,rectangle,
-zvnl-tram,10,,8-naslvt-10,#e1001e,#ffffff,,rectangle,
-zvnl-tram,11,,8-naslvt-11,#e1001e,#ffffff,,rectangle,
-zvnl-tram,12,,8-naslvt-12,#233b8d,#ffffff,,rectangle,
-zvnl-tram,14,,8-naslvt-14,#18a0e1,#ffffff,,rectangle,
-zvnl-tram,15,,8-naslvt-15,#233b8d,#ffffff,,rectangle,
-zvnl-tram,16,,8-naslvt-16,#e1001e,#ffffff,,rectangle,
-zvnl-tram,50,,8-naslvt-50,#ffffff,#000000,#000000,rectangle,
-zvnl-tram,56,,8-naslvt-56,#ffffff,#000000,#000000,rectangle,
-zvnl-tram,N10,,8-naslvt-n10,#e1001e,#ffffff,,rectangle,
-zvnl-tram,N17,,8-naslvt-n17,#67b337,#ffffff,,rectangle,
+shortOperatorName,lineName,hafasOperatorCode,hafasLineId,backgroundColor,textColor,borderColor,shape,wikidataQid, delfiAgencyID, delfiAgencyName
+agilis,RB 15,agilis,ag-rb15,#24b27d,#ffffff,,rectangle,Q130542089,10838,agilis
+agilis,RB 17,agilis,ag-rb17,#90bf26,#ffffff,,rectangle,Q130542097,10838,agilis
+agilis,RB 18,agilis,ag-rb18,#ff9999,#ffffff,,rectangle,Q104149638,10838,agilis
+agilis,RB 21,agilis,ag-rb21,#e5a05c,#ffffff,,rectangle,Q130542098,10838,agilis
+agilis,RB 22,agilis,ag-rb22,#90bf26,#ffffff,,rectangle,Q115773398,10838,agilis
+agilis,RB 24,agilis,ag-rb24,#00ace5,#ffffff,,rectangle,Q130542099,10838,agilis
+agilis,RB 26,agilis,ag-rb26,#6cc3d9,#ffffff,,rectangle,Q130542100,10838,agilis
+agilis,RB 34,agilis,ag-rb34,#bf73bf,#ffffff,,rectangle,Q130542101,10838,agilis
+agilis,RB 51,agilis,ag-rb51,#bf73bf,#ffffff,,rectangle,Q130542102,10838,agilis
+agilis,RB 95,agilis,ag-rb95,#ff6600,#ffffff,,rectangle,Q130542103,10838,agilis
+agilis,RB 96,agilis,ag-rb96,#ff6600,#ffffff,,rectangle,Q130542104,10838,agilis
+agilis,RB 97,agilis,ag-rb97,#90bf26,#ffffff,,rectangle,Q130542106,10838,agilis
+agilis,RB 98,agilis,ag-rb98,#24b27d,#ffffff,,rectangle,Q130542107,10838,agilis
+agilis,RB 99,agilis,ag-rb99,#ffb200,#ffffff,,rectangle,Q130542108,10838,agilis
+agilis,RE 18,agilis,ag-re18,#006428,#ffffff,,rectangle,Q130542152,10838,agilis
+alex-dlb,RE 23,alex-die-landerbahn-gmbh-dlb,re23,#ffffff,#006666,#006666,rectangle,Q130542294,10837,alex - Die Länderbahn GmbH DLB
+alex-dlb,RE 25,alex-die-landerbahn-gmbh-dlb,re25,#006666,#ffffff,,rectangle,Q130542295,10837,alex - Die Länderbahn GmbH DLB
+ams,S7,abellio-rail-mitteldeutschland-gmbh,4-ams-7,#0a579b,#ffffff,,pill,Q63217583,11961,Abellio Rail Mitteldeutschland GmbH
+arverio-bw,RE 1,arverio-baden-wurttemberg,re-1,#88c946,#ffffff,,rectangle,Q64504218,13631,Go-Ahead Baden-Württemberg GmbH
+arverio-bw,MEX 13,arverio-baden-wurttemberg,mex-13,#00b9f2,#ffffff,,rectangle,Q130542338,13631,Go-Ahead Baden-Württemberg GmbH
+arverio-bw,MEX 16,arverio-baden-wurttemberg,mex-16,#0073c0,#ffffff,,rectangle,Q130542339,13631,Go-Ahead Baden-Württemberg GmbH
+arverio-bw,RE 8,arverio-baden-wurttemberg,re-8,#b350a8,#ffffff,,rectangle,Q64512248,13631,Go-Ahead Baden-Württemberg GmbH
+arverio-bw,RB 8,arverio-baden-wurttemberg,rb-8,#b350a8,#ffffff,,rectangle,Q131583892,13631,Go-Ahead Baden-Württemberg GmbH
+arverio-bw,RE 90,arverio-baden-wurttemberg,re-90,#fd3083,#ffffff,,rectangle,Q64512220,13631,Go-Ahead Baden-Württemberg GmbH
+arverio-by,RB86,arverio-bayern,rb-86,#77aed2,#ffffff,,rectangle,Q130789113,13786,Go-Ahead Bayern GmbH
+arverio-by,RB87,arverio-bayern,rb-87,#77aed2,#ffffff,,rectangle,Q130789121,13786,Go-Ahead Bayern GmbH
+arverio-by,RB89,arverio-bayern,rb-89,#006da7,#ffffff,,rectangle,Q130789128,13786,Go-Ahead Bayern GmbH
+arverio-by,RB92,arverio-bayern,rb-92,#f28f8e,#ffffff,,rectangle,Q130789133,13786,Go-Ahead Bayern GmbH
+arverio-by,RE72,arverio-bayern,re-72,#ef7c00,#ffffff,,rectangle,Q130789094,13786,Go-Ahead Bayern GmbH
+arverio-by,RE80,arverio-bayern,re-80,#006da7,#ffffff,,rectangle,Q116761629,13786,Go-Ahead Bayern GmbH
+arverio-by,RE89,arverio-bayern,re-89,#006da7,#ffffff,,rectangle,Q130789100,13786,Go-Ahead Bayern GmbH
+arverio-by,RE9,arverio-bayern,re-9,#006da7,#ffffff,,rectangle,Q130789102,13786,Go-Ahead Bayern GmbH
+arverio-by,RE96,arverio-bayern,re-96,#f9b000,#ffffff,,rectangle,Q130789109,13786,Go-Ahead Bayern GmbH
+bayerische-zugspitzbahn,RB 64,bayerische-zugspitzbahn,bzb-rb64,#6cc3d9,#ffffff,,rectangle,,10971,Bayerische Zugspitzbahn
+brb,RB 13,bayerische-regiobahn,brb-rb13,#ffb200,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 14,bayerische-regiobahn,brb-rb14,#ffb200,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 53,bayerische-regiobahn,brb-rb53,#ff9999,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 54,bayerische-regiobahn,brb-rb54,#00ace5,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 55,bayerische-regiobahn,brb-rb55,#ff6600,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 56,bayerische-regiobahn,brb-rb56,#ff6600,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 57,bayerische-regiobahn,brb-rb57,#ff6600,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 58,bayerische-regiobahn,brb-rb58,#ffb200,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 67,bayerische-regiobahn,brb-rb67,#bf73bf,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 68,bayerische-regiobahn,brb-rb68,#ffffff,#90bf26,#90bf26,rectangle,,10969,Bayerische Regiobahn
+brb,RB 69,bayerische-regiobahn,brb-rb69,#00ace5,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 77,bayerische-regiobahn,brb-rb77,#24b27d,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,RB 83,bayerische-regiobahn,brb-rb83,#ffffff,#bf73bf,#bf73bf,rectangle,,10969,Bayerische Regiobahn
+brb,RE 5,bayerische-regiobahn,brb-re5,#00416d,#ffffff,,rectangle,,10969,Bayerische Regiobahn
+brb,S3,bayerische-regiobahn,4-l8-s3,#2aa335,#ffffff,,pill,,10969,Bayerische Regiobahn
+brb,S4,bayerische-regiobahn,4-l8-s4,#a765a2,#ffffff,,pill,,10969,Bayerische Regiobahn
+ceske-drahy,RE 25,ceske-drahy,ex-352,#006666,#ffffff,,rectangle,,12634,Ceske Drahy
+ceske-drahy,RE 25,ceske-drahy,ex-354,#006666,#ffffff,,rectangle,,12634,Ceske Drahy
+ceske-drahy,RE 25,ceske-drahy,ex-362,#006666,#ffffff,,rectangle,,12634,Ceske Drahy
+ceske-drahy,RE 25,ceske-drahy,ex-364,#006666,#ffffff,,rectangle,,12634,Ceske Drahy
+cfl,RE 11,cfl,re-11,#20b159,#ffffff,,rectangle,,10459,CFL1
+cfl,RB 83,cfl,rb-83,#20b159,#ffffff,,rectangle,,10459,CFL1
+db-fernverkehr-ag,RE 87,db-fernverkehr-ag,re-87,#cc0066,#ffffff,,rectangle,,10918,DB Fernverkehr (Codesharing)
+db-regio-ag-baden-wurttemberg,RE 2,db-regio-ag-baden-wurttemberg,re-2,#0069b4,#ffffff,,rectangle,Q88627355,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 3,db-regio-ag-baden-wurttemberg,re-3,#e5007d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 4,db-regio-ag-baden-wurttemberg,re-4,#a05a2c,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 5,db-regio-ag-baden-wurttemberg,re-5,#724019,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 6,db-regio-ag-baden-wurttemberg,re-6,#4d4d4d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 7,db-regio-ag-baden-wurttemberg,re-7,#ed6e19,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 14a,db-regio-ag-baden-wurttemberg,re-14a,#f39794,#000000,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 14b,db-regio-ag-baden-wurttemberg,re-14b,#02aa9e,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,MEX 19,db-regio-ag-baden-wurttemberg,mex-19,#999999,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 26,db-regio-ag-baden-wurttemberg,rb-26,#009fe3,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 27,db-regio-ag-baden-wurttemberg,rb-27,#008c3c,#ffffff,,rectangle,Q130280632,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 28,db-regio-ag-baden-wurttemberg,rb-28,#724019,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 30,db-regio-ag-baden-wurttemberg,rb-30,#571d70,#ffffff,,rectangle,Q130280647,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 31,db-regio-ag-baden-wurttemberg,rb-31,#00a99d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 32,db-regio-ag-baden-wurttemberg,rb-32,#008c3c,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 37,db-regio-ag-baden-wurttemberg,rb-37,#aec90a,#ffffff,,rectangle,Q130283617,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 50,db-regio-ag-baden-wurttemberg,re-50,#b5931c,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 52,db-regio-ag-baden-wurttemberg,rb-52,#00a99d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 53,db-regio-ag-baden-wurttemberg,rb-53,#561c6f,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 55,db-regio-ag-baden-wurttemberg,re-55,#b0599e,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 63,db-regio-ag-baden-wurttemberg,rb-63,#d30730,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 72,db-regio-ag-baden-wurttemberg,rb-72,#008c3c,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 74,db-regio-ag-baden-wurttemberg,rb-74,#0a69b2,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RB 93,db-regio-ag-baden-wurttemberg,rb-93,#009fe3,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 93,db-regio-ag-baden-wurttemberg,re-93,#009fe3,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,MEX 90,db-regio-ag-baden-wurttemberg,mex-90,#e5007d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+db-regio-ag-baden-wurttemberg,RE 200,db-regio-ag-baden-wurttemberg,re-200,#aa0344,#ffffff,,rectangle,Q114680512,10443,DB Regio AG Baden-Württemberg
+db-regio-bayern,RB 6,db-regio-ag-bayern,rb-6,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 10,db-regio-ag-bayern,rb-10,#90bf26,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 11,db-regio-ag-bayern,rb-11,#00ace5,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 12,db-regio-ag-bayern,rb-12,#6cc3d9,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 16,db-regio-ag-bayern,rb-16,#ff9999,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 21,db-regio-ag-bayern,rb-21,#e5a05c,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 25,db-regio-ag-bayern,rb-25,#ffa0a0,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 30,db-regio-ag-bayern,rb-30,#bf73bf,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 31,db-regio-ag-bayern,rb-31,#ff9999,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 33,db-regio-ag-bayern,rb-33,#bf73bf,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 53,db-regio-ag-bayern,rb-53,#bf73bf,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 60,db-regio-ag-bayern,rb-60,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 61,db-regio-ag-bayern,rb-61,#bf73bf,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 62,db-regio-ag-bayern,rb-62,#90bf26,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 63,db-regio-ag-bayern,rb-63,#ffb200,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 65,db-regio-ag-bayern,rb-65,#ff9999,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 66,db-regio-ag-bayern,rb-66,#ff9999,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 73,db-regio-ag-bayern,rb-73,#6cc3d9,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 74,db-regio-ag-bayern,rb-74,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 78,db-regio-ag-bayern,rb-78,#ff9999,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 79,db-regio-ag-bayern,rb-79,#ffffff,#90bf26,#90bf26,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 80,db-regio-ag-bayern,rb-80,#ffffff,#008fbf,#008fbf,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 81,db-regio-ag-bayern,rb-81,#24b27d,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 82,db-regio-ag-bayern,rb-82,#00ace5,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 85,db-regio-ag-bayern,rb-85,#009fe3,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 91,db-regio-ag-bayern,rb-91,#6cc3d9,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RB 94,db-regio-ag-bayern,rb-94,#ffffff,#90bf26,#90bf26,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 1,db-regio-ag-bayern,re-1,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 2,db-regio-ag-bayern,re-2,#00b2b2,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 3,db-regio-ag-bayern,re-3,#800080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 7,db-regio-ag-bayern,re-7,#992e00,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 10,db-regio-ag-bayern,re-10,#006428,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 14,db-regio-ag-bayern,re-14,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 16,db-regio-ag-bayern,re-16,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 17,db-regio-ag-bayern,re-17,#992e00,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 19,db-regio-ag-bayern,re-19,#ff6600,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 20,db-regio-ag-bayern,re-20,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 22,db-regio-ag-bayern,re-22,#ff6600,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 28,db-regio-ag-bayern,re-28,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 29,db-regio-ag-bayern,re-29,#ffffff,#ff6600,#ff6600,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 30,db-regio-ag-bayern,re-30,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 31,db-regio-ag-bayern,re-31,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 32,db-regio-ag-bayern,re-32,#004080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 33,db-regio-ag-bayern,re-33,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 35,db-regio-ag-bayern,re-35,#004080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 38,db-regio-ag-bayern,re-38,#008fbf,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 40,db-regio-ag-bayern,re-40,#992e00,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 41,db-regio-ag-bayern,re-41,#992e00,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 43,db-regio-ag-bayern,re-43,#ffffff,#992e00,#992e00,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 47,db-regio-ag-bayern,re-47,#ffffff,#992e00,#992e00,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 50,db-regio-ag-bayern,re-50,#804080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 54,db-regio-ag-bayern,re-54,#800080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 55,db-regio-ag-bayern,re-55,#800080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 60,db-regio-ag-bayern,re-60,#ffffff,#800080,#800080,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 61,db-regio-ag-bayern,re-61,#ffffff,#992e00,#992e00,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 62,db-regio-ag-bayern,re-62,#ffffff,#992e00,#992e00,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 70,db-regio-ag-bayern,re-70,#006629,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 71,db-regio-ag-bayern,re-71,#e5a05c,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 73,db-regio-ag-bayern,re-73,#e5a05c,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 75,db-regio-ag-bayern,re-75,#e50000,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 76,db-regio-ag-bayern,re-76,#006629,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-bayern,RE 79,db-regio-ag-bayern,re-79,#800080,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+db-regio-mitte,RE1,db-regio-ag-mitte-suwex,re-1,#be1b40,#ffffff,,rectangle-rounded-corner,Q112773387,10445,SÜWEX
+db-regio-mitte,RE2,db-regio-ag-mitte-suwex,re-2,#e3a023,#ffffff,,rectangle-rounded-corner,,10445,SÜWEX
+db-regio-mitte,RE4,db-regio-ag-mitte-suwex,re-4,#970c7e,#ffffff,,rectangle-rounded-corner,Q112996721,10445,SÜWEX
+db-regio-mitte,RE6,db-regio-ag-mitte,re-6,#f15921,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE 11,db-regio-ag-mitte-suwex,re-11,#20b159,#ffffff,,rectangle,,10445,SÜWEX
+db-regio-mitte,RE14,db-regio-ag-mitte-suwex,re-14,#970c7e,#ffffff,,rectangle-rounded-corner,Q112996572,10445,SÜWEX
+db-regio-mitte,RE20,db-regio-ag-mitte,re-20,#ee1d23,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE25,db-regio-ag-mitte,re-25,#007ec5,#ffffff,,rectangle-rounded-corner,Q98104051,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB22,db-regio-ag-mitte,rb-22,#ee1d23,#ffffff,,rectangle-rounded-corner,Q130342880,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB23,db-regio-ag-mitte,rb-23,#15c0f2,#ffffff,,rectangle-rounded-corner,Q96474187,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE30,db-regio-ag-mitte,re-30,#e30019,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB45,db-regio-ag-mitte,rb-45,#8bc63f,#ffffff,,rectangle-rounded-corner,Q98152720,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB46,db-regio-ag-mitte,rb-46,#00805f,#ffffff,,rectangle-rounded-corner,Q98152733,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE50,db-regio-ag-mitte,re-50,#e30019,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB51,db-regio-ag-mitte,rb-51,#00805f,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB53,db-regio-ag-mitte,rb-53,#40ae49,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB55,db-regio-ag-mitte,rb-55,#005824,#ffffff,,rectangle-rounded-corner,Q108435213,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE40,db-regio-ag-mitte,re-40,#ff9027,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB41,db-regio-ag-mitte,rb-41,#00ab4f,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB44,db-regio-ag-mitte,rb-44,#7ac547,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE45,db-regio-ag-mitte,re-45,#cf631a,#ffffff,,rectangle-rounded-corner,Q126890289,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE60,db-regio-ag-mitte,re-60,#d03831,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB67,db-regio-ag-mitte,rb-67,#406bb1,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB68,db-regio-ag-mitte,rb-68,#406bb1,#ffffff,,rectangle-rounded-corner,Q68930888,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE70,db-regio-ag-mitte,re-70,#d03831,#ffffff,,rectangle-rounded-corner,Q80105383,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RE73,db-regio-ag-mitte,re-73,#ff2e17,#ffffff,,rectangle-rounded-corner,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,RB 83,db-regio-ag-mitte,rb-83,#20b159,#ffffff,,rectangle,,10440,DB Regio AG Mitte Region Hessen
+db-regio-mitte,SE14,db-regio-ag-mitte-suwex,se14,#90268f,#ffffff,,rectangle-rounded-corner,,10445,SÜWEX
+db-regio-nordost,FEX,db-regio-ag-nordost,fex19829,#79122f,#ffffff,,rectangle,Q100533383,10434,DB Regio AG Nordost
+db-regio-nordost,RB10,db-regio-ag-nordost,rb-10,#66aa22,#ffffff,,rectangle,Q15195695,10434,DB Regio AG Nordost
+db-regio-nordost,RB11,db-regio-ag-nordost,rb-11,#ed1c24,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB12,db-regio-ag-nordost,rb-12,#399fdf,#ffffff,,rectangle,Q42383940,10434,DB Regio AG Nordost
+db-regio-nordost,RB14,db-regio-ag-nordost,rb-14,#a5027d,#ffffff,,rectangle,Q15119376,10434,DB Regio AG Nordost
+db-regio-nordost,RB17,db-regio-ag-nordost,rb-17,#dd4daf,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB18,db-regio-ag-nordost,rb-18,#399fdf,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB20,db-regio-ag-nordost,rb-20,#007734,#ffffff,,rectangle,Q68007873,10434,DB Regio AG Nordost
+db-regio-nordost,RB21,db-regio-ag-nordost,rb-21,#501689,#ffffff,,rectangle,Q105947745,10434,DB Regio AG Nordost
+db-regio-nordost,RB22,db-regio-ag-nordost,rb-22,#009bd5,#ffffff,,rectangle,Q68006335,10434,DB Regio AG Nordost
+db-regio-nordost,RB23,db-regio-ag-nordost,3-800165-23,#eb7405,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB23,db-regio-ag-nordost,rb-23,#0066ad,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB24,db-regio-ag-nordost,3-800165-24,#da6ba2,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB24,db-regio-ag-nordost,rb-24,#e2001a,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB25,db-regio-ag-nordost,rb-25,#00a998,#ffffff,,rectangle,Q63484785,10434,DB Regio AG Nordost
+db-regio-nordost,RB28,db-regio-ag-nordost,rb-28,#ee7000,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB31,db-regio-ag-nordost,rb-31,#66aa22,#ffffff,,rectangle,Q66439830,10434,DB Regio AG Nordost
+db-regio-nordost,RB32,db-regio-ag-nordost,rb-32,#697c8a,#ffffff,,rectangle,Q112802971,10434,DB Regio AG Nordost
+db-regio-nordost,RB43,db-regio-ag-nordost,rb-43,#009bd5,#ffffff,,rectangle,Q84429153,10434,DB Regio AG Nordost
+db-regio-nordost,RB49,db-regio-ag-nordost,rb-49,#992746,#ffffff,,rectangle,Q84436359,10434,DB Regio AG Nordost
+db-regio-nordost,RB55,db-regio-ag-nordost,rb-55,#eb7405,#ffffff,,rectangle,Q63224617,10434,DB Regio AG Nordost
+db-regio-nordost,RB92,db-regio-ag-nordost,rb-92,#eb7405,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RB93,db-regio-ag-nordost,rb-93,#eb7405,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE1,db-regio-ag-nordost,re-1,#108449,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE2,db-regio-ag-nordost,re-2,#ffd502,#000000,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE3,db-regio-ag-nordost,re-3,#eb7405,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE4,db-regio-ag-nordost,3-800158-4,#992746,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE4,db-regio-ag-nordost,re-4,#66aa22,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE5,db-regio-ag-nordost,re-5,#0066ad,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE6,db-regio-ag-nordost,re-6,#da6ba2,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#007734,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE7,db-regio-ag-nordost,re-7,#da6ba2,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE10,db-regio-ag-nordost,re-10,#5e5e5d,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE11,db-regio-ag-nordost,re-11,#da6ba2,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE13,db-regio-ag-nordost,re-13,#009686,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE15,db-regio-ag-nordost,re-15,#ffd502,#000000,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE18,db-regio-ag-nordost,re-18,#eb7405,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE50,db-regio-ag-nordost,re-50,#2785d0,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,RE51,db-regio-ag-nordost,re-51,#00998a,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,S1,db-regio-ag-nordost,4-800156-1,#00a998,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,S2,db-regio-ag-nordost,4-800156-2,#a0138e,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,S2X,db-regio-ag-nordost,4-800156-2x,#a0138e,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-nordost,S3,db-regio-ag-nordost,4-800156-3,#a64c35,#ffffff,,rectangle,,10434,DB Regio AG Nordost
+db-regio-sudost,RB 51,db-regio-ag-sudost,rb-51,#469cd7,#ffffff,,rectangle,,10437,DB Regio AG Südost
+db-regio-sudost,RE 7,db-regio-ag-sudost,re-7,#992e00,#ffffff,,rectangle,Q1885609,10437,DB Regio AG Südost
+db-regio-sudost,RE 13,db-regio-ag-sudost,re-13,#ebaa3b,#ffffff,,rectangle,Q113505112,10437,DB Regio AG Südost
+db-regio-sudost,RE 14,db-regio-ag-sudost,re-14,#a98956,#ffffff,,rectangle,,10437,DB Regio AG Südost
+db-regio-sudost,RE 57,db-regio-ag-sudost,re-57,#992e00,#ffffff,,rectangle,,10437,DB Regio AG Südost
+db-regio-sudost,S1,db-regio-ag-sudost,4-800486-1,#f5de2b,#000000,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S2,db-regio-ag-sudost,4-8004a9-2,#18a2e3,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S3,db-regio-ag-sudost,4-800486-3,#e1001e,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S4,db-regio-ag-sudost,4-800486-4,#109644,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S5,db-regio-ag-sudost,4-800486-5,#ed7c1c,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S5X,db-regio-ag-sudost,4-800486-5x,#fdce5c,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S6,db-regio-ag-sudost,4-800486-6,#5c1239,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S8,db-regio-ag-sudost,4-8004a9-8,#5c2582,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S9,db-regio-ag-sudost,4-8004a9-9,#be006b,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S10,db-regio-ag-sudost,4-800486-10,#ffffff,#000000,#f5de2b,pill,,10437,DB Regio AG Südost
+db-regio-sudost,S47,db-regio-ag-sudost,4-8004a9-47,#53af4c,#ffffff,,pill,,10437,DB Regio AG Südost
+db-regionetz-sudostbayernbahn,RE 4,db-regionetz-verkehrs-gmbh-sudostbayernbahn,re-4,#ffffff,#992e00,#992e00,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 32,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-32,#e5a05c,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 40,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-40,#e5a05c,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 41,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-41,#bf73bf,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 42,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-42,#00ace5,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 44,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-44,#90bf26,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 45,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-45,#6cc3d9,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 46,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-46,#24b27d,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 47,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-47,#ffb200,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 48,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-48,#bf73bf,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 49,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-49,#ffb200,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 52,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-52,#bf73bf,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-sudostbayernbahn,RB 59,db-regionetz-verkehrs-gmbh-sudostbayernbahn,rb-59,#e5a05c,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-westfrankenbahn,RB 56,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-56,#fab23c,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-westfrankenbahn,RB 83,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-83,#fdd245,#000000,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-westfrankenbahn,RB 84,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-84,#e29c57,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-westfrankenbahn,RB 88,db-regionetz-verkehrs-gmbh-westfrankenbahn,rb-88,#47359c,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-westfrankenbahn,RE 80,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-80,#423f41,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+db-regionetz-westfrankenbahn,RE 87,db-regionetz-verkehrs-gmbh-westfrankenbahn,re-87,#ff2e17,#ffffff,,rectangle,,10448,DB RegioNetz Verkehrs GmbH Südostbayernbahn
+ding-swu,1,,8-ald087-1,#e52329,#ffffff,,rectangle,,7623,SWU Verkehr
+ding-swu,2,,8-ald087-2,#3fad56,#ffffff,,rectangle,,7623,SWU Verkehr
+dsb-s-tog,A,dsb-s-tog,4-860022-a,#00a8e7,#ffffff,,rectangle-rounded-corner,Q2323144,,
+dsb-s-tog,B,dsb-s-tog,4-860022-b,#52ae32,#ffffff,,rectangle-rounded-corner,Q1903862,,
+dsb-s-tog,Bx,dsb-s-tog,4-860022-bx,#adce6d,#ffffff,,rectangle-rounded-corner,Q2127863,,
+dsb-s-tog,C,dsb-s-tog,4-860022-c,#f39200,#ffffff,,rectangle-rounded-corner,Q4452746,,
+dsb-s-tog,E,dsb-s-tog,4-860022-e,#7c6eb0,#ffffff,,rectangle-rounded-corner,Q4624816,,
+dsb-s-tog,F,dsb-s-tog,4-860022-f,#fdc300,#ffffff,,rectangle-rounded-corner,Q2133631,,
+dsb-s-tog,H,dsb-s-tog,4-860022-h,#e74011,#ffffff,,rectangle-rounded-corner,Q1891933,,
+dvg-dessau,1,,8-nasdvg-1,#f59c00,#ffffff,,rectangle,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,3,,8-nasdvg-3,#f59c00,#ffffff,,rectangle,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,10,,5-nas001-10,#2e76bb,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,11,,5-nas001-11,#95d2f1,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,12,,5-nas001-12,#529bb9,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,13,,5-nas001-13,#9ec753,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,14,,5-nas001-14,#e3000b,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,15,,5-nas001-15,#a80126,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,16,,5-nas001-16,#941680,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,17,,5-nas001-16,#ffcc00,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,21,,5-nas001-16,#ee722e,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,22,,5-nas001-16,#0f3f93,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,N1,,5-nas001-n1,#000000,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,N2,,5-nas001-n2,#000000,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,N3,,5-nas001-n3,#000000,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,Rufbus N4,,9-nas001-n4,#000000,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,N5,,5-nas001-n5,#000000,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dvg-dessau,N6,,5-nas001-n6,#000000,#ffffff,,pill,,10357,Dessauer Verkehrsgesellschaft
+dwe-dessau,DWE,dessau-worlitzer-eisenbahn,dwe,#ffffff,#000000,#000000,rectangle,,10357,Dessauer Verkehrsgesellschaft
+erfurter-bahn,RB 13,erfurter-bahn-gmbh,rb-13,#24b27d,#ffffff,,rectangle,,8654,Erfurter Bahn
+erfurter-bahn,RB 40,erfurter-bahn-gmbh,rb-40,#24b27d,#ffffff,,rectangle,,8654,Erfurter Bahn
+erfurter-bahn,RB 50,erfurter-bahn-gmbh,rb-50,#24b27d,#ffffff,,rectangle,,8654,Erfurter Bahn
+hans,RB16,hanseatische-eisenbahn-gmbh,rb-16,#775fb0,#ffffff,,rectangle,,10927,Hanseatische Eisenbahn GmbH
+hans,RB33,hanseatische-eisenbahn-gmbh,rb-33,#ed1c24,#ffffff,,rectangle,,10927,Hanseatische Eisenbahn GmbH
+hans,RB34,hanseatische-eisenbahn-gmbh,rb-34,#0066ad,#ffffff,,rectangle,,10927,Hanseatische Eisenbahn GmbH
+hans,RB73,hanseatische-eisenbahn-gmbh,rb-73,#009686,#ffffff,,rectangle,,10927,Hanseatische Eisenbahn GmbH
+hans,RB74,hanseatische-eisenbahn-gmbh,rb-74,#0066ad,#ffffff,,rectangle,,10927,Hanseatische Eisenbahn GmbH
+hans,RE27,hanseatische-eisenbahn-gmbh,re27,#399fdf,#ffffff,,rectangle,,10927,Hanseatische Eisenbahn GmbH
+hlb,RB21,hlb-hessenbahn-gmbh,hlb-rb21,#007ec5,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB29,hlb-hessenbahn-gmbh,hlb-rb29,#c77db4,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB37,hlb-hessenbahn-gmbh,hlb-rb37,#970c7e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB40,hlb-hessenbahn-gmbh,hlb-rb40,#970c7e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB41,hlb-hessenbahn-gmbh,hlb-rb41,#970c7e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB45,hlb-hessenbahn-gmbh,hlb-rb45,#007ec5,#ffffff,,rectangle-rounded-corner,Q125770469,11046,Hessische Landesbahn GmbH
+hlb,RB46,hlb-hessenbahn-gmbh,hlb-rb46,#94522e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB47,hlb-hessenbahn-gmbh,hlb-rb47,#cf7db2,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB48,hlb-hessenbahn-gmbh,hlb-rb48,#e3a02e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB49,hlb-hessenbahn-gmbh,hlb-rb49,#2175bb,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB52,hlb-hessenbahn-gmbh,hlb-rb52,#e3a02e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB58,hlb-hessenbahn-gmbh,hlb-rb58,#970c7e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB61,hlb-hessenbahn-gmbh,hlb-rb61,#2175bb,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB75,hlb-hessenbahn-gmbh,hlb-rb75,#2175bb,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RB90,hlb-hessenbahn-gmbh,hlb-rb90,#90268f,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RE9,hlb-hessenbahn-gmbh,hlb-re9,#e3a02e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RE59,hlb-hessenbahn-gmbh,hlb-re59,#970c7e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RE24,hlb-hessenbahn-gmbh,hlb-re24,#007ec5,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RE98,hlb-hessenbahn-gmbh,hlb-re98,#e3a02e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hlb,RE99,hlb-hessenbahn-gmbh,hlb-re99,#e3a02e,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+hvv-akn,A 1,akn-eisenbahn-gmbh,akn-a1,#f7931d,#ffffff,,pill,,10833,AKN Eisenbahn AG
+hvv-akn,A 2,akn-eisenbahn-gmbh,akn-a2,#f7931d,#ffffff,,pill,,10833,AKN Eisenbahn AG
+hvv-akn,A 3,akn-eisenbahn-gmbh,akn-a3,#f7931d,#ffffff,,pill,,10833,AKN Eisenbahn AG
+hvv-db-sbhh,S 1,s-bahn-hamburg,4-0s-1,#4da553,#ffffff,,pill,,10375,S-Bahn Hamburg
+hvv-db-sbhh,S 2,s-bahn-hamburg,4-0s-2,#95334a,#ffffff,,pill,,10375,S-Bahn Hamburg
+hvv-db-sbhh,S 3,s-bahn-hamburg,4-0s-3,#512c75,#ffffff,,pill,,10375,S-Bahn Hamburg
+hvv-db-sbhh,S 5,s-bahn-hamburg,4-0s-5,#3b87a9,#ffffff,,pill,,10375,S-Bahn Hamburg
+hvv-had,61,,6-hvvhad-61,#009bb6,#ffffff,,trapezoid,,15139,HADAG-ZVU
+hvv-had,62,,6-hvvhad-62,#009bb6,#ffffff,,trapezoid,,15139,HADAG-ZVU
+hvv-had,64,,6-hvvhad-64,#009bb6,#ffffff,,trapezoid,,15139,HADAG-ZVU
+hvv-had,72,,6-hvvhad-72,#009bb6,#ffffff,,trapezoid,,15139,HADAG-ZVU
+hvv-had,73,,6-hvvhad-73,#009bb6,#ffffff,,trapezoid,,15139,HADAG-ZVU
+hvv-had,75,,6-hvvhad-75,#009bb6,#ffffff,,trapezoid,,15139,HADAG-ZVU
+hvv-hha,U 1,,7-hvv001-1,#0072bc,#ffffff,,rectangle,,15141,Hochbahn U-Bahn
+hvv-hha,U 2,,7-hvv001-2,#ee1d23,#ffffff,,rectangle,,15141,Hochbahn U-Bahn
+hvv-hha,U 3,,7-hvv001-3,#ffdc01,#ffffff,,rectangle,,15141,Hochbahn U-Bahn
+hvv-hha,U 4,,7-hvv001-4,#00aaad,#ffffff,,rectangle,,15141,Hochbahn U-Bahn
+hvv-hha,5,,5-hvvhha-5,#eb4630,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,6,,5-hvvhha-6,#18257b,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,8,,5-hvvhha-8,#c49569,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,9,,5-hvvhha-9,#5fb358,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,10,,5-hvvhha-10,#ed753a,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,11,,5-hvvhha-11,#903634,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,13,,5-hvvhha-13,#712f91,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,14,,5-hvvhha-14,#dc424d,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,16,,5-hvvhha-16,#571445,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,17,,5-hvvhha-17,#62685f,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,18,,5-hvvhha-18,#6b80be,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,19,,5-hvvhha-19,#f4ba4f,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,20,,5-hvvhha-20,#519bd2,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,23,,5-hvvhha-23,#e74796,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,24,,5-hvvhha-24,#f8d258,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,25,,5-hvvhha-25,#0c653c,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,26,,5-hvvhha-26,#bcd25d,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,27,,5-hvvhha-27,#11adde,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,28,,5-hvvhha-28,#7e9bb4,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,603,,5-hvvhha-603,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,604,,5-hvvhha-604,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,605,,5-hvvhha-605,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,606,,5-hvvhha-606,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,607,,5-hvvhha-607,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,608,,5-hvvhha-608,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,617,,5-hvvhha-617,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,618,,5-hvvhha-618,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,640,,5-hvvhha-640,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,641,,5-hvvhha-641,#000000,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X11,,5-hvvhha-x11,#5fb358,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X22,,5-hvvhha-x22,#5fb358,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X35,,5-hvvhha-x35,#eb452e,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X40,,5-hvvhha-x40,#73c4a2,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X61,,5-hvvhha-x61,#ed7339,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X65,,5-hvvhha-x65,#52b4dc,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-hha,X86,,5-hvvhha-x65,#ebc353,#ffffff,,hexagon,,15140,Hochbahn Bus
+hvv-kvi,X66,,5-hvvkvi-x66,#6780bf,#ffffff,,hexagon,,15143,KVIPVH
+hvv-kvi,X89,,5-hvvkvi-x89,#8cc359,#ffffff,,hexagon,,15143,KVIPVH
+hvv-kvi,X99,,5-hvvkvi-x99,#bc3c95,#ffffff,,hexagon,,15143,KVIPVH
+hvv-vhh,1,,5-hvvvhh-1,#bcd25d,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,2,,5-hvvvhh-2,#f4b94f,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,3,,5-hvvvhh-3,#bc3d95,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,12,,5-hvvvhh-12,#522a90,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,15,,5-hvvvhh-15,#4bbf9d,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,21,,5-hvvvhh-21,#234ea3,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,22,,5-hvvvhh-22,#712f91,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,29,,5-hvvvhh-29,#522a90,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,601,,5-hvvvhh-601,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,602,,5-hvvvhh-602,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,609,,5-hvvvhh-609,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,610,,5-hvvvhh-610,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,619,,5-hvvvhh-619,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,621,,5-hvvvhh-621,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,627,,5-hvvvhh-627,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,629,,5-hvvvhh-629,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,638,,5-hvvvhh-638,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,639,,5-hvvvhh-639,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,649,,5-hvvvhh-649,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,658,,5-hvvvhh-658,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,668,,5-hvvvhh-668,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,669,,5-hvvvhh-669,#000000,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X3,,5-hvvvhh-x3,#722f91,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X30,,5-hvvvhh-x30,#8e332a,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X32,,5-hvvvhh-x32,#bf9466,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X33,,5-hvvvhh-x32,#1c448f,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X80,,5-hvvvhh-x80,#ebc353,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X81,,5-hvvvhh-x81,#30653c,#ffffff,,hexagon,,15146,VHH Bus
+hvv-vhh,X95,,5-hvvvhh-x95,#c06936,#ffffff,,hexagon,,15146,VHH Bus
+kvv-avg,S1,albtal-verkehrs-gesellschaft-mbh,4-a6s1-1,#00a76d,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S4,albtal-verkehrs-gesellschaft-mbh,4-a6s4-4,#ae4a63,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S5,albtal-verkehrs-gesellschaft-mbh,4-a6s5-5,#f69795,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S6,albtal-verkehrs-gesellschaft-mbh,4-a6s6-6,#282268,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S7,albtal-verkehrs-gesellschaft-mbh,4-a6s7-7,#fff200,#000000,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S8,albtal-verkehrs-gesellschaft-mbh,4-a6s8-8,#6e692a,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S11,albtal-verkehrs-gesellschaft-mbh,4-a6s11-11,#00a76d,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S12,albtal-verkehrs-gesellschaft-mbh,4-a6s12-12,#00a76d,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S31,albtal-verkehrs-gesellschaft-mbh,4-a6s31-31,#00a99d,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S32,albtal-verkehrs-gesellschaft-mbh,4-a6s32-32,#00a99d,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S41,albtal-verkehrs-gesellschaft-mbh,4-a6s41-41,#bed730,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S42,albtal-verkehrs-gesellschaft-mbh,4-a6s42-42,#0097bb,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S51,albtal-verkehrs-gesellschaft-mbh,4-a6s51-51,#f69795,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S52,albtal-verkehrs-gesellschaft-mbh,4-a6s52-52,#f69795,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S71,albtal-verkehrs-gesellschaft-mbh,4-a6s71-71,#fff200,#000000,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S81,albtal-verkehrs-gesellschaft-mbh,4-a6s81-81,#6e692a,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S FEX,albtal-verkehrs-gesellschaft-mbh,4-a6s1-fex,#00a76d,#ffffff,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-avg,S E,albtal-verkehrs-gesellschaft-mbh,4-kvv22e-e,#ffffff,#000000,,rectangle-rounded-corner,,10836,Albtal-Verkehrs-Gesellschaft
+kvv-regionalbus,X34,,5-kvv015-x34,#d71920,#ffffff,,pill,,7674,Bus VBK
+kvv-regionalbus,X44,,5-kvv002-x44,#007239,#ffffff,,pill,,7674,Bus VBK
+kvv-regionalbus,X45,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-x45,#00aaad,#ffffff,,pill,,11071,Friedrich Müller Omnibus GmbH
+kvv-regionalbus,X63,regionalverkehr-alb-bodensee,5-rabrab-x63,#00aaad,#ffffff,,pill,,10444,DB ZugBus Regionalverkehr Alb-Bodensee
+kvv-regionalbus,107,,5-kvv006-107,#006ba2,#ffffff,,pill,,7674,Bus VBK
+kvv-regionalbus,125,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-125,#a87b50,#ffffff,,pill,,11071,Friedrich Müller Omnibus GmbH
+kvv-regionalbus,158,,5-kvv025-158,#f5821f,#ffffff,,pill,,7674,Bus VBK
+kvv-regionalbus,222,,5-kvv030-222,#c3529e,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,E,,8-kvv021-e,#ffffff,#000000,,rectangle,,7672,Tram VBK
+kvv-vbk,NL1,,8-kvv021-nl1,#ed1c24,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL2,,8-kvv021-nl2,#0071bc,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL3,,5-kvv003-nl3,#806a50,#ffffff,,pill,,7672,Tram VBK
+kvv-vbk,NL11,,9-kvv004-nl11,#00aeef,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL12,,9-kvv004-nl12,#2e3092,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL13,,9-kvv004-nl13,#9b95c9,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL14,,9-kvv004-nl14,#a25641,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL15,,9-kvv004-nl15,#80c342,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL16,,9-kvv004-nl16,#177752,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,NL17,,9-kvv004-nl17,#574187,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,S2,,4-kvv021-2,#a066aa,#ffffff,,rectangle-rounded-corner,,7672,Tram VBK
+kvv-vbk,1,,8-kvv021-1,#ed1c24,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,2,,8-kvv021-2,#0071bc,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,3,,8-kvv021-3,#947139,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,4,,8-kvv021-4,#ffcb04,#000000,,rectangle,,7672,Tram VBK
+kvv-vbk,5,,8-kvv021-5,#00c0f3,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,6,,8-kvv021-6,#85bc22,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,8,,8-kvv021-8,#f7931d,#000000,,rectangle,,7672,Tram VBK
+kvv-vbk,9,,8-kvv021-9,#b3a5a1,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,10,,8-kvv021-10,#a4d7bb,#000000,,rectangle,,7672,Tram VBK
+kvv-vbk,16,,8-kvv021-16,#db2475,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,17,,8-kvv021-17,#660000,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,18,,8-kvv021-18,#197248,#ffffff,,rectangle,,7672,Tram VBK
+kvv-vbk,21,,5-kvv024-21,#177752,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,22,,5-kvv024-22,#62bb46,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,23,,5-kvv024-23,#adbc72,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,24,,5-kvv024-24,#004a21,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,26,,5-kvv024-26,#d7df23,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,27,,5-kvv024-27,#00a851,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,29,,5-kvv024-29,#90ab98,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,30,,5-kvv024-30,#00aeef,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,31,,5-kvv024-31,#a1d1e6,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,32,,5-kvv024-32,#485e88,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,42,,5-kvv024-42,#485e88,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,44,,5-kvv024-44,#a1d1e6,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,47,,5-kvv024-47,#00aeef,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,50,,5-kvv024-50,#874487,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,51,,5-kvv024-51,#b592b9,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,52,,5-kvv024-52,#874487,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,55,,5-kvv024-55,#574187,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,60,,5-kvv024-60,#574187,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,62,,5-kvv024-62,#9b95c9,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,70,,5-kvv024-70,#806a50,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,71,,5-kvv024-71,#b2a291,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,72,,5-kvv024-72,#d2ab67,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,73,,5-kvv024-73,#806a50,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,74,,5-kvv024-74,#d2ab67,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,75,,5-kvv024-75,#a25641,#ffffff,,pill,,7674,Bus VBK
+kvv-vbk,83,,5-kvv024-83,#808285,#ffffff,,pill,,7674,Bus VBK
+lavv-swl,1,,5-swlbus-1,#85bc22,#ffffff,,rectangle,,11941,SWL
+lavv-swl,2,,5-swlbus-2,#fbba00,#000000,,rectangle,,11941,SWL
+lavv-swl,3,,5-swlbus-3,#de007d,#ffffff,,rectangle,,11941,SWL
+lavv-swl,4,,5-swlbus-4,#009ee3,#ffffff,,rectangle,,11941,SWL
+lavv-swl,5,,5-swlbus-5,#007757,#ffffff,,rectangle,,11941,SWL
+lavv-swl,6,,5-swlbus-6,#0070ba,#ffffff,,rectangle,,11941,SWL
+lavv-swl,7,,5-swlbus-7,#00b2bb,#ffffff,,rectangle,,11941,SWL
+lavv-swl,8,,5-swlbus-8,#ffed00,#000000,,rectangle,,11941,SWL
+lavv-swl,9,,5-swlbus-9,#0b9a33,#ffffff,,rectangle,,11941,SWL
+lavv-swl,10,,5-swlbus-10,#9d1680,#ffffff,,rectangle,,11941,SWL
+lavv-swl,11,,5-swlbus-11,#e3000f,#ffffff,,rectangle,,11941,SWL
+lavv-swl,12,,5-swlbus-12,#58348b,#ffffff,,rectangle,,11941,SWL
+lavv-swl,14,,5-swlbus-14,#ee7100,#ffffff,,rectangle,,11941,SWL
+lavv-swl,101,,5-swlbus-101,#85bc22,#ffffff,,rectangle,,11941,SWL
+lavv-swl,102,,5-swlbus-102,#fbba00,#000000,,rectangle,,11941,SWL
+lavv-swl,103,,5-swlbus-103,#de007d,#ffffff,,rectangle,,11941,SWL
+lavv-swl,104,,5-swlbus-104,#009ee3,#ffffff,,rectangle,,11941,SWL
+lavv-swl,105,,5-swlbus-105,#007757,#ffffff,,rectangle,,11941,SWL
+lavv-swl,106,,5-swlbus-106,#0070ba,#ffffff,,rectangle,,11941,SWL
+lavv-swl,107,,5-swlbus-107,#00b2bb,#ffffff,,rectangle,,11941,SWL
+lavv-swl,108,,5-swlbus-108,#ffed00,#000000,,rectangle,,11941,SWL
+lavv-swl,109,,5-swlbus-109,#0b9a33,#ffffff,,rectangle,,11941,SWL
+lavv-swl,110,,5-swlbus-110,#9d1680,#ffffff,,rectangle,,11941,SWL
+liege-s,S41,sncb,4-88-41,#0f6030,#ffffff,#ffffff,circle,,,
+mdv-lvb,1,,8-naslvt-1,#78b145,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,2,,8-naslvt-2,#f7ce46,#000000,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,3,,8-naslvt-3,#78b145,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,3E,,8-naslvt-3e,#78b145,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,4,,8-naslvt-4,#27398a,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,7,,8-naslvt-7,#27398a,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,8,,8-naslvt-8,#f7ce46,#000000,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,10,,8-naslvt-10,#d02e26,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,11,,8-naslvt-11,#d02e26,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,12,,8-naslvt-12,#27398a,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,15,,8-naslvt-15,#27398a,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-lvb,16,,8-naslvt-16,#d02e26,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+mdv-swh-havag,1,,8-nashat-1,#f4b84f,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,2,,8-nashat-2,#ee843e,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,3,,8-nashat-3,#469cd8,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,5,,8-nashat-5,#1d459f,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,7,,8-nashat-7,#ea67aa,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,8,,8-nashat-8,#7e471e,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,9,,8-nashat-9,#a7b150,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,10,,8-nashat-10,#3d682d,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,12,,8-nashat-12,#96c75a,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+mdv-swh-havag,16,,8-nashat-12,#a13671,#ffffff,,rectangle,,8896,Hallesche Verkehrs-AG
+metronom,RB31,metronom,me-rb31,#7f257b,#ffffff,,rectangle,,10931,metronom
+metronom,RB41,metronom,me-rb41,#2eb273,#ffffff,,rectangle,,10931,metronom
+metronom,RE2,metronom,me-re2,#b22236,#ffffff,,rectangle,,10931,metronom
+metronom,RE3,metronom,me-re3,#7f257b,#ffffff,,rectangle,,10931,metronom
+metronom,RE4,metronom,me-re4,#2eb273,#ffffff,,rectangle,,10931,metronom
+mitteldeutsche-regiobahn,RE 3,mitteldeutsche-regiobahn,re-3,#0093d4,#ffffff,,rectangle-rounded-corner,,10853,Mitteldeutsche Regiobahn
+mitteldeutsche-regiobahn,RE 6,mitteldeutsche-regiobahn,re-6,#9e60a4,#ffffff,,rectangle-rounded-corner,,10853,Mitteldeutsche Regiobahn
+mitteldeutsche-regiobahn,RB 30,mitteldeutsche-regiobahn,rb-30,#ed9126,#ffffff,,rectangle-rounded-corner,,10853,Mitteldeutsche Regiobahn
+mitteldeutsche-regiobahn,RB 45,mitteldeutsche-regiobahn,rb-45,#ed694a,#ffffff,,rectangle-rounded-corner,,10853,Mitteldeutsche Regiobahn
+mitteldeutsche-regiobahn,RB 110,mitteldeutsche-regiobahn,rb-110,#a2cbba,#ffffff,,rectangle-rounded-corner,,10853,Mitteldeutsche Regiobahn
+mvb-magdeburg,51,,5-nasmbb-51,#38529b,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,52,,5-nasmbb-52,#e8a038,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,53,,5-nasmbb-53,#f7ce46,#000000,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,54,,5-nasmbb-54,#86b645,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,56,,5-nasmbb-56,#d5bf3f,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,57,,5-nasmbb-57,#cc2b7c,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,58,,5-nasmbb-58,#44989b,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,59,,5-nasmbb-59,#2b6552,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,61,,5-nasmbb-61,#3880b9,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,66,,5-nasmbb-66,#a33f1d,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,69,,5-nasmbb-69,#43287e,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,71,,5-nasmbb-71,#c32e37,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,72,,5-nasmbb-72,#38529b,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,73,,5-nasmbb-73,#383a33,#ffffff,,pill,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,1,,8-nasmbt-1,#b72c5d,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,2,,8-nasmbt-2,#38529b,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,3,,8-nasmbt-3,#f7ce46,#000000,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,4,,8-nasmbt-4,#86b645,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,5,,8-nasmbt-5,#ae6f25,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,6,,8-nasmbt-6,#43287e,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,9,,8-nasmbt-9,#2b6552,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvb-magdeburg,10,,8-nasmbt-10,#3880b9,#ffffff,,rectangle,,8891,Magdeburger Verkehrsbetriebe
+mvv-db-sbm,S1,db-regio-ag-s-bahn-munchen,4-800725-1,#1fbce6,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S2,db-regio-ag-s-bahn-munchen,4-800725-2,#79b833,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S3,db-regio-ag-s-bahn-munchen,4-800725-3,#962a85,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S4,db-regio-ag-s-bahn-munchen,4-800725-4,#e41f28,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S5,db-regio-ag-s-bahn-munchen,4-800725-5,#00527f,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S6,db-regio-ag-s-bahn-munchen,4-800725-6,#008f5c,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S7,db-regio-ag-s-bahn-munchen,4-800725-7,#8a372f,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S8,db-regio-ag-s-bahn-munchen,4-800725-8,#2d2b29,#ffcd01,,pill,,15017,DB Regio AG S-Bahn München
+mvv-db-sbm,S20,db-regio-ag-s-bahn-munchen,4-800725-20,#f05972,#ffffff,,pill,,15017,DB Regio AG S-Bahn München
+mvv-mvg-tram,12,,8-swm002-12,#903f97,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,16,,8-swm002-16,#006cb3,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,17,,8-swm002-17,#875a46,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,18,,8-swm002-18,#20b14a,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,19,,8-swm002-19,#ee1c25,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,20,,8-swm002-20,#16c0e9,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,21,,8-swm002-21,#16c0e9,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,23,,8-swm002-23,#b3d235,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,25,,8-swm002-25,#f48f99,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,27,,8-swm002-27,#fba61c,#ffffff,,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,28,,8-swm002-28,#ffffff,#fba822,#fba822,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,29,,8-swm002-29,#ffffff,#ec1622,#ec1622,rectangle,,14747,Straßenbahn München
+mvv-mvg-tram,E7,,8-swm002-e7,#ffffff,#000000,#ffffff,rectangle,,14747,Straßenbahn München
+mvv-mvg-ubahn,U1,,7-swm001-1,#52822f,#ffffff,,rectangle,,8118,U-Bahn München
+mvv-mvg-ubahn,U2,,7-swm001-2,#c20831,#ffffff,,rectangle,,8118,U-Bahn München
+mvv-mvg-ubahn,U3,,7-swm001-3,#ec6725,#ffffff,,rectangle,,8118,U-Bahn München
+mvv-mvg-ubahn,U4,,7-swm001-4,#00a984,#ffffff,,rectangle,,8118,U-Bahn München
+mvv-mvg-ubahn,U5,,7-swm001-5,#bc7a00,#ffffff,,rectangle,,8118,U-Bahn München
+mvv-mvg-ubahn,U6,,7-swm001-6,#0065ae,#ffffff,,rectangle,,8118,U-Bahn München
+mvv-regional-bus,501,,5-mvvrbu-501,#1b2645,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,511,,5-mvvrbu-511,#979032,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,601,,5-mvvrbu-601,#702e1a,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,602,,5-mvvrbu-602,#839dbb,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,603,,5-mvvrbu-603,#2f3858,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,614,,5-mvvrbu-614,#c0a339,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,615,,5-mvvrbu-615,#274469,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,616,,5-mvvrbu-616,#717156,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,617,,5-mvvrbu-617,#49719a,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,618,,5-mvvrbu-618,#49719a,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,619,,5-mvvrbu-619,#4c7ec8,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,635,,5-mvvrbu-635,#662a1c,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,680,,5-mvvrbu-680,#6c6775,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,681,,5-mvvrbu-681,#ab5479,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,682,,5-mvvrbu-682,#c29a44,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,683,,5-mvvrbu-683,#79312a,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,684,,5-mvvrbu-684,#377a5d,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,687,,5-mvvrbu-687,#6a6153,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,688,,5-mvvrbu-688,#b8ae36,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,691,,5-mvvrbu-691,#4d8240,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,851,,5-mvvrbu-851,#91431f,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,857,,5-mvvrbu-857,#5b66a9,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,858,,5-mvvrbu-858,#769851,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,859,,5-mvvrbu-859,#2f4b6b,#ffffff,,rectangle,,14943,Bus München
+mvv-regional-bus,X200,,5-mvvrbu-x200,#9b7839,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X201,,5-mvvrbu-x201,#35794d,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X202,,5-mvvrbu-x202,#883562,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X203,,5-mvvrbu-x203,#4f7ab9,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X204,,5-mvvrbu-x204,#897098,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X205,,5-mvvrbu-x205,#3c5d5b,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X206,,5-mvvrbu-x206,#545395,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X320,,5-mvvrbu-x320,#56823d,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X660,,5-mvvrbu-x660,#8e5c2e,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X732,,5-mvvrbu-x732,#8a892c,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X800,,5-mvvrbu-x800,#b57c3e,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X850,,5-mvvrbu-x850,#7d662c,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X900,,5-mvvrbu-x900,#455c95,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X910,,5-mvvrbu-x910,#756543,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X920,,5-mvvrbu-x920,#769754,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-regional-bus,X970,,5-mvvrbu-x970,#903939,#ffffff,,rectangle,,14942,ExpressBus München
+mvv-stadtwerke-dachau,716,,5-mvvrbu-716,#235798,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,717,,5-mvvrbu-717,#000080,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,718,,5-mvvrbu-718,#ffcc00,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,719,,5-mvvrbu-719,#00adef,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,720,,5-mvvrbu-720,#ef3120,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,722,,5-mvvrbu-722,#ef3120,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,726,,5-mvvrbu-726,#00a880,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-dachau,744,,5-mvvrbu-744,#91c900,#ffffff,,rectangle,,12943,"Stadtwerke Dachau, Dachau1"
+mvv-stadtwerke-freising,620,,5-mvvrbu-620,#ed1c24,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,621,,5-mvvrbu-621,#2e3092,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,622,,5-mvvrbu-622,#a6ce38,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,623,,5-mvvrbu-623,#738377,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,624,,5-mvvrbu-624,#ed1651,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,630,,5-mvvrbu-630,#ffcb03,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,631,,5-mvvrbu-631,#35734d,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,633,,5-mvvrbu-633,#f5821f,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,634,,5-mvvrbu-634,#a25642,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,637,,5-mvvrbu-637,#795e6e,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,638,,5-mvvrbu-638,#8dd8f8,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,639,,5-mvvrbu-639,#4072aa,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,640,,5-mvvrbu-640,#b3d334,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,641,,5-mvvrbu-641,#ffcc30,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,650,,5-mvvrbu-650,#17b35c,#ffffff,,rectangle,,7687,MVV-Regionalbus
+mvv-stadtwerke-freising,651,,5-mvvrbu-651,#008742,#ffffff,,rectangle,,7687,MVV-Regionalbus
+nah-sh,RE 6,db-regio-ag-nord,re-6,#00975f,#ffffff,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RB 61,nordbahn,nbe-rb61,#174094,#ffffff,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RB 62,db-regio-ag-nord,rb-62,#00aeca,#000000,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RB 63,nordbahn,nbe-rb63,#ffdc00,#000000,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RB 64,nordbahn,nbe-rb64,#ea899a,#000000,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RB 65,norddeutsche-eisenbahn-gesellschaft,neg-rb65,#dedd00,#000000,,rectangle,,10905,Norddeutsche Eisenbahn Gesellschaft
+nah-sh,RB 66,norddeutsche-eisenbahn-gesellschaft,neg-rb66,#798e0e,#ffffff,,rectangle,,10905,Norddeutsche Eisenbahn Gesellschaft
+nah-sh,RE 7,db-regio-ag-nord,re-7,#ef7c00,#000000,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RE 70,db-regio-ag-nord,re-70,#c30732,#ffffff,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RB 71,nordbahn,nbe-rb71,#008bd2,#ffffff,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RE 72,nordbahn,nbe-re72,#adce6d,#000000,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RB 73,nordbahn,nbe-re73,#008c57,#ffffff,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RE 74,nordbahn,nbe-re74,#693b58,#ffffff,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RB 75,nordbahn,nbe-re75,#ba731a,#ffffff,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RB 76,erixx,erx-rb76,#ffdc00,#000000,,rectangle,,10966,erixx
+nah-sh,RE 8,db-regio-ag-nord,re-8,#a3d9f0,#000000,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RE 80,db-regio-ag-nord,re-80,#d9338a,#ffffff,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RB 81,db-regio-ag-nord,re-81,#798e0e,#ffffff,,rectangle,,10435,DB Regio AG Nord
+nah-sh,RB 82,nordbahn,nbe-rb82,#9c9c9c,#ffffff,,rectangle,,10919,Nordbahn Eisenbahngesellschaft
+nah-sh,RE 83,erixx,erx-re83,#2d53a0,#ffffff,,rectangle,,10966,erixx
+nah-sh,RB 84,erixx,erx-rb84,#e4afd2,#000000,,rectangle,,10966,erixx
+nah-sh,RB 85,db-regio-ag-nord,rb-85,#fbb902,#000000,,rectangle,,10435,DB Regio AG Nord
+nah-sh,X 85,db-regio-ag-nord,3-b1-x85,#a9b85d,#ffffff,,rectangle,,10435,DB Regio AG Nord
+neb-niederbarnimer-eisenbahn,RB12,neb-niederbarnimer-eisenbahn,rb-12,#a5027d,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB25,neb-niederbarnimer-eisenbahn,rb-25,#007cb0,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB26,neb-niederbarnimer-eisenbahn,rb-26,#009686,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB27,neb-niederbarnimer-eisenbahn,rb-27,#e2001a,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB35,neb-niederbarnimer-eisenbahn,rb-35,#816da6,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB36,neb-niederbarnimer-eisenbahn,rb-36,#ad5937,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB54,neb-niederbarnimer-eisenbahn,rb-54,#816da6,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB60,neb-niederbarnimer-eisenbahn,rb-60,#66aa22,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB61,neb-niederbarnimer-eisenbahn,rb-61,#992746,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB62,neb-niederbarnimer-eisenbahn,rb-62,#da6ba2,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,RB63,neb-niederbarnimer-eisenbahn,rb-63,#ffd502,#000000,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+neb-niederbarnimer-eisenbahn,TES,neb-niederbarnimer-eisenbahn,rb-tes,#d70000,#ffffff,,rectangle,,10912,NEB Niederbarnimer Eisenbahn
+nrw-regional,RE 1,national-express,re-1,#ff2d16,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 2,db-regio-ag-nrw,re-2,#00b8f1,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 3,eurobahn,re-3,#e46e25,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RE 4,national-express,re-4,#e88f24,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 5,national-express,re-5,#0182ba,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 6,national-express,re-6,#9e2a96,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 7,national-express,re-7,#052e69,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 8,db-regio-ag-nrw,re-8,#006bbb,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 9,db-regio-ag-nrw,re-9,#401446,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 10,rheinruhrbahn-transdev,rrb-re10,#e66caf,#ffffff,,rectangle-rounded-corner,,14173,RheinRuhrBahn
+nrw-regional,RE 11,national-express,re-11,#5accc2,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 12,db-regio-ag-nrw,re-12,#ad294c,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 13,eurobahn,re-13,#7f5c1e,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RE 14,rheinruhrbahn-transdev,rrb-re14,#003328,#ffffff,,rectangle-rounded-corner,,14173,RheinRuhrBahn
+nrw-regional,RE 16,vias-rail-gmbh,via-re16,#0e5778,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RE 17,db-regio-ag-nrw,re-17,#489b40,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 18,db-arriva,re-18,#10b3b4,#ffffff,,rectangle-rounded-corner,,DB Regio AG NRW,
+nrw-regional,RE 19,vias-rail-gmbh,via-re19,#2f652b,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RB 20,db-regio-ag-nrw,rb-20,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 21,rurtalbahn,rtb-rb21,#7a7c80,#ffffff,,rectangle-rounded-corner,,10858,Rurtalbahn
+nrw-regional,RE 22,db-regio-ag-nrw,re-22,#ffad3e,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 24,db-regio-ag-nrw,rb-24,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 25,db-regio-ag-nrw,rb-25,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 26,mittelrheinbahn-trans-regio,rb-26,#7a7c80,#ffffff,,rectangle-rounded-corner,,10946,MittelrheinBahn (Trans Regio)
+nrw-regional,RB 27,db-regio-ag-nrw,rb-27,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 28,rurtalbahn,rtb-rb28,#7a7c80,#ffffff,,rectangle-rounded-corner,,10858,Rurtalbahn
+nrw-regional,RE 29,sncb,re-29,#d594c8,#ffffff,,rectangle-rounded-corner,,12622,SNCB
+nrw-regional,RB 30,db-regio-ag-nrw,rb-30,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 31,rheinruhrbahn-transdev,rrb-rb31,#7a7c80,#ffffff,,rectangle-rounded-corner,,14173,RheinRuhrBahn
+nrw-regional,RB 32,db-regio-ag-nrw,rb-32,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 33,db-regio-ag-nrw,rb-33,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 34,db-fernverkehr-ag,re-34,#8c467d,#ffffff,,rectangle-rounded-corner,,10918,DB Fernverkehr (Codesharing)
+nrw-regional,RE 34,db-regio-ag-nrw,re-34,#8c467d,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 34,hlb-hessenbahn-gmbh,hlb-re34,#8c467d,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 34,vias-rail-gmbh,via-rb34,#7a7c80,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RB 35,vias-rail-gmbh,via-rb35,#7a7c80,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RB 36,rheinruhrbahn-transdev,rrb-rb36,#7a7c80,#ffffff,,rectangle-rounded-corner,,14173,RheinRuhrBahn
+nrw-regional,RB 37,tri-train-rental-gmbh,tri-rb37,#7a7c80,#ffffff,,rectangle-rounded-corner,,13122,TRI Train Rental GmbH
+nrw-regional,RB 38,db-regio-ag-nrw,rb-38,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 39,vias-rail-gmbh,via-rb39,#7a7c80,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RB 40,db-regio-ag-nrw,rb-40,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 41,db-regio-ag-nrw,re-41,#5844a4,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 42,db-regio-ag-nrw,re-42,#d9bf13,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 43,db-regio-ag-nrw,rb-43,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 44,rheinruhrbahn-transdev,rrb-re44,#6294b0,#ffffff,,rectangle-rounded-corner,,14173,RheinRuhrBahn
+nrw-regional,RB 46,vias-rail-gmbh,via-rb46,#7a7c80,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RE 47,regiobahn,r-re-47,#66cdec,#ffffff,,rectangle-rounded-corner,,10894,REGIOBAHN
+nrw-regional,RB 48,national-express,rb-48,#7a7c80,#ffffff,,rectangle-rounded-corner,,10913,National Express
+nrw-regional,RE 49,db-regio-ag-nrw,re-49,#c4836b,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 50,eurobahn,rb-50,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 51,db-regio-ag-nrw,rb-51,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 52,db-regio-ag-nrw,rb-52,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 53,db-regio-ag-nrw,rb-53,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 54,db-regio-ag-nrw,rb-54,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RE 57,db-regio-ag-nrw,re-57,#2e6da6,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 58,nordwestbahn,nwb-rb58,#7a7c80,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+nrw-regional,RB 59,eurobahn,rb-59,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 61,eurobahn,rb-61,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RE 62,db-regio-ag-nord,re-62,#1f52a6,#ffffff,,rectangle-rounded-corner,,10435,DB Regio AG Nord
+nrw-regional,RB 63,db-regio-ag-nrw,rb-63,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 64,db-regio-ag-nrw,rb-64,#7a7c80,#ffffff,,rectangle-rounded-corner,,10436,DB Regio AG NRW
+nrw-regional,RB 65,eurobahn,rb-65,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 66,eurobahn,rb-66,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 67,eurobahn,rb-67,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 69,eurobahn,rb-69,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 71,eurobahn,rb-71,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 72,eurobahn,rb-72,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 73,eurobahn,rb-73,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 74,nordwestbahn,nwb-rb74,#7a7c80,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+nrw-regional,RB 75,nordwestbahn,nwb-rb75,#7a7c80,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+nrw-regional,RB 77,regionalverkehre-start-deutschland-gmbh-start-niedersachsen-mitte,rb-77,#7a7c80,#ffffff,,rectangle-rounded-corner,,14872,Regionalverkehre Start Deutschland GmbH Niedersachsen-Mitte
+nrw-regional,RE 78,eurobahn,re-78,#52b9ce,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RE 82,eurobahn,re-82,#489b40,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 84,nordwestbahn,nwb-rb84,#7a7c80,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+nrw-regional,RB 85,nordwestbahn,nwb-rb85,#7a7c80,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+nrw-regional,RB 89,eurobahn,rb-89,#7a7c80,#ffffff,,rectangle-rounded-corner,,11049,Eurobahn
+nrw-regional,RB 90,hlb-hessenbahn-gmbh,hlb-rb90,#7a7c80,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 91,vias-rail-gmbh,via-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner,,10933,VIAS Rail GmbH
+nrw-regional,RB 91,hlb-hessenbahn-gmbh,hlb-rb91,#7a7c80,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 92,hlb-hessenbahn-gmbh,hlb-rb92,#7a7c80,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 93,hlb-hessenbahn-gmbh,hlb-rb93,#7a7c80,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 94,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-94,#7a7c80,#ffffff,,rectangle-rounded-corner,,10441,DB RegioNetz Verkehrs GmbH Kurhessenbahn
+nrw-regional,RB 95,hlb-hessenbahn-gmbh,hlb-rb95,#7a7c80,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 96,hlb-hessenbahn-gmbh,hlb-rb96,#7a7c80,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-regional,RB 97,db-regionetz-verkehrs-gmbh-kurhessenbahn,rb-97,#7a7c80,#ffffff,,rectangle-rounded-corner,,10441,DB RegioNetz Verkehrs GmbH Kurhessenbahn
+nrw-regional,RE 99,hlb-hessenbahn-gmbh,hlb-re99,#28b34c,#ffffff,,rectangle-rounded-corner,,11046,Hessische Landesbahn GmbH
+nrw-sbahn,S 1,db-regio-ag-nrw,4-800337-1,#0cb14b,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 2,db-regio-ag-nrw,4-8003l1-2,#0074bc,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 3,db-regio-ag-nrw,4-8003l1-3,#fff200,#000000,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 4,db-regio-ag-nrw,4-800337-4,#f5821f,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 5,db-regio-ag-nrw,4-800354-5,#80c342,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 6,db-regio-ag-nrw,4-8003s-6,#e21d3c,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 7,rheinruhrbahn-transdev,4-tdrr-s7,#00afb5,#ffffff,,pill,,14173,RheinRuhrBahn
+nrw-sbahn,S 8,db-regio-ag-nrw,4-800354-8,#b23815,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 9,db-regio-ag-nrw,4-8003l1-9,#c6168d,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 11,db-regio-ag-nrw,4-8003s-11,#f26522,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 12,db-regio-ag-nrw,4-8003s-12,#4db857,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 19,db-regio-ag-nrw,4-8003s-19,#00658e,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 23,db-regio-ag-nrw,4-800352-23,#8c2a77,#ffffff,,pill,,10436,DB Regio AG NRW
+nrw-sbahn,S 28,regiobahn,4-m2-28,#4a0b4d,#ffffff,,pill,,10894,REGIOBAHN
+nrw-sbahn,S 68,db-regio-ag-nrw,4-8003s-68,#00bfe8,#ffffff,,pill,,10436,DB Regio AG NRW
+nvs,1,,8-vwmstr-1,#e5007d,#ffffff,,rectangle,,7560,Straßenbahn
+nvs,1,,5-vwmbus-1,#e5007d,#ffffff,,pill,,8219,Schwerin Bus
+nvs,2,,8-vwmstr-2,#e3000f,#ffffff,,rectangle,,7560,Straßenbahn
+nvs,3,,8-vwmstr-3,#f08481,#ffffff,,rectangle,,7560,Straßenbahn
+nvs,4,,8-vwmstr-4,#e5007d,#ffffff,,rectangle,,7560,Straßenbahn
+nvs,5,,5-vwmbus-5,#ef7c00,#ffffff,,pill,,8219,Schwerin Bus
+nvs,6,,5-vwmbus-6,#6f5b6f,#ffffff,,pill,,8219,Schwerin Bus
+nvs,7,,5-vwmbus-7,#ffcc00,#ffffff,,pill,,8219,Schwerin Bus
+nvs,8,,5-vwmbus-8,#2f2483,#ffffff,,pill,,8219,Schwerin Bus
+nvs,9,,5-vwmbus-9,#847258,#ffffff,,pill,,8219,Schwerin Bus
+nvs,10,,5-vwmbus-10,#008bd2,#ffffff,,pill,,8219,Schwerin Bus
+nvs,11,,5-vwmbus-11,#52a6b2,#ffffff,,pill,,8219,Schwerin Bus
+nvs,12,,5-vwmbus-12,#d0a9d0,#ffffff,,pill,,8219,Schwerin Bus
+nvs,13,,5-vwmbus-13,#b1ac7e,#ffffff,,pill,,8219,Schwerin Bus
+nvs,14,,5-vwmbus-14,#a61380,#ffffff,,pill,,8219,Schwerin Bus
+nvs,16,,5-vwmbus-16,#a65a44,#ffffff,,pill,,8219,Schwerin Bus
+nvs,17,,5-vwmbus-17,#afca05,#ffffff,,pill,,8219,Schwerin Bus
+nvs,18,,5-vwmbus-18,#00963f,#ffffff,,pill,,8219,Schwerin Bus
+nvs,19,,5-vwmbus-19,#f7a940,#ffffff,,pill,,8219,Schwerin Bus
+oberpfalzbahn-dlb,RB 23,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb23,#6cc3d9,#ffffff,,rectangle,,10923,oberpfalzbahn - Die Länderbahn GmbH DLB
+oberpfalzbahn-dlb,RB 27,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb27,#ffb200,#ffffff,,rectangle,,10923,oberpfalzbahn - Die Länderbahn GmbH DLB
+oberpfalzbahn-dlb,RB 28,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb28,#90bf26,#ffffff,,rectangle,,10923,oberpfalzbahn - Die Länderbahn GmbH DLB
+oberpfalzbahn-dlb,RB 29,oberpfalzbahn-die-landerbahn-gmbh-dlb,rb29,#ff6600,#ffffff,,rectangle,,10923,oberpfalzbahn - Die Länderbahn GmbH DLB
+odeg,RB13,ostdeutsche-eisenbahn-gmbh,rb-13,#3f4545,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB14,ostdeutsche-eisenbahn-gmbh,rb-14,#196e76,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB15,ostdeutsche-eisenbahn-gmbh,rb-15,#00a998,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB17,ostdeutsche-eisenbahn-gmbh,rb-17,#dd4daf,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB18,ostdeutsche-eisenbahn-gmbh,rb-18,#399fdf,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB19,ostdeutsche-eisenbahn-gmbh,rb-19,#f46717,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB33,ostdeutsche-eisenbahn-gmbh,rb-33,#a5027d,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB37,ostdeutsche-eisenbahn-gmbh,rb-37,#ad5937,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB46,ostdeutsche-eisenbahn-gmbh,rb-46,#da6ba2,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB51,ostdeutsche-eisenbahn-gmbh,rb-51,#da6ba2,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB64,ostdeutsche-eisenbahn-gmbh,rb-64,#006552,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RB65,ostdeutsche-eisenbahn-gmbh,rb-65,#0066ad,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RE1,ostdeutsche-eisenbahn-gmbh,re-1,#e2001a,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RE8,ostdeutsche-eisenbahn-gmbh,re-8,#775fb0,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RE9,ostdeutsche-eisenbahn-gmbh,re-9,#b51d48,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+odeg,RE10,ostdeutsche-eisenbahn-gmbh,re-10,#775fb0,#ffffff,,rectangle,,8569,ODEG Ostdeutsche Eisenbahn GmbH
+ooevv-linz-linien,3,linz-linien-ag-strassenbahn-stadt-linz,8-810031-3,#a3238e,#ffffff,,rectangle,,,
+ooevv-linz-linien,4,linz-linien-ag-strassenbahn-stadt-linz,8-810031-4,#c40352,#ffffff,,rectangle,,,
+ooevv-oebb,S1,osterreichische-bundesbahnen,4-81-1-1589920-5372014,#ee7f00,#ffffff,,rectangle-rounded-corner,,,
+ooevv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1589920-5372014,#0098a1,#ffffff,,rectangle-rounded-corner,,,
+ooevv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1589920-5372014,#342980,#ffffff,,rectangle-rounded-corner,,,
+ooevv-oebb,S4,osterreichische-bundesbahnen,4-81-4-1589920-5372014,#a4ba00,#ffffff,,rectangle-rounded-corner,,,
+ooevv-stern-hafferl,S5,stern-hafferl-verkehrs-gmbh,4-810008-5,#e2007a,#ffffff,,rectangle-rounded-corner,,,
+ostalb-mobil-ovg-goeppingen,931,,5-vvs031-931,#fbc707,#000000,,rectangle,,14432,OstalbMobil
+ostalb-mobil-ovg-goeppingen,932,,5-vvs031-932,#785f42,#ffffff,,rectangle,,14432,OstalbMobil
+ostalb-mobil-ovk-betz,21,,5-ova050-21,#2e3192,#ffffff,,rectangle,,14432,OstalbMobil
+ostalb-mobil-ovk-dannenmann,266,,5-vvs031-266,#0994dc,#ffffff,,rectangle,,15027,Omnibus Dannenmann GmbH
+ostalb-mobil-ovk-dannenmann,268,,5-vvs031-268,#f47216,#ffffff,,rectangle,,15027,Omnibus Dannenmann GmbH
+ostalb-mobil-ovk-domhan,71,,5-ova002-71,#2e3192,#ffffff,,rectangle,,14432,OstalbMobil
+ostalb-mobil-stadtbus-gmuend,1,,5-ova002-1,#ed1c24,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,2,,5-ova002-2,#6e87cd,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,3,,5-ova002-3,#fff200,#000000,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,4,,5-ova002-4,#00adef,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,5,,5-ova002-5,#f47216,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,5b,,5-ova002-5b,#f47216,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,6,,5-ova002-6,#99d420,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,7,,5-ova002-7,#ca93d0,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,40,,5-ova002-40,#00adef,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,50,,5-ova002-50,#f47216,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,66,,5-ova002-66,#00a650,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,70,,5-ova002-70,#2e3192,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+ostalb-mobil-stadtbus-gmuend,73,,5-ova002-73,#00adef,#ffffff,,rectangle,,14789,Omnibusverkehr Abt Schwäbisch Gmünd1
+pid-prague,1,dopravni-podnik-hl-m-prahy,8-540001-1,#ffffff,#a2cf62,#a2cf62,rectangle,,,
+pid-prague,2,dopravni-podnik-hl-m-prahy,8-540001-2,#ffffff,#f6c955,#f6c955,rectangle,,,
+pid-prague,3,dopravni-podnik-hl-m-prahy,8-540001-3,#ffffff,#4ca859,#4ca859,rectangle,,,
+pid-prague,4,dopravni-podnik-hl-m-prahy,8-540001-4,#ffffff,#a5d7b4,#a5d7b4,rectangle,,,
+pid-prague,5,dopravni-podnik-hl-m-prahy,8-540001-5,#ffffff,#f3b1b3,#f3b1b3,rectangle,,,
+pid-prague,6,dopravni-podnik-hl-m-prahy,8-540001-6,#ffffff,#d6ae72,#d6ae72,rectangle,,,
+pid-prague,7,dopravni-podnik-hl-m-prahy,8-540001-7,#ffffff,#ee843e,#ee843e,rectangle,,,
+pid-prague,8,dopravni-podnik-hl-m-prahy,8-540001-8,#ffffff,#ec6575,#ec6575,rectangle,,,
+pid-prague,9,dopravni-podnik-hl-m-prahy,8-540001-9,#ffffff,#eb452e,#eb452e,rectangle,,,
+pid-prague,10,dopravni-podnik-hl-m-prahy,8-540001-10,#ffffff,#469cd8,#469cd8,rectangle,,,
+pid-prague,11,dopravni-podnik-hl-m-prahy,8-540001-11,#ffffff,#e74696,#e74696,rectangle,,,
+pid-prague,12,dopravni-podnik-hl-m-prahy,8-540001-12,#ffffff,#9278b7,#9278b7,rectangle,,,
+pid-prague,13,dopravni-podnik-hl-m-prahy,8-540001-13,#ffffff,#f0a0c7,#f0a0c7,rectangle,,,
+pid-prague,14,dopravni-podnik-hl-m-prahy,8-540001-14,#ffffff,#c27b63,#c27b63,rectangle,,,
+pid-prague,15,dopravni-podnik-hl-m-prahy,8-540001-15,#ffffff,#fae25d,#fae25d,rectangle,,,
+pid-prague,16,dopravni-podnik-hl-m-prahy,8-540001-16,#ffffff,#68c9f1,#68c9f1,rectangle,,,
+pid-prague,17,dopravni-podnik-hl-m-prahy,8-540001-17,#ffffff,#802015,#802015,rectangle,,,
+pid-prague,18,dopravni-podnik-hl-m-prahy,8-540001-18,#ffffff,#f2b3d3,#f2b3d3,rectangle,,,
+pid-prague,19,dopravni-podnik-hl-m-prahy,8-540001-19,#ffffff,#884d27,#884d27,rectangle,,,
+pid-prague,20,dopravni-podnik-hl-m-prahy,8-540001-20,#ffffff,#682678,#682678,rectangle,,,
+pid-prague,21,dopravni-podnik-hl-m-prahy,8-540001-21,#ffffff,#dec750,#dec750,rectangle,,,
+pid-prague,22,dopravni-podnik-hl-m-prahy,8-540001-22,#ffffff,#16268f,#16268f,rectangle,,,
+pid-prague,23,dopravni-podnik-hl-m-prahy,8-540001-23,#ffffff,#7c85bf,#7c85bf,rectangle,,,
+pid-prague,24,dopravni-podnik-hl-m-prahy,8-540001-24,#ffffff,#97989b,#97989b,rectangle,,,
+pid-prague,25,dopravni-podnik-hl-m-prahy,8-540001-25,#ffffff,#81c059,#81c059,rectangle,,,
+pid-prague,26,dopravni-podnik-hl-m-prahy,8-540001-26,#ffffff,#a0dff6,#a0dff6,rectangle,,,
+pid-prague,A,dopravni-podnik-hl-m-prahy,7-540001-a,#00a54f,#ffffff,,rectangle,,,
+pid-prague,B,dopravni-podnik-hl-m-prahy,7-540001-b,#feca0a,#293219,,rectangle,,,
+pid-prague,C,dopravni-podnik-hl-m-prahy,7-540001-c,#ee1d23,#ffffff,,rectangle,,,
+polregio,RB91,polregio,r-91,#eb7405,#ffffff,,rectangle,,,
+regio-s-bahn-donau-iller,RS 2,db-regio-ag-baden-wurttemberg,rs2,#901411,#ffffff,,pill,,10443,DB Regio AG Baden-Württemberg
+regio-s-bahn-donau-iller,RS 21,db-regio-ag-baden-wurttemberg,rs21,#e92a1c,#ffffff,,pill,,10443,DB Regio AG Baden-Württemberg
+regio-s-bahn-donau-iller,RS 3,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs3,#62358a,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+regio-s-bahn-donau-iller,RS 5,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs5,#00622e,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+regio-s-bahn-donau-iller,RS 51,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs51,#43aa2c,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+regio-s-bahn-donau-iller,RS 7,db-regio-ag-bayern,rs7,#234997,#ffffff,,pill,,10446,DB Regio AG Bayern
+regio-s-bahn-donau-iller,RS 71,db-regio-ag-bayern,rs71,#1398d3,#ffffff,,pill,,10446,DB Regio AG Bayern
+regiobus-hannover,170,,5-webrbg-170,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,300,,5-webrbg-300,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,301,,5-webrbg-301,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,310,,5-webrbg-310,#ffffff,#2c2e35,#af2a21,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,320,,5-webrbg-320,#ffffff,#2c2e35,#0155ae,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,360,,5-webrbg-360,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,365,,5-webrbg-365,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,366,,5-webrbg-366,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,367,,5-webrbg-367,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,380,,5-webrbg-380,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,381,,5-webrbg-381,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,382,,5-webrbg-382,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,383,,5-webrbg-383,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,385,,5-webrbg-385,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,400,,5-webrbg-400,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,404,,5-webrbg-404,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,410,,5-webrbg-410,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,421,,5-webrbg-421,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,430,,5-webrbg-430,#ffffff,#2c2e35,#af2a21,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,431,,5-webrbg-431,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,460,,5-webrbg-460,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,490,,5-webrbg-490,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,492,,5-webrbg-492,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,500,,5-webrbg-500,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,510,,5-webrbg-510,#ffffff,#2c2e35,#af2a21,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,520,,5-webrbg-520,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,521,,5-webrbg-521,#ffffff,#2c2e35,#8ce0f8,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,522,,5-webrbg-522,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,523,,5-webrbg-523,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,530,,5-webrbg-530,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,532,,5-webrbg-532,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,534,,5-webrbg-534,#ffffff,#2c2e35,#0155ae,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,540,,5-webrbg-540,#ffffff,#2c2e35,#9b2e4c,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,560,,5-webrbg-560,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,561,,5-webrbg-561,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,562,,5-webrbg-562,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,570,,5-webrbg-570,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,571,,5-webrbg-571,#ffffff,#2c2e35,#fc87bf,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,572,,5-webrbg-572,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,573,,5-webrbg-573,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,574,,5-webrbg-574,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,575,,5-webrbg-575,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,580,,5-webrbg-580,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,600,,5-webrbg-600,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,616,,5-webrbg-616,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,620,,5-webrbg-620,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,621,,5-webrbg-621,#ffffff,#2c2e35,#ffeb3d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,630,,5-webrbg-630,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,635,,5-webrbg-635,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,636,,5-webrbg-636,#ffffff,#2c2e35,#0073c0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,638,,5-webrbg-638,#ffffff,#2c2e35,#8ce0f8,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,639,,5-webrbg-639,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,651,,5-webrbg-651,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,652,,5-webrbg-652,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,690,,5-webrbg-690,#ffffff,#2c2e35,#af2a21,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,692,,5-webrbg-692,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,694,,5-webrbg-694,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,695,,5-webrbg-695,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,696,,5-webrbg-696,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,697,,5-webrbg-697,#ffffff,#2c2e35,#009edd,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,698,,5-webrbg-698,#ffffff,#2c2e35,#102694,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,700,,5-webrbg-700,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,701,,5-webrbg-701,#ffffff,#2c2e35,#9b2e4c,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,710,,5-webrbg-710,#ffffff,#2c2e35,#53afbb,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,711,,5-webrbg-711,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,715,,5-webrbg-715,#ffffff,#2c2e35,#fc87bf,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,740,,5-webrbg-740,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,741,,5-webrbg-741,#ffffff,#2c2e35,#102694,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,745,,5-webrbg-745,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,760,,5-webrbg-760,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,780,,5-webrbg-780,#ffffff,#2c2e35,#117b40,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,785,,5-webrbg-785,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,801,,5-webrbg-801,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,802,,5-webrbg-802,#ffffff,#2c2e35,#ffeb3d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,820,,5-webrbg-820,#ffffff,#2c2e35,#0073c0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,830,,5-webrbg-830,#ffffff,#2c2e35,#ffadb2,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,831,,5-webrbg-831,#ffffff,#2c2e35,#117b40,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,835,,5-webrbg-835,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,840,,5-webrbg-840,#ffffff,#2c2e35,#53afbb,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,850,,5-webrbg-850,#ffffff,#2c2e35,#9b2e4c,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,860,,5-webrbg-860,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,865,,5-webrbg-865,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,870,,5-webrbg-870,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,900,,5-webrbg-900,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,905,,5-webrbg-905,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,906,,5-webrbg-906,#ffffff,#2c2e35,#0073c0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,907,,5-webrbg-907,#ffffff,#2c2e35,#af2a21,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,910,,5-webrbg-910,#ffffff,#2c2e35,#00ab4f,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,916,,5-webrbg-916,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,917,,5-webrbg-917,#ffffff,#2c2e35,#ff9027,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,920,,5-webrbg-920,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,926,,5-webrbg-926,#ffffff,#2c2e35,#903da0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,927,,5-webrbg-927,#ffffff,#2c2e35,#35ccf6,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,930,,5-webrbg-930,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,938,,5-webrbg-938,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,946,,5-webrbg-946,#ffffff,#2c2e35,#fc87bf,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,948,,5-webrbg-948,#ffffff,#2c2e35,#117b40,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,949,,5-webrbg-949,#ffffff,#2c2e35,#9b2e4c,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,950,,5-webrbg-950,#ffffff,#2c2e35,#00ab4f,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,962,,5-webrbg-962,#ffffff,#2c2e35,#ff2e17,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,963,,5-webrbg-963,#ffffff,#2c2e35,#ffbe32,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,964,,5-webrbg-964,#ffffff,#2c2e35,#8ce0f8,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,965,,5-webrbg-965,#ffffff,#2c2e35,#3ebc6d,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,966,,5-webrbg-966,#ffffff,#2c2e35,#0073c0,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,967,,5-webrbg-967,#ffffff,#2c2e35,#95cc45,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,968,,5-webrbg-968,#ffffff,#2c2e35,#fb3199,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N31,,5-webrbg-n31,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N41,,5-webrbg-n41,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N43,,5-webrbg-n43,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N50,,5-webrbg-n50,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N56,,5-webrbg-n56,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N57,,5-webrbg-n57,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N62,,5-webrbg-n62,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N63,,5-webrbg-n63,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N70,,5-webrbg-n70,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+regiobus-hannover,N94,,5-webrbg-n94,#08345d,#ffffff,,pill,,12076,RegioBus Hannover GmbH
+rmv-db-sbahn,S1,db-regio-ag-s-bahn-rhein-main,4-800528-1,#009edd,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S2,db-regio-ag-s-bahn-rhein-main,4-800528-2,#ff2e17,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S3,db-regio-ag-s-bahn-rhein-main,4-800528-3,#00b098,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S4,db-regio-ag-s-bahn-rhein-main,4-800528-4,#ffc734,#2c2e35,#2c2e35,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S5,db-regio-ag-s-bahn-rhein-main,4-800528-5,#95542a,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S6,db-regio-ag-s-bahn-rhein-main,4-800528-6,#ff7322,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S7,db-regio-ag-s-bahn-rhein-main,4-800528-7,#214d36,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S8,db-regio-ag-s-bahn-rhein-main,4-800528-8,#88c946,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-db-sbahn,S9,db-regio-ag-s-bahn-rhein-main,4-800528-9,#872996,#ffffff,,pill,,12201,DB Regio AG S-Bahn Rhein-Main
+rmv-eswe-bus,1,,5-rmv001-1,#ee7203,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,3,,5-rmv001-3,#8b5593,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,4,,5-rmv001-4,#2fac66,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,5,,5-rmv001-5,#e4032e,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,6,,5-rmv001-6,#eb5e57,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,8,,5-rmv001-8,#ee7203,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,9,,5-rmv001-9,#477ec0,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,14,,5-rmv001-14,#2fac66,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,15,,5-rmv001-15,#e4032e,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,16,,5-rmv001-16,#f39a8b,#000000,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,17,,5-rmv001-17,#009fe3,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,18,,5-rmv001-18,#8c9da6,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,20,,5-rmv001-20,#e4032e,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,21,,5-rmv001-21,#009641,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,22,,5-rmv001-22,#009641,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,23,,5-rmv001-23,#005da9,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,24,,5-rmv001-24,#005da9,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,26,,5-rmv001-26,#005da9,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,27,,5-rmv001-27,#005da9,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,28,,5-rmv001-28,#00b6ed,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,33,,5-rmv001-33,#8b5593,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,34,,5-rmv001-34,#918dbe,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,37,,5-rmv001-37,#283583,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,38,,5-rmv001-38,#009fe3,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,39,,5-rmv001-39,#f4954a,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,45,,5-rmv001-45,#cbce00,#000000,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,46,,5-rmv001-46,#c75c9f,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,47,,5-rmv001-47,#6b7c85,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,48,,5-rmv001-48,#477ec0,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,49,,5-rmv001-49,#8ec89a,#000000,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,74,,5-rmv001-74,#e6007d,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N2,,5-rmv001-n2,#005da9,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N3,,5-rmv001-n3,#b80e80,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N3,,5-rmv001-n3,#b80e80,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N4,,5-rmv001-n4,#6fbc85,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N5,,5-rmv001-n5,#009641,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N7,,5-rmv001-n7,#009fe3,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N9,,5-rmv001-n9,#c868a6,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N10,,5-rmv001-n10,#fbba00,#000000,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N11,,5-rmv001-n11,#ce7e00,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N12,,5-rmv001-n12,#e30613,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-eswe-bus,N13,,5-rmv001-n13,#000000,#ffffff,,rectangle,,8749,ESWE Verkehrsgesellschaft mbH
+rmv-express-bus,X72,,5-rmv408-x72,#e7007a,#ffffff,,rectangle-rounded-corner,,,
+rmv-heag-bus,A,,5-rmvheb-a,#a97b50,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,AH,,5-rmvheb-ah,#603711,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,AIR,,5-rmvheb-air,#3f9199,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,BE1,,5-rmv289-be1,#2e3092,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,EB,,5-rmv289-eb,#8bc63e,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,F,,5-rmvheb-f,#be1d2c,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,FM,,5-rmvheb-fm,#be1d2c,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,G,,5-rmvheb-g,#fbb03f,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,H,,5-rmvheb-h,#652d91,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,K,,5-rmvheb-k,#1074bc,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,L,,5-rmvheb-l,#e984b6,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,N,,5-rmvheb-n,#9f1960,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,O,,5-rmvheb-o,#9f1960,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,P,,5-rmv289-p,#f7931d,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,PE,,5-rmv289-pe,#f7931d,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,PG,,5-rmv289-pg,#f7931d,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,R,,5-rmvheb-r,#3ab54a,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,WE1,,5-rmv289-we1,#63708c,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,WE2,,5-rmv289-we2,#63708c,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,WE3,,5-rmv289-we3,#f15929,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,WE4,,5-rmv289-we4,#f15929,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-bus,WX,,5-rmvheb-wx,#fbb03f,#ffffff,,rectangle-rounded-corner,,8641,HEAG Mobilo
+rmv-heag-tram,1,,8-rmvhtr-1,#f77893,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,2,,8-rmvhtr-2,#00ab4f,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,3,,8-rmvhtr-3,#ffbe3c,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,4,,8-rmvhtr-4,#1e78c2,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,5,,8-rmvhtr-5,#3ab5e6,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,6,,8-rmvhtr-6,#fe782b,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,7,,8-rmvhtr-7,#fb3199,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,8,,8-rmvhtr-8,#f5381f,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,9,,8-rmvhtr-9,#7ac64d,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-heag-tram,10,,8-rmvhtr-10,#872996,#ffffff,,pill,,8641,HEAG Mobilo
+rmv-hsb-bus,1,,5-rmv399-1,#ffffff,#000000,#8bc63e,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,2,,5-rmv399-2,#ffffff,#000000,#ffdc01,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,4,,5-rmv399-4,#ffffff,#000000,#875400,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,5,,5-rmv399-5,#ffffff,#000000,#f48233,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,6,,5-rmv399-6,#ffffff,#000000,#873e97,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,7,,5-rmv399-7,#ffffff,#000000,#008cd0,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,8,,5-rmv399-8,#ffffff,#000000,#d70c8c,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,9,,5-rmv399-9,#ffffff,#000000,#ef4022,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,10,,5-rmv399-10,#ffffff,#000000,#015aaa,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,11,,5-rmv399-11,#ffffff,#000000,#77b6e4,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,12,,5-rmv399-12,#ffffff,#000000,#f390b3,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-hsb-bus,20,,5-rmv399-20,#ffffff,#000000,#b00d1d,rectangle-rounded-corner,,8675,Hanauer Straßenbahn GmbH
+rmv-mm-bus,6,,5-rmvmmb-6,#ef7d00,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,9,,5-rmvmmb-9,#006e89,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,28,,5-rmvmmb-28,#dbe283,#000000,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,33,,5-rmvmmb-33,#008fcf,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,54,,5-rmvmmb-54,#408927,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,55,,5-rmvmmb-55,#408927,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,56,,5-rmvmmb-56,#95c11f,#000000,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,57,,5-rmvmmb-57,#00b1eb,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,58,,5-rmvmmb-58,#95c11f,#000000,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,60,,5-rmvmmb-60,#00afcb,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,62,,5-rmvmmb-62,#c22e0c,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,63,,5-rmvmmb-63,#00afcb,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,64,,5-rmvmmb-64,#f59c00,#000000,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,65,,5-rmvmmb-65,#f59c00,#000000,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,66,,5-rmvmmb-66,#ffd500,#000000,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,67,,5-rmvmmb-67,#e30613,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,68,,5-rmvmmb-68,#00803d,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,69,,5-rmvmmb-69,#e30613,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,70,,5-rmvmmb-70,#a71b71,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,71,,5-rmvmmb-71,#a71b71,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,74,,5-rmvmmb-74,#e6007d,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,76,,5-rmvmmb-76,#8a1002,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,78,,5-rmvmmb-78,#124a73,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,79,,5-rmvmmb-79,#00803d,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,80,,5-rmvmmb-80,#0061a7,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,81,,5-rmvmmb-81,#0061a7,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,90,,5-rmvmmb-90,#8d004c,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,91,,5-rmvmmb-91,#914f00,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,92,,5-rmvmmb-92,#006d8f,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-bus,93,,5-rmvmmb-93,#5b7813,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-tram,50,,8-rmvmmt-50,#000000,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-tram,51,,8-rmvmmt-51,#4a4a49,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-tram,52,,8-rmvmmt-52,#7c7b7b,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-tram,53,,8-rmvmmt-53,#646363,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-mm-tram,59,,8-rmvmmt-59,#929292,#ffffff,,rectangle,,14207,Mainzer Mobilität
+rmv-vgf-tram,11,,8-rmv254-11,#fec10c,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,12,,8-rmv254-12,#c64a1a,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,14,,8-rmv254-14,#f05a22,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,15,,8-rmv254-15,#fec10c,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,16,,8-rmv254-16,#f5821f,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,17,,8-rmv254-17,#f05a22,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,18,,8-rmv254-18,#faa519,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,20,,8-rmv254-20,#ffffff,#faa519,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-tram,21,,8-rmv254-21,#faa519,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U1,,7-rmv255-1,#c52b1e,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U2,,7-rmv255-2,#00ab4f,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U3,,7-rmv255-3,#345aaf,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U4,,7-rmv255-4,#fc5cac,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U5,,7-rmv255-5,#0c7d3e,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U6,,7-rmv255-6,#0082ca,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U7,,7-rmv255-7,#f19e2d,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U8,,7-rmv255-8,#ca7fbe,#ffffff,,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rmv-vgf-ubahn,U9,,7-rmv255-9,#ffd939,#2c2e35,#2c2e35,pill,,8639,Stadtwerke Verkehrsgesellschaft Frankfurt
+rvf-sbahn,RE S1,db-regio-ag-baden-wurttemberg,re-s1,#d30630,#ffffff,,rectangle-rounded-corner,,10443,DB Regio AG Baden-Württemberg
+rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c6-1,#d30630,#ffffff,,rectangle-rounded-corner,,10443,DB Regio AG Baden-Württemberg
+rvf-sbahn,S1,db-regio-ag-baden-wurttemberg,4-8006c4-1,#d30630,#ffffff,,rectangle-rounded-corner,,10443,DB Regio AG Baden-Württemberg
+rvf-sbahn,S2,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s2,#afca0b,#ffffff,,rectangle-rounded-corner,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sbahn,S3,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s3,#b15a9e,#ffffff,,rectangle-rounded-corner,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sbahn,S5,sweg-sudwestdeutsche-landesverkehrs-gmbh,4-s6-s5,#0069b4,#ffffff,,rectangle-rounded-corner,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sbahn,S10,db-regio-ag-baden-wurttemberg,4-8006c6-10,#d30630,#ffffff,,rectangle-rounded-corner,,10443,DB Regio AG Baden-Württemberg
+rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c6-11,#f69795,#ffffff,,rectangle-rounded-corner,,10443,DB Regio AG Baden-Württemberg
+rvf-sbahn,S11,db-regio-ag-baden-wurttemberg,4-8006c4-11,#f69795,#ffffff,,rectangle-rounded-corner,,10443,DB Regio AG Baden-Württemberg
+rvf-sweg-sudwest,1,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb1,#a3238e,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,1,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-1,#a3238e,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,2,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb2,#fab383,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,2,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-2,#fab383,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,3,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb3,#f68b1e,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,3,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-3,#f68b1e,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,4,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-4,#009a4e,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,5,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb5,#ed1c24,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,5,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-5,#ed1c24,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,6,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb6,#74714c,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,6,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-6,#74714c,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,7,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-7,#ffdd00,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,9,sweg-sudwestdeutsche-landesverkehrs-gmbh,5-swg099-sb9,#008a90,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,9,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-9,#008a90,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-sweg-sudwest,10,sweg-sudwestdeutsche-landesverkehrs-gmbh,9-swg099-10,#cf9c50,#ffffff,,rectangle,,10939,Südwestdeutsche Verkehrs-AG
+rvf-vag-stadtbahn,1,,8-vag002-1,#ed1c24,#ffffff,,rectangle,,7642,VAG - Stadtbahn
+rvf-vag-stadtbahn,2,,8-vag002-2,#35af3f,#ffffff,,rectangle,,7642,VAG - Stadtbahn
+rvf-vag-stadtbahn,3,,8-vag002-3,#f79210,#ffffff,,rectangle,,7642,VAG - Stadtbahn
+rvf-vag-stadtbahn,4,,8-vag002-4,#f033a3,#ffffff,,rectangle,,7642,VAG - Stadtbahn
+rvf-vag-stadtbahn,5,,8-vag002-5,#0994ce,#ffffff,,rectangle,,7642,VAG - Stadtbahn
+s-bahn-bern-bls,S 1,bls-ag,4-850033-1,#50b447,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 2,bls-ag,4-850033-2,#1cb1e6,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 3,bls-ag,4-850033-3,#8868b3,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 31,bls-ag,4-850033-31,#b0aa38,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 4,bls-ag,4-850033-4,#53c4af,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 44,bls-ag,4-850033-44,#646026,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 5,bls-ag,4-850033-5,#881c3f,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 51,bls-ag,4-850033-51,#9cc843,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 52,bls-ag,4-850033-52,#f7cf39,#ffffff,,rectangle,,,
+s-bahn-bern-bls,S 6,bls-ag,4-850033-6-827562-5222797,#f84e4d,#ffffff,,rectangle,,,
+s-bahn-bern-rbs,S 7,regionalverkehr-bern-solothurn,4-850088-7,#ff812d,#ffffff,,rectangle,,,
+s-bahn-bern-rbs,S 8,regionalverkehr-bern-solothurn,4-850088-8,#191918,#ffffff,,rectangle,,,
+s-bahn-bern-rbs,S 9,regionalverkehr-bern-solothurn,4-850088-9,#fa2d18,#ffffff,,rectangle,,,
+s-bahn-hannover-transdev,S 1,s-bahn-hannover-transdev,4-tdhs-1,#846daa,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 2,s-bahn-hannover-transdev,4-tdhs-2,#007a3d,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 21,s-bahn-hannover-transdev,4-tdhs-21,#007a3d,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 3,s-bahn-hannover-transdev,4-tdhs-3,#cc69a6,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 4,s-bahn-hannover-transdev,4-tdhs-4,#9b2b48,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 5,s-bahn-hannover-transdev,4-tdhs-5,#f18700,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 51,s-bahn-hannover-transdev,4-tdhs-51,#f18700,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 6,s-bahn-hannover-transdev,4-tdhs-6,#004f9f,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 7,s-bahn-hannover-transdev,4-tdhs-7,#afcb27,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-hannover-transdev,S 8,s-bahn-hannover-transdev,4-tdhs-8,#1794ca,#ffffff,,pill,,13776,S-Bahn Hannover
+s-bahn-zentralschweiz-bls,S 6,bls-ag,4-850033-6-924462-5234071,#0165b6,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-bls,S 7,bls-ag,4-850033-7,#73c0e8,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-bls,S 77,bls-ag,4-850033-77,#7a84c4,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-sbb,S 1,sbb,4-85-1-924462-5234071,#1bb04d,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-sbb,S 2,sbb,4-85-2-947252-5247813,#f93f27,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-sbb,S 3,sbb,4-85-3-924462-5234071,#fe7d25,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-sbb,S 9,sbb,4-85-9-924462-5234071,#a3cf45,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-sbb,S 99,sbb,4-85-99,#95b15e,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-zb,S 4,zentralbahn,4-850086-4,#aa2a3f,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-zb,S 41,zentralbahn,4-850086-41,#055d80,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-zb,S 44,zentralbahn,4-850086-44,#d35d68,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-zb,S 5,zentralbahn,4-850086-5,#fb47a3,#ffffff,,rectangle-rounded-corner,,,
+s-bahn-zentralschweiz-zb,S 55,zentralbahn,4-850086-55,#fc87bf,#ffffff,,rectangle-rounded-corner,,,
+saarbahn,S1,saarbahn,8-vgssbs-1,#f39200,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,30,,5-vgssbb-30,#5c2483,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,101,,5-vgssbb-101,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,102,,5-vgssbb-102,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,103,,5-vgssbb-103,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,104,,5-vgssbb-104,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,105,,5-vgssbb-105,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,106,,5-vgssbb-106,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,107,,5-vgssbb-107,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,108,,5-vgssbb-108,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,109,,5-vgssbb-109,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,110,,5-vgssbb-110,#5c2483,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,111,,5-vgssbb-111,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,112,,5-vgssbb-112,#e30613,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,120,,5-vgssbb-120,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,121,,5-vgssbb-121,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,122,,5-vgssbb-122,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,123,,5-vgssbb-123,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,124,,5-vgssbb-124,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,125,,5-vgssbb-125,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,126,,5-vgssbb-126,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,128,,5-vgssbb-128,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,129,,5-vgssbb-129,#00a13a,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,130,,5-vgssbb-130,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,131,,5-vgssbb-131,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,133,,5-vgssbb-133,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,134,,5-vgssbb-134,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,135,,5-vgssbb-135,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,136,,5-vgssbb-136,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,137,,5-vgssbb-137,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,138,,5-vgssbb-138,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,139,,5-vgssbb-139,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,151,,5-vgssbb-151,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,152,,5-vgssbb-152,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,153,,5-vgssbb-153,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,154,,5-vgssbb-154,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,161,,5-vgssbb-161,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,163,,5-vgssbb-163,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,164,,5-vgssbb-164,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,165,,5-vgssbb-165,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+saarbahn,168,,5-vgssbb-168,#008bd2,#ffffff,,rectangle,,8931,Saarbahn GmbH
+schweiz-fernverkehr,RE 6,schweizerische-bundesbahnen,re-6,#4f1a4a,#ffffff,,rectangle-rounded-corner,,,
+schweiz-fernverkehr,RE 33,schweizerische-bundesbahnen,re-33,#076867,#ffffff,,rectangle-rounded-corner,,,
+schweiz-fernverkehr,RE 37,schweizerische-bundesbahnen,re-37,#ffaa90,#2c2e35,,rectangle-rounded-corner,,,
+schweiz-fernverkehr,RE 48,schweizerische-bundesbahnen,re-48,#b9a96f,#ffffff,,rectangle-rounded-corner,,,
+start,RB12,regionalverkehre-start-deutschland-gmbh-start-taunus,stn-rb12,#94522e,#ffffff,,rectangle-rounded-corner,,14174,Regionalverkehre Start Deutschland GmbH Taunus
+start,RB15,regionalverkehre-start-deutschland-gmbh-start-taunus,stn-rb15,#e3a02e,#ffffff,,rectangle-rounded-corner,,14174,Regionalverkehre Start Deutschland GmbH Taunus
+svv-brb,S3,bayerische-regiobahn,4-l8-s3,#3ab048,#ffffff,,rectangle-rounded-corner,,10969,Bayerische Regiobahn
+svv-brb,S4,bayerische-regiobahn,4-l8-s4,#9764ac,#ffffff,,rectangle-rounded-corner,,10969,Bayerische Regiobahn
+svv-oebb,R3,osterreichische-bundesbahnen,r-3,#99be41,#ffffff,,rectangle-rounded-corner,,13396,Österreichische Bundesbahnen
+svv-oebb,R9,osterreichische-bundesbahnen,r-9,#e4be3d,#ffffff,,rectangle-rounded-corner,,13396,Österreichische Bundesbahnen
+svv-oebb,R21,osterreichische-bundesbahnen,r-21,#44bccf,#ffffff,,rectangle-rounded-corner,,13396,Österreichische Bundesbahnen
+svv-oebb,REX21,osterreichische-bundesbahnen,rex-21,#ff8124,#ffffff,,rectangle-rounded-corner,,13396,Österreichische Bundesbahnen
+svv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1451275-5318936,#0077bd,#ffffff,,rectangle-rounded-corner,,13396,Österreichische Bundesbahnen
+svv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1451275-5318936,#3ab048,#ffffff,,rectangle-rounded-corner,,13396,Österreichische Bundesbahnen
+svv-slb,R33,salzburger-lokalbahnen,,#c22438,#ffffff,,rectangle-rounded-corner,,,
+svv-slb,S1,salzburger-lokalbahnen,4-810007-1,#c22438,#ffffff,,rectangle-rounded-corner,,,
+svv-slb,S11,salzburger-lokalbahnen,4-810007-11,#c22438,#ffffff,,rectangle-rounded-corner,,,
+sweg-stuttgart,RE 6,sweg-bahn-stuttgart-gmbh,re-6,#ebaf2d,#ffffff,,rectangle,Q131584411,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RE 10a,sweg-bahn-stuttgart-gmbh,re-10a,#014f9f,#ffffff,,rectangle,Q131584412,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RE 10b,sweg-bahn-stuttgart-gmbh,re-10b,#014f9f,#ffffff,,rectangle,Q131584450,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RE 71,sweg-bahn-stuttgart-gmbh,re-71,#7db83f,#ffffff,,rectangle,Q131584454,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,MEX 12,sweg-bahn-stuttgart-gmbh,mex-12,#f27320,#ffffff,,rectangle,Q131584405,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,MEX 17a,sweg-bahn-stuttgart-gmbh,mex-17a,#00a9df,#ffffff,,rectangle,Q131584401,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,MEX 17c,sweg-bahn-stuttgart-gmbh,mex-17c,#ec2933,#ffffff,,rectangle,Q131584403,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,MEX 18,sweg-bahn-stuttgart-gmbh,mex-18,#009c48,#ffffff,,rectangle,Q131584398,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RB 17a,sweg-bahn-stuttgart-gmbh,rb-17a,#00a9df,#ffffff,,rectangle,Q131584392,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RB 17c,sweg-bahn-stuttgart-gmbh,rb-17c,#ec2933,#ffffff,,rectangle,Q131584394,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RB 18,sweg-bahn-stuttgart-gmbh,rb-18,#009c48,#ffffff,,rectangle,Q131583989,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RE 18,sweg-bahn-stuttgart-gmbh,re-18,#009c48,#ffffff,,rectangle,Q131583931,14172,SWEG Bahn Stuttgart
+sweg-stuttgart,RB 10a,sweg-bahn-stuttgart-gmbh,rb-10a,#014f9f,#ffffff,,rectangle,Q131587496,14172,SWEG Bahn Stuttgart
+sweg-sudwest,RB 42,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb42,#088c3c,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 42a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb42a,#f06c1c,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 43,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb43,#089ce4,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 43a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb43a,#b8941c,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 59a,sweg-sudwestdeutsche-landesverkehrs-gmbh,swerb59a,#ffc734,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 66,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb66,#014f9f,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 67,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb67,#00a9df,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 68,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb68,#ec2933,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RB 69,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rb69,#f27320,#ffffff,,rectangle,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RS 1,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs1,#1d4e9e,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RS 11,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs11,#009ddb,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RS 12,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs12,#74ba24,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RS 2,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs2,#fbc707,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+sweg-sudwest,RS 4,sweg-sudwestdeutsche-landesverkehrs-gmbh,swe-rs4,#d91338,#ffffff,,pill,,7916,Südwestdeutsche-Verkehrs-AG
+tlx,L2,trilex-die-landerbahn-gmbh-dlb,tl-l2,#0f7ec0,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tlx,L24,trilex-die-landerbahn-gmbh-dlb,tl-l24,#6eae47,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tlx,L4,trilex-die-landerbahn-gmbh-dlb,tl-l4,#242320,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tlx,L7,trilex-die-landerbahn-gmbh-dlb,tl-l7,#ea7b09,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tlx,RB60,trilex-die-landerbahn-gmbh-dlb,tl-rb60,#569b6d,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tlx,RB61,trilex-die-landerbahn-gmbh-dlb,tl-rb61,#438577,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tlx,RE1,trilex-express-die-landerbahn-gmbh-dlb,tlx-re1,#e97b3b,#ffffff,,rectangle-rounded-corner,,10890,trilex-express - Die Länderbahn GmbH DLB
+tlx,RE2,trilex-express-die-landerbahn-gmbh-dlb,tlx-re2,#db031c,#ffffff,,rectangle-rounded-corner,,10890,trilex-express - Die Länderbahn GmbH DLB
+tlx,T9,trilex-die-landerbahn-gmbh-dlb,tl-t9,#f6b90b,#ffffff,,rectangle-rounded-corner,,10892,trilex  - Die Länderbahn GmbH DLB
+tnw-blt,10,baselland-transport,8-850037-10,#fbc707,#000000,,rectangle-rounded-corner,,,
+tnw-blt,11,baselland-transport,8-850037-11,#ed1c24,#ffffff,,rectangle-rounded-corner,,,
+tnw-blt,E11,baselland-transport,8-850037-e11,#ed1c24,#ffffff,,rectangle-rounded-corner,,,
+tnw-blt,17,baselland-transport,8-850037-17,#00adef,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,1,basler-verkehrsbetriebe,8-85bvb-1,#7a4a30,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,2,basler-verkehrsbetriebe,8-85bvb-2,#9e7c46,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,3,basler-verkehrsbetriebe,8-85bvb-3,#3948a4,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,6,basler-verkehrsbetriebe,8-85bvb-6,#176fc1,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,8,basler-verkehrsbetriebe,8-85bvb-8,#f24dae,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,14,basler-verkehrsbetriebe,8-85bvb-14,#f47216,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,15,basler-verkehrsbetriebe,8-85bvb-15,#00a650,#ffffff,,rectangle-rounded-corner,,,
+tnw-bvb,16,basler-verkehrsbetriebe,8-85bvb-16,#99d420,#000000,,rectangle-rounded-corner,,,
+tnw-bvb,21,basler-verkehrsbetriebe,8-85bvb-21,#1ab19c,#ffffff,,rectangle-rounded-corner,,,
+uestra,1,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-1,#ffffff,#2c2e35,#ff2e3e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,2,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-2,#ffffff,#2c2e35,#ff2e3e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,3,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-3,#ffffff,#2c2e35,#0073c0,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,4,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-4,#ffffff,#2c2e35,#ffac2e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,5,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-5,#ffffff,#2c2e35,#ffac2e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,6,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-6,#ffffff,#2c2e35,#ffac2e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,7,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-7,#ffffff,#2c2e35,#0073c0,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,8,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-8,#ffffff,#2c2e35,#ff2e3e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,9,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-9,#ffffff,#2c2e35,#0073c0,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,10,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-10,#ffffff,#2c2e35,#6dc248,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,11,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-11,#ffffff,#2c2e35,#ffac2e,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,12,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-12,#ffffff,#2c2e35,#6dc248,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,13,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-13,#ffffff,#2c2e35,#0073c0,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,17,ustra-hannoversche-verkehrsbetriebe-ag,8-webuet-17,#ffffff,#2c2e35,#6dc248,rectangle,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,100,,5-webueb-100,#ffffff,#2c2e35,#fb3199,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,120,,5-webueb-120,#ffffff,#2c2e35,#ff9027,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,121,,5-webueb-121,#ffffff,#2c2e35,#95cc45,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,122,,5-webueb-122,#ffffff,#2c2e35,#95cc45,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,123,,5-webueb-123,#ffffff,#2c2e35,#fc87bf,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,124,,5-webueb-124,#ffffff,#2c2e35,#95cc45,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,125,,5-webueb-125,#ffffff,#2c2e35,#ff2e17,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,126,,5-webueb-126,#ffffff,#2c2e35,#ff2e17,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,127,,5-webueb-127,#ffffff,#2c2e35,#ffbe32,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,128,,5-webueb-128,#ffffff,#2c2e35,#af2a21,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,129,,5-webueb-129,#ffffff,#2c2e35,#fc5cac,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,130,,5-webueb-130,#ffffff,#2c2e35,#95cc45,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,133,,5-webueb-133,#ffffff,#2c2e35,#ffbe32,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,134,,5-webueb-134,#ffffff,#2c2e35,#3ebc6d,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,135,,5-webueb-135,#ffffff,#2c2e35,#3ebc6d,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,136,,5-webueb-136,#ffffff,#2c2e35,#af2a21,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,137,,5-webueb-137,#ffffff,#2c2e35,#ff9027,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,200,,5-webueb-200,#ffffff,#2c2e35,#fc87bf,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,253,,5-webueb-253,#ffffff,#2c2e35,#ff9027,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,254,,5-webueb-254,#ffffff,#2c2e35,#35ccf6,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,267,,5-webueb-267,#ffffff,#2c2e35,#3ebc6d,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,330,,5-webueb-330,#ffffff,#2c2e35,#ffbe32,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,340,,5-webueb-340,#ffffff,#2c2e35,#ff2e17,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,341,,5-webueb-341,#ffffff,#2c2e35,#3ebc6d,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,345,,5-webueb-345,#ffffff,#2c2e35,#ffbe32,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,346,,5-webueb-346,#ffffff,#2c2e35,#903da0,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,347,,5-webueb-347,#ffffff,#2c2e35,#ff9027,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,348,,5-webueb-348,#ffffff,#2c2e35,#fc87bf,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,363,,5-webueb-363,#ffffff,#2c2e35,#ff9027,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,371,,5-webueb-371,#ffffff,#2c2e35,#0155ae,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,372,,5-webueb-372,#ffffff,#2c2e35,#35ccf6,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,373,,5-webueb-373,#ffffff,#2c2e35,#ff9027,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,390,,5-webueb-390,#ffffff,#2c2e35,#95cc45,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,420,,5-webueb-420,#ffffff,#2c2e35,#fc87bf,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,450,,5-webueb-450,#ffffff,#2c2e35,#ffbe32,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,470,,5-webueb-470,#ffffff,#2c2e35,#fc87bf,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,480,,5-webueb-480,#ffffff,#2c2e35,#3ebc6d,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,581,,5-webueb-581,#ffffff,#2c2e35,#903da0,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,610,,5-webueb-610,#ffffff,#2c2e35,#3ebc6d,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,611,,5-webueb-611,#ffffff,#2c2e35,#af2a21,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,631,,5-webueb-631,#ffffff,#2c2e35,#95cc45,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+uestra,800,,5-webueb-800,#ffffff,#2c2e35,#35ccf6,pill,,554,üstra Hannoversche Verkehrsbetriebe AG
+vbb-bvg-tram,M1,,8-vbbbvt-m1,#63b9e9,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M2,,8-vbbbvt-m2,#7ab929,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M4,,8-vbbbvt-m4,#ca1214,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M5,,8-vbbbvt-m5,#c8893b,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M6,,8-vbbbvt-m6,#005695,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M8,,8-vbbbvt-m8,#ee7203,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M10,,8-vbbbvt-m10,#007b3d,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M13,,8-vbbbvt-m13,#00a092,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,M17,,8-vbbbvt-m17,#a6422a,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,12,,8-vbbbvt-12,#8870ab,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,16,,8-vbbbvt-16,#007fab,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,18,,8-vbbbvt-18,#d6ad00,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,21,,8-vbbbvt-21-1498437-5841048,#bc90c1,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,27,,8-vbbbvt-27,#cb621a,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,37,,8-vbbbvt-37,#815238,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,50,,8-vbbbvt-50,#eb9000,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,60,,8-vbbbvt-60,#009bd9,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,61,,8-vbbbvt-61,#e30613,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,62,,8-vbbbvt-62,#00512d,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,63,,8-vbbbvt-63,#ee7203,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,67,,8-vbbbvt-67,#dd6ca6,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-tram,68,,8-vbbbvt-68,#65b32e,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U1,,7-vbbbvu-1,#7dad4c,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U2,,7-vbbbvu-2,#da421e,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U3,,7-vbbbvu-3,#16683d,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U4,,7-vbbbvu-4,#f0d722,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U5,,7-vbbbvu-5,#7e5330,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U6,,7-vbbbvu-6,#8c6dab,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U7,,7-vbbbvu-7,#009bd5,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U8,,7-vbbbvu-8,#224f86,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-bvg-ubahn,U9,,7-vbbbvu-9,#f3791d,#ffffff,,rectangle,,796,Berliner Verkehrsbetriebe
+vbb-db-sbahn,S1,s-bahn-berlin,4-08-1,#eb588f,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S2,s-bahn-berlin,4-08-2,#047939,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S25,s-bahn-berlin,4-08-25,#047939,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S26,s-bahn-berlin,4-08-26,#047939,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S3,s-bahn-berlin,4-08-3,#026597,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S41,s-bahn-berlin,4-08-41,#aa3c1f,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S42,s-bahn-berlin,4-08-42,#ba622d,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S45,s-bahn-berlin,4-08-45,#aa3c1f,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S46,s-bahn-berlin,4-08-46,#ca8539,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S47,s-bahn-berlin,4-08-47,#ca8539,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S5,s-bahn-berlin,4-08-5,#ea561c,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S7,s-bahn-berlin,4-08-7,#764d9a,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S75,s-bahn-berlin,4-08-75,#764d9a,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S8,s-bahn-berlin,4-08-8,#4fa433,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S85,s-bahn-berlin,4-08-85,#4fa433,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-db-sbahn,S9,s-bahn-berlin,4-08-9,#951732,#ffffff,,pill,,1,S-Bahn Berlin GmbH
+vbb-vip-bus,603,,5-vbbvib-603,#fca13d,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,605,,5-vbbvib-605,#c1732a,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,609,,5-vbbvib-609,#907d32,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,612,,5-vbbvib-612,#842a26,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,616,,5-vbbvib-616,#0155ae,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,638,,5-vbbvib-638,#665fb1,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,639,,5-vbbvib-639,#f0eef6,#9e9ace,#9e9ace,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,690,,5-vbbvib-690,#446080,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,691,,5-vbbvib-691,#feeedd,#ff9027,#ff9027,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,692,,5-vbbvib-692,#00b9f2,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,693,,5-vbbvib-693,#e36eb5,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,694,,5-vbbvib-694,#70a4b8,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,695,,5-vbbvib-695,#bf2a4f,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,696,,5-vbbvib-696,#eb2d4c,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,697,,5-vbbvib-697,#772382,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,698,,5-vbbvib-698,#117b40,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,699,,5-vbbvib-699,#d9992f,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,X5,,5-vbbvib-x5,#f2e6f1,#b167b3,#b167b3,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,X15,,5-vbbvib-x15,#ffffff,#49c07d,#49c07d,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,N14,,5-vbbvib-n14,#ffa32b,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,N15,,5-vbbvib-n15,#ff7322,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,N16,,5-vbbvib-n16,#009edd,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-bus,N17,,5-vbbvib-n17,#5fbf49,#ffffff,,pill,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,91,,8-vbbvit-91,#ff2e17,#ffffff,,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,92,,8-vbbvit-92,#024890,#ffffff,,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,93,,8-vbbvit-93,#ff7322,#ffffff,,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,94,,8-vbbvit-94,#89969e,#ffffff,,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,96,,8-vbbvit-96,#00b098,#ffffff,,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,98,,8-vbbvit-98,#daedf9,#009edd,#009edd,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbb-vip-tram,99,,8-vbbvit-99,#5fbf49,#ffffff,,rectangle,,8606,Verkehrsbetrieb Potsdam GmbH
+vbg,RB 1,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb1,#e30613,#ffffff,,rectangle-rounded-corner,,10382,vogtlandbahn - Die Länderbahn GmbH DLB
+vbg,RB 2,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb2,#0067b0,#ffffff,,rectangle-rounded-corner,,10382,vogtlandbahn - Die Länderbahn GmbH DLB
+vbg,RB 4,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb4,#954b3f,#ffffff,,rectangle-rounded-corner,,10382,vogtlandbahn - Die Länderbahn GmbH DLB
+vbg,RB 5,vogtlandbahn-die-landerbahn-gmbh-dlb,vbg-rb5,#009641,#ffffff,,rectangle-rounded-corner,,10382,vogtlandbahn - Die Länderbahn GmbH DLB
+vbn-bsag,1,bremer-strassenbahn-ag,8-webbtr-1,#00a54f,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,1E,bremer-strassenbahn-ag,8-webbtr-1e,#00a54f,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,1S,bremer-strassenbahn-ag,8-webbtr-1s,#00a54f,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,2,bremer-strassenbahn-ag,8-webbtr-2,#0166b3,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,3,bremer-strassenbahn-ag,8-webbtr-3,#00aeef,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,4,bremer-strassenbahn-ag,8-webbtr-4,#ee1d23,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,4S,bremer-strassenbahn-ag,8-webbtr-4s,#ee1d23,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,5,bremer-strassenbahn-ag,8-webbtr-5,#00aab8,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,5S,bremer-strassenbahn-ag,8-webbtr-5s,#00aab8,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,6,bremer-strassenbahn-ag,8-webbtr-6,#feca0a,#000000,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,6E,bremer-strassenbahn-ag,8-webbtr-6e,#feca0a,#000000,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,8,bremer-strassenbahn-ag,8-webbtr-8,#8bc63e,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,10,bremer-strassenbahn-ag,8-webbtr-10,#15258e,#ffffff,,rectangle,,12020,Bremer Straßenbahn AG
+vbn-bsag,20,,5-webbbu-20,#8bc63e,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,21,,5-webbbu-21,#00aeef,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,22,,5-webbbu-22,#a69dcd,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,24,,5-webbbu-24,#951b81,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,25,,5-webbbu-25,#009640,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,26,,5-webbbu-26,#e30613,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,27,,5-webbbu-27,#ef7d00,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,28,,5-webbbu-28,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,29,,5-webbbu-29,#95c11f,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,31,,5-webbbu-31,#95c11f,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,33,,5-webbbu-33,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,34,,5-webbbu-34,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,37,,5-webbbu-37,#951b81,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,38,,5-webbbu-38,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,39,,5-webbbu-39,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,40,,5-webbbu-40,#e30613,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,41,,5-webbbu-41,#e30613,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,41S,,5-webbbu-41s,#e30613,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,42,,5-webbbu-42,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,44,,5-webbbu-44,#ef7d00,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,52,,5-webbbu-52,#94c01f,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,55,,5-webbbu-55,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,57,,5-webbbu-57,#ef7d00,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,58,,5-webbbu-58,#ef7d00,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,61,,5-webbbu-61,#009fe3,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,62,,5-webbbu-62,#009640,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,63,,5-webbbu-63,#312783,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,63S,,5-webvol-63s,#312783,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,65,,5-webbbu-65,#94c01f,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,66,,5-webbbu-66,#94c01f,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,80,,5-webbbu-80,#94c01f,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,81,,5-webbbu-81,#009640,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,82,,5-webbbu-82,#ef7d00,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,90,,5-webbbu-90,#312783,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,91,,5-webbbu-91,#009fe3,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,92,,5-webbbu-92,#009fe3,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,93,,5-webbbu-93,#ffcc00,#000000,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,94,,5-webbbu-94,#e30613,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,95,,5-webbbu-95,#ef7d00,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,96,,5-webbbu-96,#951b81,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-bsag,98,,5-webbbu-98,#009640,#ffffff,,pill,,12020,Bremer Straßenbahn AG
+vbn-nwb-regio-s-bahn,RS 1,nordwestbahn,4-n1-rs1,#00448b,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+vbn-nwb-regio-s-bahn,RS 2,nordwestbahn,4-n1-rs2,#e89023,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+vbn-nwb-regio-s-bahn,RS 3,nordwestbahn,4-n1-rs3,#93bf30,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+vbn-nwb-regio-s-bahn,RS 30,nordwestbahn,4-n1-rs30,#4faf3b,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+vbn-nwb-regio-s-bahn,RS 4,nordwestbahn,4-n1-rs4,#e2000b,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+vbn-nwb-regio-s-bahn,RS 6,nordwestbahn,4-n1-rs6,#899bb9,#ffffff,,rectangle-rounded-corner,,12638,NordWestBahn
+vgn-db-sbn,S 1,db-regio-ag-bayern,4-800721-1,#92292e,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vgn-db-sbn,S 2,db-regio-ag-bayern,4-800721-2,#4dbd38,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vgn-db-sbn,S 3,db-regio-ag-bayern,4-800721-3,#f1471d,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vgn-db-sbn,S 4,db-regio-ag-bayern,4-800721-4,#2c3797,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vgn-db-sbn,S 5,db-regio-ag-bayern,4-800721-5,#0c7bc1,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vgn-db-sbn,S 6,db-regio-ag-bayern,4-800721-6,#95af33,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vgn-estw-bus,280,,5-estbus-280,#68709b,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,281,,5-estbus-281,#9b853c,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,281T,,9-estbus-281t,#9b853c,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,283,,5-estbus-283,#bfde47,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,283T,,9-estbus-283t,#bfde47,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,284,,5-estbus-284,#722671,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,285,,5-estbus-285,#ca028c,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,285T,,9-estbus-285t,#ca028c,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,286,,5-estbus-286,#bf9e30,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,287,,5-estbus-287,#f5ec42,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,287T,,9-estbus-287t,#f5ec42,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,289,,5-estbus-289,#6ca6c5,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,290,,5-estbus-290,#405eaf,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,293,,5-estbus-293,#1e0061,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,293T,,9-estbus-293t,#1e0061,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,294,,5-estbus-294,#b15f9e,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,295,,5-estbus-295,#5b9ba3,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,296,,5-estbus-296,#7bbfef,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,298,,5-estbus-298,#4d8d50,#ffffff,,pill,,13543,ESTW
+vgn-estw-bus,299,,5-estbus-299,#cb2e32,#ffffff,,pill,,13543,ESTW
+vgn-infra-bus,171,,5-fuebus-171,#b61a58,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,172,,5-fuebus-172,#d57536,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,173,,5-fuebus-173,#a6c2e7,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,174,,5-fuebus-174,#94622f,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,175,,5-fuebus-175,#d15b89,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,176,,5-fuebus-176,#f0db61,#151515,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,177,,5-fuebus-177,#6b8eb2,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,178,,5-fuebus-178,#b189b5,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,179,,5-fuebus-179,#728239,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-infra-bus,189,,5-fuebus-189,#7c2b1a,#ffffff,,pill,,13653,Stadtverkehr Fürth
+vgn-swh-bus,1501,,5-hof004-1501,#914284,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1502,,5-hof004-1502,#6ba8eb,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1503,,5-hof004-1503,#36208e,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1504,,5-hof004-1504,#cb2e32,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1505,,5-hof004-1505,#ca028c,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1506,,5-hof004-1506,#9a90c5,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1507,,5-hof004-1507,#85c3cd,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1508,,5-hof004-1508,#edd03e,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1509,,5-hof004-1509,#d98838,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1510,,5-hof004-1510,#dd9998,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1511,,5-hof004-1511,#5ca755,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1512,,5-hof004-1512,#b0d24d,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1513,,5-hof004-1513,#dd9998,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1514,,5-hof004-1514,#d98838,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1515,,5-hof004-1515,#ca028c,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1516,,5-hof004-1516,#a0cff3,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1517,,5-hof004-1517,#edd14c,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-swh-bus,1518,,5-hof004-1518,#9086bf,#ffffff,,pill,,7980,Stadtverkehr Hürth
+vgn-vag-tram,4,,8-vanstr-4,#f46989,#ffffff,,rectangle,,13652,Tram Nürnberg
+vgn-vag-tram,5,,8-vanstr-5,#8a3ea3,#ffffff,,rectangle,,13652,Tram Nürnberg
+vgn-vag-tram,6,,8-vanstr-6,#fcf105,#151515,,rectangle,,13652,Tram Nürnberg
+vgn-vag-tram,7,,8-vanstr-7,#9ba1d9,#ffffff,,rectangle,,13652,Tram Nürnberg
+vgn-vag-tram,8,,8-vanstr-8,#32bdf2,#ffffff,,rectangle,,13652,Tram Nürnberg
+vgn-vag-tram,11,,8-vanstr-11,#db994d,#ffffff,,rectangle,,13652,Tram Nürnberg
+vgn-vag-tram,10,,8-vanstr-10,#c94f82,#ffffff,,rectangle,,13652,Tram Nürnberg
+vgn-vag-ubahn,U 1,,7-vanuba-1,#1c62aa,#ffffff,,rectangle,,13651,U-Bahn Nürnberg
+vgn-vag-ubahn,U 2,,7-vanuba-2,#ed1c24,#ffffff,,rectangle,,13651,U-Bahn Nürnberg
+vgn-vag-ubahn,U 3,,7-vanuba-3,#4dc2bb,#ffffff,,rectangle,,13651,U-Bahn Nürnberg
+vias,RB10,vias-gmbh,via-rb10,#e3a02e,#ffffff,,rectangle-rounded-corner,,10932,VIAS GmbH
+vlexx,RE3,vlexx,re-3,#e3a023,#ffffff,,rectangle-rounded-corner,,10951,vlexx
+vlexx,RE17,vlexx,re-17,#c77db4,#ffffff,,rectangle-rounded-corner,,10951,vlexx
+vmt-evag-tram,1,,8-rmteva-1,#f18700,#ffffff,,rectangle,,11742,Erfurter Verkehrsbetriebe AG
+vmt-evag-tram,2,,8-rmteva-2,#e3000b,#ffffff,,rectangle,,11742,Erfurter Verkehrsbetriebe AG
+vmt-evag-tram,3,,8-rmteva-3,#67095f,#ffffff,,rectangle,,11742,Erfurter Verkehrsbetriebe AG
+vmt-evag-tram,4,,8-rmteva-4,#007ac3,#ffffff,,rectangle,,11742,Erfurter Verkehrsbetriebe AG
+vmt-evag-tram,5,,8-rmteva-5,#00883c,#ffffff,,rectangle,,11742,Erfurter Verkehrsbetriebe AG
+vmt-evag-tram,6,,8-rmteva-6,#78ac28,#ffffff,,rectangle,,11742,Erfurter Verkehrsbetriebe AG
+vmt-jena-bus,10,,5-rmtjnv-10,#77c3ee,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,11,,5-rmtjnv-11,#2f277e,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,12,,5-rmtjnv-12,#4295b9,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,14,,5-rmtjnv-14,#44995d,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,15,,5-rmtjnv-15,#3a847a,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,16,,5-rmtjnv-16,#80bc9c,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,17,,5-rmtjnv-17,#d8592b,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,18,,5-rmtjnv-18,#42944b,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,28,,5-rmtjnv-28,#85b64c,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,41,,5-rmtjnv-41,#bc587d,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,42,,5-rmtjnv-42,#931e41,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,43,,5-rmtjnv-43,#9ac9d4,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,43A,,5-rmtjnv-43a,#9ac9d4,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,44,,5-rmtjnv-44,#2f6d95,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,47,,5-rmtjnv-47,#665a9d,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-bus,48,,5-rmtjnv-48,#c3c66d,#ffffff,,pill,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-tram,1,,8-rmtjnv-1,#d8592b,#ffffff,,rectangle,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-tram,2,,8-rmtjnv-2,#f0ba46,#ffffff,,rectangle,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-tram,4,,8-rmtjnv-4,#c92d24,#ffffff,,rectangle,,10283,Jenaer Nahverkehr GmbH
+vmt-jena-tram,5,,8-rmtjnv-5,#633271,#ffffff,,rectangle,,10283,Jenaer Nahverkehr GmbH
+vor-oebb,S1,osterreichische-bundesbahnen,4-81-1-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S2,osterreichische-bundesbahnen,4-81-2-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S3,osterreichische-bundesbahnen,4-81-3-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S4,osterreichische-bundesbahnen,4-81-4-1821578-5360392,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S7,osterreichische-bundesbahnen,4-81-7,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S40,osterreichische-bundesbahnen,4-81-40,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S45,osterreichische-bundesbahnen,4-81-45,#c8d200,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S50,osterreichische-bundesbahnen,4-81-50,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S60,osterreichische-bundesbahnen,4-81-60,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-oebb,S80,osterreichische-bundesbahnen,4-81-80,#0097d5,#ffffff,,rectangle-rounded-corner,,,
+vor-wl,18,wiener-linien,8-810009-18,#c00808,#ffffff,,rectangle,,,
+vor-wl,U1,wiener-linien,7-810009-1,#e3000f,#ffffff,,rectangle,,,
+vor-wl,U2,wiener-linien,7-810009-2,#a862a4,#ffffff,,rectangle,,,
+vor-wl,U3,wiener-linien,7-810009-3,#ef7c00,#ffffff,,rectangle,,,
+vor-wl,U4,wiener-linien,7-810009-4,#00963f,#ffffff,,rectangle,,,
+vor-wl,U6,wiener-linien,7-810009-6,#9d6830,#ffffff,,rectangle,,,
+vos-osnabrueck,10,,5-webos1-10,#8c61a0,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,12,,5-web-os-12,#2c247d,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,13,,5-webvos-13,#469cde,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,14,,5-webos1-14,#dc6d2b,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,15,,5-webos1-15,#eba83b,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,16,,5-webos1-16,#347841,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,17,,5-webos1-17,#4aa563,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,18,,5-webosv-18,#3479bd,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,19,,5-webosv-19,#1f4d98,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,20,,5-webos1-20,#8c61a0,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,21,,5-webos1-21,#8c61a0,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,M1,,5-webos1-m1,#408f54,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,M2,,5-webos1-m2,#30277e,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,M3,,5-webos1-m3,#9ebf43,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,M4,,5-webos1-m4,#c42f26,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vos-osnabrueck,M5,,5-webos1-m5,#d35b95,#ffffff,,rectangle,,7817,Verkehrsgemeinschaft Osnabrück
+vr,A,vr,4-10-a,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874158,,
+vr,D,vr,4-10-d,#58a618,#ffffff,,rectangle-rounded-corner,Q118874955,,
+vr,E,vr,4-10-e,#8c4799,#ffffff,,rectangle-rounded-corner,Q118869683,,
+vr,G,vr,4-10-g,#58a618,#ffffff,,rectangle-rounded-corner,Q118923662,,
+vr,H,vr,4-10-h,#58a618,#ffffff,,rectangle-rounded-corner,Q130430491,,
+vr,I,vr,4-10-i,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874956,,
+vr,K,vr,4-10-k,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874957,,
+vr,L,vr,4-10-l,#8c4799,#ffffff,,rectangle-rounded-corner,Q118869556,,
+vr,M,vr,4-10-m,#58a618,#ffffff,,rectangle-rounded-corner,Q118902123,,
+vr,O,vr,4-10-o,#58a618,#ffffff,,rectangle-rounded-corner,Q118924451,,
+vr,P,vr,4-10-p,#8c4799,#ffffff,,rectangle-rounded-corner,Q118874962,,
+vr,R,vr,4-10-r,#58a618,#ffffff,,rectangle-rounded-corner,Q118874959,,
+vr,T,vr,4-10-t,#58a618,#ffffff,,rectangle-rounded-corner,Q118874961,,
+vr,U,vr,4-10-u,#8c4799,#ffffff,,rectangle-rounded-corner,Q118869424,,
+vr,Y,vr,4-10-y,#8c4799,#ffffff,,rectangle-rounded-corner,Q118868930,,
+vr,Z,vr,4-10-z,#58a618,#ffffff,,rectangle-rounded-corner,Q118874964,,
+vrn-hetzler-pfadt,550,hetzler-pfadt,5-vrn028-550,#4f3599,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-hetzler-pfadt,552,hetzler-pfadt,5-vrn028-552,#fe3b85,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-hetzler-pfadt,553,hetzler-pfadt,5-vrn028-553,#ff5725,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-hetzler-pfadt,554,hetzler-pfadt,5-vrn028-554,#ff902c,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-hetzler-pfadt,555,hetzler-pfadt,5-vrn028-555,#102694,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-hetzler-pfadt,595,hetzler-pfadt,5-vrn028-595,#1c6836,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-palatinabus,507,palatinabus,5-vrn032-507,#ab6f42,#ffffff,,pill,,7926,PalatinaBus GmbH
+vrn-palatinabus,591,palatinabus,5-vrn032-591,#2faf9f,#ffffff,,pill,,7926,PalatinaBus GmbH
+vrn-qnv-queichtal-nahverkehr,539,qnv-queichtal-nahverkehr,5-vrn050-539,#c1b89d,#ffffff,,pill,,7939,Queichtal Nahverkehrsgesellschaft
+vrn-qnv-queichtal-nahverkehr,540,qnv-queichtal-nahverkehr,5-vrn050-540,#6e6353,#ffffff,,pill,,7939,Queichtal Nahverkehrsgesellschaft
+vrn-qnv-queichtal-nahverkehr,590,qnv-queichtal-nahverkehr,5-vrn050-590,#ffc53f,#ffffff,,pill,,7939,Queichtal Nahverkehrsgesellschaft
+vrn-qnv-queichtal-nahverkehr,599,qnv-queichtal-nahverkehr,5-vrn050-599,#ff2f1a,#ffffff,,pill,,7939,Queichtal Nahverkehrsgesellschaft
+vrn-regionalbus,625,,5-vrn033-625,#0e6e46,#ffffff,,pill,,7927,Busverkehr-Rhein-Neckar
+vrn-regionalbus,626,,5-vrn033-626,#509fc8,#ffffff,,pill,,7927,Busverkehr-Rhein-Neckar
+vrn-regionalbus,627,,5-vrn033-627,#6e1430,#ffffff,,pill,,7927,Busverkehr-Rhein-Neckar
+vrn-regionalbus,628,,5-vrn033-628,#007abe,#ffffff,,pill,,7927,Busverkehr-Rhein-Neckar
+vrn-regionalbus,629,,5-vrn033-629,#034c53,#ffffff,,pill,,7927,Busverkehr-Rhein-Neckar
+vrn-regionalbus,630,busverkehr-rhein-neckar,5-rbgbrn-630,#ff2e17,#ffffff,,pill,,7927,Busverkehr-Rhein-Neckar
+vrn-rheinpfalzbus,546,rheinpfalzbus,5-rbprpb-546,#45ba4b,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,547,rheinpfalzbus,5-rbprpb-547,#8e5a38,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,548,rheinpfalzbus,5-rbprpb-548,#3bb4e5,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,549,rheinpfalzbus,5-rbprpb-549,#ec7aba,#ffffff,,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,556,rheinpfalzbus,5-rbprpb-556,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,557,rheinpfalzbus,5-rbprpb-557,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,558,rheinpfalzbus,5-rbprpb-558,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,559,rheinpfalzbus,5-rbprpb-559,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,593,rheinpfalzbus,5-rbprpb-593,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,594,rheinpfalzbus,5-rbprpb-594,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,596,rheinpfalzbus,5-rbprpb-596,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rheinpfalzbus,598,rheinpfalzbus,5-rbprpb-598,#7f9e6b,#ffffff,#5e6e6f,pill,,13664,Hetzler & Pfadt vorher Viabus
+vrn-rnv-bus,5,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,5-vrnoeg-5-967040-5496598,#00965e,#ffffff,,pill,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-bus,20,,5-vrn019-20,#e07500,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,20A,,5-vrn019-20a,#e07500,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,27,,5-vrn019-21,#91c46d,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,28,,5-vrn019-28,#b09fcd,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,28A,,5-vrn019-28a,#b09fcd,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,29,,5-vrn019-29,#00bbef,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,30,,5-vrn019-30,#b2a0ce,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,31,,5-vrn019-31,#4794d1,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,32,,5-vrn019-32,#580600,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,33,,5-vrn019-33,#e3000b,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,34,,5-vrn019-34,#139cd9,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,35,,5-vrn019-35,#946b25,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,36,,5-vrn019-36,#008f88,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,36A,,5-vrn019-36a,#008f88,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,37,,5-vrn019-37,#91c46d,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,38,,5-vrn019-38,#0096b5,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,39,,5-vrn019-39,#4c2183,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,39A,,5-vrn019-39a,#4c2183,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,40,,5-vrn017-40,#4c2182,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,42,,5-vrn017-42,#a1c3d5,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,43,,5-vrn017-43,#4896d2,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,44,,5-vrn017-44,#009992,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,45,,5-vrn017-45,#0068b4,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,46,,5-vrn017-46,#a89ab1,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,47,,5-vrn017-47,#82d0f5,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,48,,5-vrn017-48,#009ee3,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,49,,5-vrn017-49,#ffffff,#00963e,#00963e,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,50,,5-vrn017-50,#91c46d,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,51,,5-vrn017-51,#0068b4,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,52,,5-vrn017-52,#a89ab1,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,53,,5-vrn017-53,#00bbee,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,54,,5-vrn017-54,#b19fcd,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,55,,5-vrn017-55,#4c2182,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,56,,5-vrn017-56,#00bbee,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,57,,5-vrn017-57,#5ac5f2,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,58,,5-vrn017-58,#a1c3d5,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,59,,5-vrn017-59,#a89ab1,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,60,,5-vrn017-60,#4c2182,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,61,,5-vrn017-61,#4896d2,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,62,,5-vrn017-62,#a89ab1,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,63,,5-vrn017-63,#a1c3d5,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,64,,5-vrn017-64,#0090a5,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,65,,5-vrn017-65,#8ac5bd,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,66,,5-vrn017-66,#e5007c,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-bus,67,,5-vrn017-67,#e17500,#ffffff,,pill,,7913,RNV Mannheim (Bus)
+vrn-rnv-tram,1,rhein-neckar-verkehr-gmbh,8-vrn008-1,#f39b9a,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,2,rhein-neckar-verkehr-gmbh,8-vrn008-2,#b00044,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,3,rhein-neckar-verkehr-gmbh,8-vrn008-3,#d5ad00,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,4,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4,#e3000b,#ffffff,,rectangle,,7909,RNV LU-MA (Strab)
+vrn-rnv-tram,4A,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4a,#e3000b,#ffffff,,rectangle,,7909,RNV LU-MA (Strab)
+vrn-rnv-tram,5,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-5,#00965e,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,5A,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-5a,#00965e,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,6,rhein-neckar-verkehr-gmbh,8-vrn008-6,#956b25,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,6A,rhein-neckar-verkehr-gmbh,8-vrn008-6a,#956b25,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,6E,rhein-neckar-verkehr-gmbh,8-vrn008-e,#956b25,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,7,rhein-neckar-verkehr-gmbh,8-vrn008-7,#ffcc00,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,8,rhein-neckar-verkehr-gmbh,8-vrn008-8,#e17500,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,9,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-9,#93c23b,#ffffff,,rectangle,,7909,RNV LU-MA (Strab)
+vrn-rnv-tram,10,rhein-neckar-verkehr-gmbh,8-vrn008-10,#a60f80,#ffffff,,rectangle,,7911,RNV HD-MA-Weinheim (Strab)
+vrn-rnv-tram,15,rhein-neckar-verkehr-gmbh-oberrheinische-eisenbahn,8-vrnoeg-15,#f7ab63,#ffffff,,rectangle,,7909,RNV LU-MA (Strab)
+vrn-rnv-tram,16,rhein-neckar-verkehr-gmbh,8-vrn008-16,#5e6baf,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,21,rhein-neckar-verkehr-gmbh,8-vrn011-21,#e3000b,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,22,rhein-neckar-verkehr-gmbh,8-vrn011-22,#fdc300,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,23,rhein-neckar-verkehr-gmbh,8-vrn011-23,#e48e00,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,24,rhein-neckar-verkehr-gmbh,8-vrn011-24,#8c1d75,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,25,rhein-neckar-verkehr-gmbh,8-vrn011-25,#93c23b,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,26,rhein-neckar-verkehr-gmbh,8-vrn011-26,#f39b9a,#ffffff,,rectangle,,7910,RNV Heidelberg (Strab)
+vrn-rnv-tram,X,rhein-neckar-verkehr-gmbh-rhein-haardtbahn,8-vrnrhb-4x,#9d9d9d,#ffffff,,rectangle,,7909,RNV LU-MA (Strab)
+vrn-sbahn-rn,S1,db-regio-ag-mitte,4-801539-1,#ed1c24,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S1X,db-regio-ag-mitte,4-801539-1x,#ed1c24,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S2,db-regio-ag-mitte,4-801539-2,#1575c5,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S3,db-regio-ag-mitte,4-801539-3,#fddd04,#231f20,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S4,db-regio-ag-mitte,4-801539-4,#00a650,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S5,db-regio-ag-mitte,4-801518-5,#f68a25,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S5X,db-regio-ag-mitte,4-801518-5x,#f68a25,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S6,db-regio-ag-mitte,4-801518-6,#40c1f3,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S7,db-regio-ag-mitte,4-801539-7,#ffffff,#ef249c,#ef249c,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S8,db-regio-ag-mitte,4-801518-8,#a25bad,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S9,db-regio-ag-mitte,4-801518-9,#73c82c,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S9X,db-regio-ag-mitte,4-801518-9x,#73c82c,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S33,db-regio-ag-mitte,4-801539-33,#833aa1,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S39,db-regio-ag-mitte,4-801539-39,#ffffff,#bf5810,#bf5810,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S44,db-regio-ag-mitte,4-801539-44,#ffffff,#00a650,#00a650,pill,,10449,DB Regio AG Mitte Region Südwest
+vrn-sbahn-rn,S51,db-regio-ag-mitte,4-801518-51,#f68a25,#ffffff,,pill,,10449,DB Regio AG Mitte Region Südwest
+vrr-bogestra,U35,,7-vrr032-35,#2350a9,#ffffff,,rectangle-rounded-corner,,7542,"BOGESTRA Stadtbahn, Linie U35"
+vrr-bogestra,301,,8-vrr033-301,#00a650,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,302,,8-vrr033-302,#86bbe0,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,305,,8-vrr033-305,#a865b9,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,306,,8-vrr030-306,#f0404c,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,308,,8-vrr033-308,#99d420,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,309,,8-vrr033-309,#2e3192,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,310,,8-vrr033-310,#aa3f7f,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,316,,8-vrr030-316,#e08417,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-bogestra,318,,8-vrr033-318,#6aa99a,#ffffff,,rectangle-rounded-corner,,7543,BOGESTRA Straßenbahn
+vrr-dsw21,490,,5-vrr038-490,#831f82,#ffffff,,rectangle,,7632,Dortmunder Stadtwerke Bus
+vrr-dsw21,AirportExpress,,5-vrr038-airex,#53ae2e,#ffffff,,rectangle,,7632,Dortmunder Stadtwerke Bus
+vrr-dsw21,AirportShuttle,,5-vrr038-airsh,#53ae2e,#ffffff,,rectangle,,7632,Dortmunder Stadtwerke Bus
+vrr-dsw21,U41,,7-vrr036-41,#fee702,#7b7979,#7b7979,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U42,,7-vrr036-42,#fab20b,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U43,,7-vrr036-43,#00a990,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U44,,7-vrr036-44,#66cde2,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U45,,7-vrr036-45,#ed1c24,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U46,,7-vrr036-46,#7264b8,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U47,,7-vrr036-47,#80cc28,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,U49,,7-vrr036-49,#f799be,#ffffff,,rectangle,,31,Dortmunder Stadtwerke U-Bahn
+vrr-dsw21,H1,,8-vrr039-hb1,#ec008c,#ffffff,,rectangle,,7633,Dortmunder Stadtwerke Hochbahn
+vrr-dsw21,H2,,8-vrr039-hb2,#ec008c,#ffffff,,rectangle,,7633,Dortmunder Stadtwerke Hochbahn
+vrr-dsw21,H3,,8-vrr039-hb3,#ec008c,#ffffff,,rectangle,,7633,Dortmunder Stadtwerke Hochbahn
+vrr-dsw21,H5,,8-vrr039-hb5,#ec008c,#ffffff,,rectangle,,7633,Dortmunder Stadtwerke Hochbahn
+vrr-dsw21,H7,,8-vrr039-hb7,#ec008c,#ffffff,,rectangle,,7633,Dortmunder Stadtwerke Hochbahn
+vrr-dvg,901,,8-vrr020-901,#009adf,#ffffff,,rectangle,,7634,DVG Strab
+vrr-dvg,903,,8-vrr020-903,#009adf,#ffffff,,rectangle,,7634,DVG Strab
+vrr-dvg,U79,,7-vrr020-79,#009a93,#ffffff,,rectangle,,7636,DVG
+vrr-hst,CE51,,5-vrr050-ce51,#c10004,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,CE52,,5-vrr050-ce52,#e63758,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE1,,5-vrr050-ne1,#ff2a2a,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE2,,5-vrr050-ne2,#ff6600,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE3,,5-vrr050-ne3,#ffcc00,#000000,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE4,,5-vrr050-ne4,#2ca02c,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE5,,5-vrr050-ne5,#5f8dd3,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE6,,5-vrr050-ne6,#7137c8,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE9,,5-vrr088-ne9,#800080,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE11,,5-vrr050-ne11,#3737c8,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE12,,5-vrr050-ne12,#5fd35f,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE19,,5-vrr050-ne19,#a02c2c,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE21,,5-vrr050-ne21,#803300,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,NE32,,5-vrr050-ne32,#364a9c,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,510,,5-vrr050-510,#b06520,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,512,,5-vrr050-512,#b06520,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,513,,5-vrr050-513,#7f4984,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,514,,5-vrr050-514,#f49b00,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,515,,5-vrr050-515,#567b3e,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,516,,5-vrr050-516,#7eaf49,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,517,,5-vrr050-517,#619f4e,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,518,,5-vrr050-518,#007bc1,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,519,,5-vrr050-519,#007bc1,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,521,,5-vrr050-521,#df0008,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,522,,5-vrr050-522,#e63758,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,524,,5-vrr050-524,#7fceef,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,525,,5-vrr050-525,#df0008,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,527,,5-vrr050-527,#7c277d,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,528,,5-vrr050-528,#7fceef,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,534,,5-vrr050-534,#7c277d,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,535,,5-vrr050-535,#e14c25,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,537,,5-vrr050-537,#006cb6,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,538,,5-vrr050-538,#006cb6,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,539,,5-vrr050-539,#897300,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,540,,5-vrr050-540,#364a9c,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,541,,5-vrr050-541,#e63758,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,542,,5-vrr050-542,#71c837,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-hst,543,,5-vrr050-543,#f49b00,#ffffff,,rectangle-rounded-corner,,7662,Hagener Straßenbahn AG Bus
+vrr-rheinbahn,U70,,7-vrr070-70,#71b2d0,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U71,,7-vrr070-71,#59c6f2,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U72,,7-vrr070-72,#25b8c5,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U73,,7-vrr070-73,#4465ad,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U75,,7-vrr070-75,#008fc2,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U76,,7-vrr070-76,#0063af,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U77,,7-vrr070-77,#7197cf,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U78,,7-vrr070-78,#009adf,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U79,,7-vrr070-79,#009a93,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,U83,,7-vrr070-83,#1d3a8f,#ffffff,,rectangle,,7762,Rheinbahn Stadtbahn
+vrr-rheinbahn,701,,8-vrr071-701,#f07d00,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,704,,8-vrr071-704,#bd1616,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,705,,8-vrr071-705,#c0087f,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,706,,8-vrr071-706,#e30613,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,707,,8-vrr071-707,#7e1974,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,708,,8-vrr071-708,#f29eb7,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,709,,8-vrr071-709,#e94190,#ffffff,,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,721,,5-vrr072-721,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,722,,5-vrr072-722,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,723,,5-vrr072-723,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,724,,5-vrr072-724,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,725,,5-vrr072-725,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,726,,5-vrr072-726,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,727,,5-vrr072-727,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,728,,5-vrr072-728,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,729,,5-vrr072-729,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,730,,5-vrr072-730,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,731,,5-vrr072-731,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,732,,5-vrr072-732,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,733,,5-vrr072-733,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,734,,5-vrr072-734,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,735,,5-vrr072-735,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,736,,5-vrr072-736,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,737,,5-vrr072-737,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,738,,5-vrr072-738,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,741,,5-vrr072-741,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,742,,5-vrr072-742,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,743,,5-vrr072-743,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,745,,5-vrr072-745,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,746,,5-vrr072-746,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,747,,5-vrr072-747,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,748,,5-vrr072-748,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,749,,5-vrr072-749,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,751,,5-vrr072-751,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,752,,5-vrr072-752,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,753,,5-vrr072-753,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,754,,5-vrr072-754,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,756,,5-vrr072-756,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,757,,5-vrr072-757,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,758,,5-vrr072-758,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,759,,5-vrr072-759,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,760,,5-vrr072-760,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,761,,5-vrr072-761,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,770,,5-vrr072-770,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,771,,5-vrr072-771,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,772,,5-vrr072-772,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,773,,5-vrr072-773,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,774,,5-vrr072-774,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,776,,5-vrr072-776,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,777,,5-vrr072-777,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,778,,5-vrr072-778,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,779,,5-vrr072-779,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,780,,5-vrr072-780,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,781,,5-vrr072-781,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,782,,5-vrr072-782,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,783,,5-vrr072-783,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,784,,5-vrr072-784,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,785,,5-vrr072-785,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,786,,5-vrr072-786,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,787,,5-vrr072-787,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,788,,5-vrr072-788,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,789,,5-vrr072-789,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,790,,5-vrr072-790,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,791,,5-vrr072-791,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,792,,5-vrr072-792,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,805,,5-vrr072-805,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,807,,5-vrr072-807,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,810,,5-vrr072-810,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,812,,5-vrr072-812,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,815,,5-vrr072-815,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,817,,5-vrr072-817,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,827,,5-vrr072-827,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,828,,5-vrr072-828,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,829,,5-vrr072-829,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,830,,5-vrr072-830,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,831,,5-vrr072-831,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,832,,5-vrr072-832,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,833,,5-vrr072-833,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,834,,5-vrr072-834,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,835,,5-vrr072-835,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,836,,5-vrr072-836,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,839,,5-vrr072-839,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,863,,5-vrr072-863,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,891,,5-vrr072-891,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,896,,5-vrr072-896,#f1db68,#696969,#f1db68,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,M1,,5-vrr073-m1,#3bb954,#ffffff,,rectangle,,12211,Rheinbahn MetroBus
+vrr-rheinbahn,M2,,5-vrr073-m2,#3bb954,#ffffff,,rectangle,Q130545061,12211,Rheinbahn MetroBus
+vrr-rheinbahn,M3,,5-vrr073-m3,#3bb954,#ffffff,,rectangle,,12211,Rheinbahn MetroBus
+vrr-rheinbahn,SB19,,5-vrr072-sb19,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB50,,5-vrr072-sb50,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB51,,5-vrr072-sb51,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB52,,5-vrr072-sb52,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB53,,5-vrr072-sb53,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB55,,5-vrr072-sb55,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB57,,5-vrr072-sb57,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB59,,5-vrr072-sb59,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB68,,5-vrr072-sb68,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SB79,,5-vrr072-sb79,#40909c,#ffffff,#40909c,rectangle,,7764,Rheinbahn Bus
+vrr-rheinbahn,SkyTrain,,8-vrr077-skyt,#53b6ed,#ffffff,,rectangle,,7766,Rheinbahn SkyTrain
+vrr-ruhrbahn,U11,,7-vrr010-11,#313390,#ffffff,,rectangle,,7638,"Essener Verkehrs AG, U-Bahn"
+vrr-ruhrbahn,U17,,7-vrr010-17,#6bb7e5,#ffffff,,rectangle,,7638,"Essener Verkehrs AG, U-Bahn"
+vrr-ruhrbahn,U18,,7-vrr013-18,#1187d2,#ffffff,,rectangle,,7638,"Essener Verkehrs AG, U-Bahn"
+vrr-ruhrbahn,101,,8-vrr011-101,#8b5c19,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,102,,8-vrr013-102,#f033a3,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,103,,8-vrr011-103,#fbc707,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,104,,8-vrr013-104,#bfb619,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,105,,8-vrr011-105,#a1d61e,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,106,,8-vrr011-106,#9a80b5,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,107,,8-vrr011-107,#d51f27,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,108,,8-vrr011-108,#ea9f0b,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,109,,8-vrr011-109,#1ca147,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-ruhrbahn,112,,8-vrr015-112,#9c0c79,#ffffff,,rectangle,,7639,"Essener Verkehrs AG, Straßenbahn"
+vrr-swk,041,,8-vrr001-041,#fb2513,#ffffff,,rectangle-rounded-corner,,7777,Städtische Werke Krefeld Strab
+vrr-swk,042,,8-vrr001-042,#fe8480,#ffffff,,rectangle-rounded-corner,,7777,Städtische Werke Krefeld Strab
+vrr-swk,043,,8-vrr001-043,#d75ec0,#ffffff,,rectangle-rounded-corner,,7777,Städtische Werke Krefeld Strab
+vrr-swk,044,,8-vrr001-044,#f95a01,#ffffff,,rectangle-rounded-corner,,7777,Städtische Werke Krefeld Strab
+vrr-sws,681,,5-vrr018-681,#006839,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,682,,5-vrr018-682,#008f6d,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,683,,5-vrr018-683,#76b82b,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,684,,5-vrr018-684,#038739,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,685,,5-vrr018-685,#599029,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,686,,5-vrr018-686,#afc40e,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,687,,5-vrr018-687,#4565ad,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,689,,5-vrr018-689,#945e43,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,690,,5-vrr018-690,#0090c9,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,691,,5-vrr018-691,#9c3632,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,692,,5-vrr018-692,#783f91,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,693,,5-vrr018-693,#a2837b,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,694,,5-vrr018-694,#5f9bc6,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,695,,5-vrr018-695,#c3436f,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,696,,5-vrr018-696,#757bb6,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,697,,5-vrr018-697,#02b1eb,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,698,,5-vrr018-698,#494495,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,699,,5-vrr018-699,#c77e18,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,NE21,,5-vrr018-ne21,#05a8e1,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,NE22,,5-vrr018-ne22,#004494,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,NE23,,5-vrr018-ne23,#4a76ba,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,NE24,,5-vrr018-ne24,#4896d2,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,NE25,,5-vrr018-ne25,#0362ad,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-sws,NE28,,5-vrr018-ne28,#004e9e,#ffffff,,rectangle,,7782,Stadtwerke Solingen
+vrr-wsw,600,,5-vrr066-600,#bd5695,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,601,,5-vrr066-601,#7e8b61,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,602,,5-vrr066-602,#7d96c4,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,603,,5-vrr066-603,#9f7456,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,604,,5-vrr066-604,#e59635,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,FreizeitBus 605,,5-vrr066-605,#aa974a,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,606,,5-vrr066-606,#7d3622,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,607,,5-vrr066-607,#709c47,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,608,,5-vrr066-608,#25594d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,609,,5-vrr066-609,#6bac43,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,610,,5-vrr066-610,#d96077,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,611,,5-vrr066-611,#846b97,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,612,,5-vrr066-612,#c2802c,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,613,,5-vrr066-613,#432059,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,614,,5-vrr066-614,#4aa5bd,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,615,,5-vrr066-615,#924374,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,616,,5-vrr066-616,#d12d40,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,617,,5-vrr066-617,#88214c,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,618,,5-vrr066-618,#c48766,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,619,,5-vrr066-619,#374c97,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,620,,5-vrr066-620,#49a17d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,621,,5-vrr066-621,#e59539,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,622,,5-vrr066-622,#adbc88,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,623,,5-vrr066-623,#cf5533,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,624,,5-vrr066-624,#449381,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,625,,5-vrr066-625,#85ac4d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,627,,5-vrr066-627,#9e511d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,628,,5-vrr066-628,#7e7543,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,630,,5-vrr066-630,#d75831,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,631,,5-vrr066-631,#64875d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,632,,5-vrr066-632,#e1af53,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,633,,5-vrr066-633,#47247d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,635,,5-vrr066-635,#bf713a,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,636,,5-vrr066-636,#ecaf63,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,637,,5-vrr066-637,#d5435c,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,638,,5-vrr066-638,#648c5e,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,640,,5-vrr066-640,#93b980,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,641,,5-vrr066-641,#bc653f,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,642,,5-vrr066-642,#5471a5,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,643,,5-vrr066-643,#43966b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,644,,5-vrr066-644,#9e7626,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,645,,5-vrr066-645,#b0b93d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,646,,5-vrr066-646,#3e8bb1,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,647,,5-vrr066-647,#dd7340,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,649,,5-vrr066-649,#94b483,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,650,,5-vrr066-650,#edbf41,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,666,,5-vrr066-666,#479fcd,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,669,,5-vrr066-669,#286035,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,670,,5-vrr066-670,#8d5c99,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,Schwebebahn,,8-vrr064-60,#4896d2,#ffffff,,rectangle-rounded-corner,,8015,Schwebebahn
+vrr-wsw,SB66,,5-vrr088-sb66,#3f8f9b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,SB67,,5-vrr045-sb67,#3f8f9b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,SB69,,5-vrr066-sb69,#3f8f9b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,CE61,,5-vrr066-ce61,#d12f2b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,CE62,,5-vrr066-ce62,#d12f2b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,CE64,,5-vrr066-ce64,#d12f2b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,CE65,,5-vrr066-ce65,#d12f2b,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,UniExpress E800,,5-vrr066-uniex,#9c9d9d,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrr-wsw,E860,,5-vrr066-e860,#c27629,#ffffff,,rectangle,,8016,Wuppertaler Stadtwerke
+vrs-bus,106,,5-vrs001-106,#097cc1,#ffffff,,rectangle,,,
+vrs-bus,118,,5-vrs001-118-779149-5669228,#85d1f5,#ffffff,,rectangle,,,
+vrs-bus,120,,5-vrs001-120,#e30a18,#ffffff,,rectangle,,,
+vrs-bus,121,,5-vrs001-121,#a2c61e,#ffffff,,rectangle,,,
+vrs-bus,122,,5-vrs001-122,#0569b3,#ffffff,,rectangle,,,
+vrs-bus,123,,5-vrs001-123,#f29ec4,#706f6f,#878787,rectangle,,,
+vrs-bus,124,,5-vrs001-124,#00b3bb,#ffffff,,rectangle,,,
+vrs-bus,125,,5-vrs001-125,#f7a706,#ffffff,,rectangle,,,
+vrs-bus,126,,5-vrs001-126,#f29ec4,#ffffff,,rectangle,,,
+vrs-bus,127,,5-vrs001-127,#1c9cd8,#ffffff,,rectangle,,,
+vrs-bus,130,,5-vrs001-130,#43c0f0,#ffffff,,rectangle,,,
+vrs-bus,131,,5-vrs001-131,#a2c61e,#ffffff,,rectangle,,,
+vrs-bus,132,,5-vrs001-132,#f7a707,#ffffff,,rectangle,,,
+vrs-bus,133,,5-vrs001-133,#e30a18,#ffffff,,rectangle,,,
+vrs-bus,134,,5-vrs001-134,#1c9cd8,#ffffff,,rectangle,,,
+vrs-bus,135,,5-vrs001-135,#ec72a6,#ffffff,,rectangle,,,
+vrs-bus,136,,5-vrs001-136,#bc866d,#ffffff,,rectangle,,,
+vrs-bus,138,,5-vrs001-138,#caa2cc,#ffffff,,rectangle,,,
+vrs-bus,139,,5-vrs001-139,#bd7542,#ffffff,,rectangle,,,
+vrs-bus,140,,5-vrs001-140,#ffcc03,#ffffff,,rectangle,,,
+vrs-bus,141,,5-vrs001-141,#33b6b3,#ffffff,,rectangle,,,
+vrs-bus,142,,5-vrs001-142,#e5077d,#ffffff,,rectangle,,,
+vrs-bus,143,,5-vrs001-143,#c6d54f,#ffffff,,rectangle,,,
+vrs-bus,144,,5-vrs001-144,#f7a706,#ffffff,,rectangle,,,
+vrs-bus,145,,5-vrs001-145,#15bbee,#ffffff,,rectangle,,,
+vrs-bus,146,,5-vrs001-146,#e94f26,#ffffff,,rectangle,,,
+vrs-bus,147,,5-vrs001-147,#f29ec4,#ffffff,,rectangle,,,
+vrs-bus,148,,5-vrs001-148,#f095be,#ffffff,,rectangle,,,
+vrs-bus,149,,5-vrs001-149,#f9d612,#ffffff,,rectangle,,,
+vrs-bus,150,,5-vrs001-150,#13baee,#ffffff,,rectangle,,,
+vrs-bus,151,,5-vrs001-151,#f7a707,#ffffff,,rectangle,,,
+vrs-bus,152,,5-vrs001-152,#ffcc03,#ffffff,,rectangle,,,
+vrs-bus,153,,5-vrs001-153,#a795c7,#ffffff,,rectangle,,,
+vrs-bus,154,,5-vrs001-154,#ec6738,#ffffff,,rectangle,,,
+vrs-bus,155,,5-vrs001-155,#128acb,#ffffff,,rectangle,,,
+vrs-bus,156,,5-vrs001-156,#fdeb1a,#878787,#878787,rectangle,,,
+vrs-bus,157,,5-vrs001-157,#1cafe6,#ffffff,,rectangle,,,
+vrs-bus,158,,5-vrs001-158,#76b72d,#ffffff,,rectangle,,,
+vrs-bus,159,,5-vrs001-159,#e84990,#ffffff,,rectangle,,,
+vrs-bus,160,,5-vrs001-160,#76b72d,#ffffff,,rectangle,,,
+vrs-bus,161,,5-vrs001-161,#1cafe6,#ffffff,,rectangle,,,
+vrs-bus,162,,5-vrs001-162,#f095be,#ffffff,,rectangle,,,
+vrs-bus,165,,5-vrs001-165,#84d0f5,#878787,#878787,rectangle,,,
+vrs-bus,166,,5-vrs001-166,#c6d54f,#878787,#878787,rectangle,,,
+vrs-bus,167,,5-vrs001-167,#ffcc03,#878787,#878787,rectangle,,,
+vrs-bus,171,,5-vrs001-171,#00b3bb,#ffffff,,rectangle,,,
+vrs-bus,180,,5-vrs001-180,#9d9d9c,#ffffff,,pill,,,
+vrs-bus,181,,5-vrs001-181,#9d9d9c,#ffffff,,pill,,,
+vrs-bus,182,,5-vrs001-182,#9d9d9c,#ffffff,,pill,,,
+vrs-bus,183,,5-vrs001-183,#9d9d9c,#ffffff,,pill,,,
+vrs-bus,184,,5-vrs001-184,#706f6f,#ffffff,,rectangle,,,
+vrs-bus,185,,5-vrs001-185,#706f6f,#ffffff,,rectangle,,,
+vrs-bus,187,,5-vrs001-187,#706f6f,#ffffff,,rectangle,,,
+vrs-bus,188,,5-vrs001-188,#9d9d9c,#ffffff,,pill,,,
+vrs-bus,189,,5-vrs001-189,#706f6f,#ffffff,,rectangle,,,
+vrs-bus,191,,5-vrs001-191,#009982,#ffffff,,rectangle,,,
+vrs-bus,192,,5-vrs001-192,#1c9cd8,#ffffff,,rectangle,,,
+vrs-bus,193,,5-vrs001-193,#f39205,#ffffff,,rectangle,,,
+vrs-bus,195,,5-vrs001-195,#f29ec4,#ffffff,,rectangle,,,
+vrs-bus,196,,5-vrs001-196,#a85e24,#ffffff,,rectangle,,,
+vrs-bus,197,,5-vrs001-197,#929292,#ffffff,,rectangle,,,
+vrs-bus,201,,5-vrs003-201,#faad19,#ffffff,,rectangle,,,
+vrs-bus,202,,5-vrs003-202,#b8427d,#ffffff,,rectangle,,,
+vrs-bus,203,,5-vrs003-203,#f7abb2,#ffffff,,rectangle,,,
+vrs-bus,204,,5-vrs003-204,#1b81c4,#ffffff,,rectangle,,,
+vrs-bus,205,,5-vrs003-205,#1b81c4,#ffffff,,rectangle,,,
+vrs-bus,206,,5-vrs003-206,#00a956,#ffffff,,rectangle,,,
+vrs-bus,207,,5-vrs003-207,#f79832,#ffffff,,rectangle,,,
+vrs-bus,208,,5-vrs003-208,#d263a5,#ffffff,,rectangle,,,
+vrs-bus,209,,5-vrs003-209,#d263a5,#ffffff,,rectangle,,,
+vrs-bus,211,,5-vrs003-211,#ee1b2b,#ffffff,,rectangle,,,
+vrs-bus,212,,5-vrs003-212,#1cbfdf,#ffffff,,rectangle,,,
+vrs-bus,213,,5-vrs003-213,#aab2d9,#ffffff,,rectangle,,,
+vrs-bus,214,,5-vrs003-214,#1b81c4,#ffffff,,rectangle,,,
+vrs-bus,215,,5-vrs003-215,#835645,#ffffff,,rectangle,,,
+vrs-bus,217,,5-vrs003-217,#b56d38,#ffffff,,rectangle,,,
+vrs-bus,218,,5-vrs003-218,#7ea17b,#ffffff,,rectangle,,,
+vrs-bus,222,,5-vrs003-222,#00aaad,#ffffff,,rectangle,,,
+vrs-bus,227,,5-vrs003-227,#ac99c9,#ffffff,,rectangle,,,
+vrs-bus,229,,5-vrs003-229,#fec70c,#9c9c9c,,rectangle,,,
+vrs-bus,232,,5-vrs003-232,#f5864b,#ffffff,,rectangle,,,
+vrs-bus,244,,5-vrs003-244,#0090c6,#ffffff,,rectangle,,,
+vrs-bus,251,,5-vrs003-251,#c18ba5,#ffffff,,rectangle,,,
+vrs-bus,253,,5-vrs003-253,#91ce9a,#ffffff,,rectangle,,,
+vrs-bus,254,,5-vrs003-254,#faaa4a,#ffffff,,rectangle,,,
+vrs-bus,255,,5-vrs003-255,#007dad,#ffffff,,rectangle,,,
+vrs-bus,257,,5-vrs003-257,#a6565c,#ffffff,,rectangle,,,
+vrs-bus,258,,5-vrs003-258,#1ca852,#ffffff,,rectangle,,,
+vrs-bus,260,,5-vrs016-260,#86526b,#ffffff,,rectangle,,,
+vrs-bus,600,,5-vrs006-600,#6d7eb8,#ffffff,,rectangle,,,
+vrs-bus,601,,5-vrs006-601,#662d91,#ffffff,,rectangle,,,
+vrs-bus,602,,5-vrs006-602,#d475b2,#ffffff,,rectangle,,,
+vrs-bus,603,,5-vrs006-603,#e74696,#ffffff,,rectangle,,,
+vrs-bus,604,,5-vrs006-604,#53b174,#ffffff,,rectangle,,,
+vrs-bus,605,,5-vrs006-605,#3d864b,#ffffff,,rectangle,,,
+vrs-bus,606,,5-vrs006-606,#9ac356,#ffffff,,rectangle,,,
+vrs-bus,607,,5-vrs006-607,#72b554,#ffffff,,rectangle,,,
+vrs-bus,608,,5-vrs006-608,#f4b94f,#ffffff,,rectangle,,,
+vrs-bus,609,,5-vrs006-609,#ef8d40,#ffffff,,rectangle,,,
+vrs-bus,610,,5-vrs006-610,#6fccf2,#ffffff,,rectangle,,,
+vrs-bus,611,,5-vrs006-611,#4faee4,#ffffff,,rectangle,,,
+vrs-bus,612,,5-vrs006-612,#c8985f,#ffffff,,rectangle,,,
+vrs-bus,613,,5-vrs006-613,#703315,#ffffff,,rectangle,,,
+vrs-bus,614,,5-vrs006-614,#766c45,#ffffff,,rectangle,,,
+vrs-bus,630,,5-vrs006-630,#c33e58,#ffffff,,rectangle,,,
+vrs-bus,632,,5-vrs006-632,#64b659,#ffffff,,rectangle,,,
+vrs-bus,633,,5-vrs006-633,#8dd2c8,#ffffff,,rectangle,,,
+vrs-bus,634,,5-vrs006-634,#db5b60,#ffffff,,rectangle,,,
+vrs-bus,635,,5-vrs006-635,#c9c552,#ffffff,,rectangle,,,
+vrs-bus,636,,5-vrs006-636,#af3031,#ffffff,,rectangle,,,
+vrs-bus,637,,5-vrs006-637,#e86741,#ffffff,,rectangle,,,
+vrs-bus,638,,5-vrs006-638,#e86741,#ffffff,,rectangle,,,
+vrs-bus,639,,5-vrs006-637,#a65c41,#ffffff,,rectangle,,,
+vrs-bus,AST 227,,9-vrs003-227,#f36e31,#ffffff,,rectangle,,,
+vrs-bus,Berg. FahrradBus,,5-vrs016-bf,#000000,#ffffff,,rectangle,,,
+vrs-bus,SB20,,5-vrs003-sb20,#f36e31,#ffffff,,rectangle,,,
+vrs-bus,SB22,,5-vrs003-sb22,#a5612e,#ffffff,,rectangle,,,
+vrs-bus,SB23,,5-vrs003-sb23,#00a54f,#ffffff,,rectangle,,,
+vrs-bus,SB24,,5-vrs003-sb24,#008540,#ffffff,,rectangle,,,
+vrs-bus,SB25,,5-vrs003-sb25,#00a9e2,#ffffff,,rectangle,,,
+vrs-bus,SB33,,5-vrr076-sb33,#81c9ef,#ffffff,,rectangle,,,
+vrs-bus,SB42,,5-vrs003-sb25,#176438,#ffffff,,rectangle,,,
+vrs-bus,SB60,,5-vrs006-sb60,#859268,#ffffff,,rectangle,,,
+vrs-bus,SB69,,5-vrs006-sb69,#df6a3c,#ffffff,,rectangle,,,
+vrs-bus,X24,,5-vrs003-x24,#243d98,#ffffff,,rectangle,,,
+vrs-stadtbahn,1,,8-vrs001-1,#e1081c,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,3,,8-vrs001-3,#f29ec2,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,4,,8-vrs001-4,#eb72a5,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,5,,8-vrs001-5,#a69dc8,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,7,,8-vrs001-7,#f08d52,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,9,,8-vrs001-9,#f09086,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,12,,8-vrs001-12,#98c01e,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,13,,8-vrs001-13,#aa8567,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,14,,8-vrs001-14,#b32499,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,15,,8-vrs001-15,#5aad31,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,16,,8-vrs001-16,#07ada5,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,17,,8-vrs001-17,#1e93d1,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,18,,8-vrs001-18,#85d1f5,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,19,,8-vrs001-19,#28523e,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,61,stadtwerke-bonn,8-s3-61,#9ab831,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,62,stadtwerke-bonn,8-s3-62,#65a53b,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,63,stadtwerke-bonn,8-s3-63,#8bccf3,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,65,stadtwerke-bonn,8-s3-65,#c6cc2a,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,66,stadtwerke-bonn,8-s3-66,#d4417d,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,67,stadtwerke-bonn,8-s3-67,#e7a8c4,#ffffff,,rectangle-rounded-corner,,,
+vrs-stadtbahn,68,stadtwerke-bonn,8-s3-68,#cbaece,#ffffff,,rectangle-rounded-corner,,,
+vst-oebb,S1,osterreichische-bundesbahnen,4-81-1-1714993-5236532,#0fa14a,#ffffff,,rectangle-rounded-corner,,,
+vst-oebb,S3,osterreichische-bundesbahnen,4-81-3-1714993-5236532,#ed028c,#ffffff,,rectangle-rounded-corner,,,
+vst-oebb,S5,osterreichische-bundesbahnen,4-81-5-1714993-5236532,#892890,#ffffff,,rectangle-rounded-corner,,,
+vst-oebb,S51,osterreichische-bundesbahnen,4-81-51,#892890,#ffffff,,rectangle-rounded-corner,,,
+vst-oebb,S8,osterreichische-bundesbahnen,4-81-8-1699752-5274525,#4fc4cf,#ffffff,,rectangle-rounded-corner,,,
+vst-oebb,S9,osterreichische-bundesbahnen,4-81-9,#957cb9,#ffffff,,rectangle-rounded-corner,,,
+vst-stb,S11,steiermarkbahn-und-bus-gmbh,4-3613-11,#0fa14a,#ffffff,,rectangle-rounded-corner,,,
+vst-stb,S31,steiermarkbahn-und-bus-gmbh,4-3613-31,#ed028c,#ffffff,,rectangle-rounded-corner,,,
+vvk-oebb,S1,osterreichische-bundesbahnen,4-81-1-1540573-5186063,#16489f,#ffffff,,rectangle-rounded-corner,,,
+vvk-oebb,S2,osterreichische-bundesbahnen,4-81-2-1540573-5186063,#3b8475,#ffffff,,rectangle-rounded-corner,,,
+vvk-oebb,S3,osterreichische-bundesbahnen,4-81-3-1592305-5185725,#e36f27,#ffffff,,rectangle-rounded-corner,,,
+vvk-oebb,S4,osterreichische-bundesbahnen,4-81-4-1540573-5186063,#ee1c25,#ffffff,,rectangle-rounded-corner,,,
+vvk-oebb,S5,osterreichische-bundesbahnen,4-81-5-1540573-5186063,#f3c836,#ffffff,,rectangle-rounded-corner,,,
+vvo-bus,EV11,,5-voe021-ev11,#c2ddaf,#000000,,pill,,,
+vvo-bus,61,,5-voe021-61,#0069b4,#ffffff,,pill,,,
+vvo-bus,62,,5-voe021-62,#008ace,#ffffff,,pill,,,
+vvo-bus,63,,5-voe021-63,#224193,#ffffff,,pill,,,
+vvo-bus,64,,5-voe021-64,#35a9e1,#ffffff,,pill,,,
+vvo-bus,65,,5-voe021-65,#1a70b8,#ffffff,,pill,,,
+vvo-bus,66,,5-voe021-66,#35a9e1,#ffffff,,pill,,,
+vvo-bus,68,,5-voe021-68,#008fba,#ffffff,,pill,,,
+vvo-bus,70,,5-voe021-70,#c99d66,#ffffff,,pill,,,
+vvo-bus,72,,5-voe021-72,#a4897a,#ffffff,,pill,,,
+vvo-bus,73,,5-voe021-73,#dbd186,#ffffff,,pill,,,
+vvo-bus,74,,9-voe021-74,#935e36,#ffffff,,pill,,,
+vvo-bus,76,,5-voe021-76,#a4897a,#ffffff,,pill,,,
+vvo-bus,76,,9-voe021-76,#a4897a,#ffffff,,pill,,,
+vvo-bus,77,,5-voe021-77,#bcae94,#ffffff,,pill,,,
+vvo-bus,77,,9-voe021-77,#bcae94,#ffffff,,pill,,,
+vvo-bus,78,,5-voe021-78,#dbd186,#ffffff,,pill,,,
+vvo-bus,79,,5-voe021-79,#bcae94,#ffffff,,pill,,,
+vvo-bus,79,,9-voe021-79,#bcae94,#ffffff,,pill,,,
+vvo-bus,80,,5-voe021-80,#683b0c,#ffffff,,pill,,,
+vvo-bus,81,,5-voe021-81,#935e36,#ffffff,,pill,,,
+vvo-bus,84,,5-voe021-84,#bcae94,#ffffff,,pill,,,
+vvo-bus,85,,5-voe021-85,#c99d66,#ffffff,,pill,,,
+vvo-bus,86,,5-voe021-86,#935e36,#ffffff,,pill,,,
+vvo-bus,87,,5-voe021-87,#a4897a,#ffffff,,pill,,,
+vvo-bus,88,,9-voe021-88,#a4897a,#ffffff,,pill,,,
+vvo-bus,89,,5-voe021-89,#bcae94,#ffffff,,pill,,,
+vvo-bus,90,,5-voe021-90,#bcae94,#ffffff,,pill,,,
+vvo-bus,91,,9-voe023-91,#c6be7a,#ffffff,,pill,,,
+vvo-bus,92,,9-voe021-92,#bcae94,#ffffff,,pill,,,
+vvo-bus,93,,9-voe023-93,#9c9661,#ffffff,,pill,,,
+vvo-bus,98A,,5-voe022-98a,#b1aa6e,#ffffff,,pill,,,
+vvo-bus,98B,,5-voe022-98b,#dbd186,#ffffff,,pill,,,
+vvo-bus,160,,5-voe023-160,#9c9d9d,#ffffff,,pill,,,
+vvo-bus,166,,5-voe023-166,#35a9e1,#ffffff,,pill,,,
+vvo-db-regio,U 28,db-regio-ag-sudost,rb-u28,#014d6f,#ffffff,,pill,,10437,DB Regio AG Südost
+vvo-db-regio,RB 33,db-regio-ag-sudost,rb-33,#ec7797,#ffffff,,rectangle,,10437,DB Regio AG Südost
+vvo-db-regio,RB 71,db-regio-ag-sudost,rb-71,#ad006f,#ffffff,,rectangle,,10437,DB Regio AG Südost
+vvo-db-regio,RB 72,db-regio-ag-sudost,rb-72,#9c321b,#ffffff,,rectangle,,10437,DB Regio AG Südost
+vvo-db-regio,RE 19,db-regio-ag-sudost,re-19,#00895d,#ffffff,,rectangle,,10437,DB Regio AG Südost
+vvo-db-regio,RE 20,db-regio-ag-sudost,re-20,#575756,#ffffff,,rectangle,,10437,DB Regio AG Südost
+vvo-db-regio,RE 50,db-regio-ag-sudost,re-50,#b60d1c,#ffffff,,rectangle,,10437,DB Regio AG Südost
+vvo-db-sbd,S 1,db-regio-ag-sudost,4-800469-1,#4f9551,#ffffff,,pill,,10437,DB Regio AG Südost
+vvo-db-sbd,S 2,db-regio-ag-sudost,4-800469-2,#f58220,#ffffff,,pill,,10437,DB Regio AG Südost
+vvo-db-sbd,S 3,db-regio-ag-sudost,4-800469-3,#00b3ef,#ffffff,,pill,,10437,DB Regio AG Südost
+vvo-db-sbd,S 8,db-regio-ag-sudost,4-8004l1-8,#2d92ad,#ffffff,,pill,,10437,DB Regio AG Südost
+vvo-ferry,F1,,6-voe091-f1,#00a5df,#ffffff,,rectangle-rounded-corner,,,
+vvo-ferry,F14,,6-voe091-f14,#00a5df,#ffffff,,rectangle-rounded-corner,,,
+vvo-ferry,F16,,6-voe091-f16,#00a5df,#ffffff,,rectangle-rounded-corner,,,
+vvo-ferry,F17,,6-voe091-f17,#00a5df,#ffffff,,rectangle-rounded-corner,,,
+vvo-tram,1,,8-voe011-1,#e30018,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,4,,8-voe011-4,#c9061a,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,6,,8-voe011-6,#ffdd00,#000000,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,8,,8-voe011-8,#229133,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,9,,8-voe011-9,#93c355,#ffffff,,rectangle-rounded-corner,,8190,DVB-Straßenbahn
+vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,,rectangle-rounded-corner,,,
+vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner,,,
+vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner,,,
+vvo-tram,13,,8-voe011-13,#fdc300,#000000,,rectangle-rounded-corner,,,
+vvo-tram,44,,8-voe011-44,#a14c8d,#000000,,rectangle-rounded-corner,,,
+vvo-tram,46,,8-voe011-46,#eba507,#000000,,rectangle-rounded-corner,,,
+vvo-tram,20,,8-voe011-20,#000000,#ffffff,,rectangle-rounded-corner,,,
+vvs-db-sbs,S1,db-regio-ag-s-bahn-stuttgart,4-800643-1,#59af41,#ffffff,,rectangle,Q18946157,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S11,db-regio-ag-s-bahn-stuttgart,4-800643-11,#59af41,#ffffff,,rectangle,Q107020232,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S2,db-regio-ag-s-bahn-stuttgart,4-800643-2,#ee1c28,#ffffff,,rectangle,Q66537943,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S3,db-regio-ag-s-bahn-stuttgart,4-800643-3,#f36e31,#ffffff,,rectangle,Q67504621,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S4,db-regio-ag-s-bahn-stuttgart,4-800643-4,#0166b3,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S5,db-regio-ag-s-bahn-stuttgart,4-800643-5,#00acdd,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S6,db-regio-ag-s-bahn-stuttgart,4-800643-6,#844c00,#ffffff,,rectangle,Q67501804,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S60,db-regio-ag-s-bahn-stuttgart,4-800643-60,#8a8d06,#ffffff,,rectangle,Q63952011,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,S62,db-regio-ag-s-bahn-stuttgart,4-800643-62,#c3792e,#ffffff,,rectangle,Q130343355,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,RB11,db-regio-ag-s-bahn-stuttgart,rb-11,#02aa9e,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+vvs-db-sbs,RB64,db-regio-ag-s-bahn-stuttgart,rb-64,#b6931d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg
+vvs-fmo,443,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-443,#009097,#ffffff,,rectangle,,11071,Friedrich Müller Omnibus GmbH
+vvs-fmo,444,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-444,#415b70,#ffffff,,rectangle,,11071,Friedrich Müller Omnibus GmbH
+vvs-fmo,444A,friedrich-muller-omnibusunternehmen-gmbh,5-rbgfmo-444a,#415b70,#ffffff,,rectangle,,11071,Friedrich Müller Omnibus GmbH
+vvs-lvl,413,,5-vvs031-413,#96c2e9,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,415,,5-vvs031-415,#c6bd7f,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,420,,5-vvs031-420,#e94190,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,421,,5-vvs031-421,#969200,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,421A,,5-vvs031-421a,#969200,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,422,,5-vvs031-422,#69c0ac,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,422A,,5-vvs031-422a,#69c0ac,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,423,,5-vvs031-423,#fbba00,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,424,,5-vvs031-424,#009ed4,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,425,,5-vvs031-425,#60a92c,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,425A,,5-vvs031-425a,#60a92c,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,426,,5-vvs031-426,#005ca9,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,427,,5-vvs031-427,#bb6130,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,427A,,5-vvs031-427a,#bb6130,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,428,,5-vvs031-428,#a0cee7,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,429,,5-vvs031-429,#95c11f,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,430,,5-vvs031-430,#8164a9,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,430A,,5-vvs031-430a,#8164a9,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,431,,5-vvs031-431,#bb1d3c,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,433,,5-vvs031-433,#e3d100,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,433A,,5-vvs031-433a,#e3d100,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,451,,5-vvs031-451,#00b1eb,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-lvl,X43,,5-vvs031-x43,#ef7d00,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-osb,551,,5-vvs031-551,#e12b54,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-osb,551A,,5-vvs031-551a,#e12b54,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-ssb-nachtbus,N 1,,5-vvs033-n1,#3c389e,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 2,,5-vvs033-n2,#6fdaf8,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 3,,5-vvs033-n3,#6fdaf8,#06429a,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 4,,5-vvs033-n4,#00ad70,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 5,,5-vvs033-n5,#ffb530,#06429a,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 6,,5-vvs033-n6,#db711d,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 7,,5-vvs033-n7,#ff2e1d,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 8,,5-vvs033-n8,#2c2e35,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 9,,5-vvs033-n9,#bb298a,#ffffff,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-nachtbus,N 10,,5-vvs033-n10,#ff8ea5,#06429a,,rectangle,,7997,Nachtbus (SSB)
+vvs-ssb-stadtbahn,SB,,3-vvs021-20,#ffb530,#24629d,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 1,,8-vvs020-u1,#d39d70,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 11,,8-vvs020-u11,#9b9c9f,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 12,,8-vvs020-u12,#80c6ea,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 13,,8-vvs020-u13,#fea0ba,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 14,,8-vvs020-u14,#64c255,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 15,,8-vvs020-u15,#0155ae,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 16,,8-vvs020-u16,#c6c03b,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 19,,8-vvs020-u19,#ffb530,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 2,,8-vvs020-u2,#ff6a2f,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 3,,8-vvs020-u3,#925d39,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 4,,8-vvs020-u4,#6866b5,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 5,,8-vvs020-u5,#18c5f4,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 6,,8-vvs020-u6,#fb3199,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 7,,8-vvs020-u7,#2bbb8f,#ffffff,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 8,,8-vvs020-u8,#c8b97b,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,U 9,,8-vvs020-u9,#ffd036,#000000,,rectangle,,7993,Stadtbahn
+vvs-ssb-stadtbahn,Zacke,,8-vvs021-10,#ffb530,#24629d,,rectangle,,7994,Zahnrad-/Seilbahn
+vvs-wbg,508,,5-vvs031-508,#875300,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,532,,5-vvs031-532,#5e8694,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,532A,,5-vvs031-532a,#5e8694,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,533,,5-vvs031-533,#d3a170,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,533A,,5-vvs031-533a,#d3a170,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,534,,5-vvs031-534,#007b3d,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,534A,,5-vvs031-534a,#007b3d,#ffffff,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,535,,5-vvs031-535,#c597b7,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,536,,5-vvs031-536,#f3a4b9,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-wbg,536A,,5-vvs031-536a,#f3a4b9,#000000,,rectangle,,7996,Privatunternehmer-Bus (VVS)
+vvs-weg,RB 46,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb46,#561c6f,#ffffff,,rectangle,,7992,NE-Zug (VVS)
+vvs-weg,RB 47,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb47,#b0599e,#ffffff,,rectangle,,7992,NE-Zug (VVS)
+vvs-weg,RB 61,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb61,#561c6f,#ffffff,,rectangle,,7992,NE-Zug (VVS)
+vvs-weg,RB 65,wurttembergische-eisenbahn-gesellschaft-mbh,weg-rb65,#b0599e,#ffffff,,rectangle,,7992,NE-Zug (VVS)
+vvt-db-regio-bayern,S7,db-regio-ag-bayern,4-800790-7,#d09eba,#ffffff,,rectangle,,10446,DB Regio AG Bayern
+vvt-oebb,cjx1,osterreichische-bundesbahnen,cjx-1,#48c9f2,#ffffff,,rectangle,,,
+vvt-oebb,S2,osterreichische-bundesbahnen,4-81-2-1365196-5198757,#f45f98,#ffffff,,rectangle,,,
+vvt-oebb,S3,osterreichische-bundesbahnen,4-81-3-1268243-5257783,#b0b6c8,#ffffff,,rectangle,,,
+vvt-oebb,S4,osterreichische-bundesbahnen,4-81-4-1268243-5257783,#4a205d,#ffffff,,rectangle,,,
+vvt-oebb,S6,osterreichische-bundesbahnen,4-81-6,#b01319,#ffffff,,rectangle,,,
+vvt-oebb,S8,osterreichische-bundesbahnen,4-81-8-1341673-5283199,#25aae1,#ffffff,,rectangle,,,
+vvv-montafoner-bahn,S4,montafoner-bahn,4-810003-4,#ffcb06,#ffffff,,rectangle,,,
+vvv-oebb,S1,osterreichische-bundesbahnen,4-81-1-1079437-5289939,#dd1936,#ffffff,,rectangle,,,
+vvv-oebb,S2,osterreichische-bundesbahnen,4-81-2-1054446-5247224,#dd1936,#ffffff,,rectangle,,,
+vvv-oebb,S3,osterreichische-bundesbahnen,4-81-3-1072203-5278907,#dd1936,#ffffff,,rectangle,,,
+vvv-oebb,R1,osterreichische-bundesbahnen,r-1,#dd1936,#ffffff,,rectangle,,,
+vvv-oebb,R2,osterreichische-bundesbahnen,r-2,#dd1936,#ffffff,,rectangle,,,
+vvv-oebb,R5,osterreichische-bundesbahnen,r-5,#dd1936,#ffffff,,rectangle,,,
+waldbahn-dlb,RB 35,waldbahn-die-landerbahn-gmbh-dlb,rb35,#006629,#ffffff,,rectangle,,10964,waldbahn - Die Länderbahn GmbH DLB
+waldbahn-dlb,RB 36,waldbahn-die-landerbahn-gmbh-dlb,rb36,#90bf26,#ffffff,,rectangle,,10964,waldbahn - Die Länderbahn GmbH DLB
+waldbahn-dlb,RB 37,waldbahn-die-landerbahn-gmbh-dlb,rb37,#ffb200,#ffffff,,rectangle,,10964,waldbahn - Die Länderbahn GmbH DLB
+waldbahn-dlb,RB 38,waldbahn-die-landerbahn-gmbh-dlb,rb38,#ff6600,#ffffff,,rectangle,,10964,waldbahn - Die Länderbahn GmbH DLB
+westfalenbahn,RE 15,westfalenbahn,wfb-re15,#ea9d22,#ffffff,,rectangle,,13291,WestfalenBahn
+westfalenbahn,RE 60,westfalenbahn,wfb-re60,#00a3de,#ffffff,,rectangle,,13291,WestfalenBahn
+westfalenbahn,RE 70,westfalenbahn,wfb-re70,#005174,#ffffff,,rectangle,,13291,WestfalenBahn
+wt-bvo,349,,5-owl021-349,#e20079,#ffffff,,pill,,,
+wt-bvo,350,,5-owl021-350,#004e2d,#ffffff,,pill,,,
+wt-bvo,351,,5-owl021-351,#97bf0d,#002650,,pill,,,
+wt-bvo,S60,,5-vph082-s60,#0089cf,#ffffff,,rectangle,,,
+wt-bvo,S85,,5-vph077-s85,#0089cf,#ffffff,,rectangle,,,
+wt-bvo,S90,,5-vph082-s90,#0089cf,#ffffff,,rectangle,,,
+wt-bvo,R10,,5-vph076-r10,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,R11,,5-vph076-r11,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,R61,,5-vph082-r61,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,R70,,5-vph076-r70,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,R71,,5-vph076-r71,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,R72,,5-vph076-r72,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,R81,,5-vph077-r81,#ed2927,#ffffff,,rectangle,,,
+wt-bvo,480,,5-vph077-480,#36b64b,#ffffff,,rectangle,,,
+wt-bvo,481,,5-vph077-481,#36b64b,#ffffff,,rectangle,,,
+wt-bvo,485,,5-vph077-485,#36b64b,#ffffff,,rectangle,,,
+wt-bvo,487,,5-vph077-487,#36b64b,#ffffff,,rectangle,,,
+wt-bvo,488,,5-vph077-488,#36b64b,#ffffff,,rectangle,,,
+wt-bvo,489,,5-vph077-489,#36b64b,#ffffff,,rectangle,,,
+wt-go-on,R20,,5-vph072-r20,#ed2927,#ffffff,,rectangle,,,
+wt-go-on,R41,,5-vph071-r41,#ed2927,#ffffff,,rectangle,,,
+wt-go-on,R45,,5-vph071-r45,#ed2927,#ffffff,,rectangle,,,
+wt-go-on,R50,,5-vph072-r50,#ed2927,#ffffff,,rectangle,,,
+wt-go-on,R51,,5-vph077-r51,#ed2927,#ffffff,,rectangle,,,
+wt-go-on,S30,,5-vph080-s30,#0089cf,#ffffff,,rectangle,,,
+wt-go-on,S40,,5-vph071-s40,#0089cf,#ffffff,,rectangle,,,
+wt-mobiel,1,mobiel-gmbh,8-owl031-1,#009fe0,#ffffff,,rectangle,,14366,GBN-moBiel-Stadtbahn
+wt-mobiel,2,mobiel-gmbh,8-owl031-2,#008f36,#ffffff,,rectangle,,14366,GBN-moBiel-Stadtbahn
+wt-mobiel,3,mobiel-gmbh,8-owl031-3,#ffed00,#00264f,,rectangle,,14366,GBN-moBiel-Stadtbahn
+wt-mobiel,4,mobiel-gmbh,8-owl031-4,#e3001b,#ffffff,,rectangle,,14366,GBN-moBiel-Stadtbahn
+wt-mobiel,N1,,5-owl032-n1,#002f6b,#ffffff,,rectangle,,,
+wt-mobiel,N2,,5-owl032-n2,#e20040,#ffffff,,rectangle,,,
+wt-mobiel,N3,,5-owl032-n3,#89ba17,#ffffff,,rectangle,,,
+wt-mobiel,N4,,5-owl032-n4,#006ab3,#ffffff,,rectangle,,,
+wt-mobiel,N5,,5-owl032-n5,#93191e,#ffffff,,rectangle,,,
+wt-mobiel,N6,,5-owl032-n6,#eb690b,#ffffff,,rectangle,,,
+wt-mobiel,N7,,5-owl032-n7,#00501f,#ffffff,,rectangle,,,
+wt-mobiel,N8,,5-owl032-n8,#009ee0,#ffffff,,rectangle,,,
+wt-mobiel,N11,,5-owl032-n11,#00acb6,#ffffff,,rectangle,,,
+wt-mobiel,N12,,5-owl032-n12,#96427f,#ffffff,,rectangle,,,
+wt-mobiel,N14,,5-owl032-n14,#c50a33,#ffffff,,rectangle,,,
+wt-mobiel,N15,,5-owl032-n15,#93191e,#ffffff,,rectangle,,,
+wt-mobiel,N18,,5-owl032-n18,#45c0eb,#ffffff,,rectangle,,,
+wt-mobiel,SEV 1,,5-owl032-ev1,#ef93ba,#002650,,pill,,,
+wt-mobiel,S15,,5-owl032-s15,#002650,#ffffff,,pill,,,
+wt-mobiel,21,,5-owl032-21,#d75163,#ffffff,,pill,,,
+wt-mobiel,22,,5-owl032-22,#d75163,#ffffff,,pill,,,
+wt-mobiel,23,,5-owl032-23,#e85b98,#002650,,pill,,,
+wt-mobiel,24,,5-owl032-24,#655a9f,#ffffff,,pill,,,
+wt-mobiel,25,,5-owl032-25,#97bf0d,#002650,,pill,,,
+wt-mobiel,26,,5-owl032-26,#97bf0d,#002650,,pill,,,
+wt-mobiel,27,,5-owl032-27,#f19fc1,#002650,,pill,,,
+wt-mobiel,28,,5-owl032-28,#004178,#ffffff,,pill,,,
+wt-mobiel,29,,5-owl032-29,#f39400,#002650,,pill,,,
+wt-mobiel,30,,5-owl032-30,#007dc4,#ffffff,,pill,,,
+wt-mobiel,31,,5-owl032-31,#655a9f,#ffffff,,pill,,,
+wt-mobiel,32,,5-owl032-32,#97bf0d,#002650,,pill,,,
+wt-mobiel,33,,5-owl032-33,#fbbc00,#002650,,pill,,,
+wt-mobiel,34,,5-owl032-34,#ffe500,#002650,,pill,,,
+wt-mobiel,36,,5-owl032-36,#a53723,#ffffff,,pill,,,
+wt-mobiel,37,,5-owl032-37,#f19fc1,#002650,,pill,,,
+wt-mobiel,38,,5-owl032-38,#004178,#ffffff,,pill,,,
+wt-mobiel,39,,5-owl032-39,#004e2d,#ffffff,,pill,,,
+wt-mobiel,46,,5-owl032-46,#655a9f,#ffffff,,pill,,,
+wt-mobiel,47,,5-owl032-47,#655a9f,#ffffff,,pill,,,
+wt-mobiel,51,,5-owl032-51,#ad8dbc,#002650,,pill,,,
+wt-mobiel,54,,5-owl032-54,#e20079,#ffffff,,pill,,,
+wt-mobiel,55,,5-owl032-55,#a53723,#ffffff,,pill,,,
+wt-mobiel,56,,5-owl032-56,#fbbc00,#002650,,pill,,,
+wt-mobiel,57,,5-owl032-57,#009037,#ffffff,,pill,,,
+wt-mobiel,58,,5-owl032-58,#009037,#ffffff,,pill,,,
+wt-mobiel,63,,5-owl032-63,#172983,#ffffff,,pill,,,
+wt-mobiel,64,,5-owl032-64,#172983,#ffffff,,pill,,,
+wt-mobiel,87,,5-owl032-87,#004e2d,#ffffff,,pill,,,
+wt-mobiel,94,,5-owl032-94,#ad8dbc,#002650,,pill,,,
+wt-mobiel,95,,5-owl032-95,#009037,#ffffff,,pill,,,
+wt-mobiel,101,,5-owl032-101,#e85b98,#002650,,pill,,,
+wt-mobiel,121,,5-owl032-121,#b09d1e,#002650,,pill,,,
+wt-mobiel,122,,5-owl032-122,#007dc4,#ffffff,,pill,,,
+wt-mobiel,123,,5-owl032-123,#007dc4,#ffffff,,pill,,,
+wt-mobiel,128,,5-owl032-128,#f39400,#002650,,pill,,,
+wt-mobiel,131,,5-owl032-131,#d75163,#ffffff,,pill,,,
+wt-mobiel,135,,5-owl032-135,#e20079,#ffffff,,pill,,,
+wt-mobiel,136,,5-owl032-136,#e2001a,#ffffff,,pill,,,
+wt-mobiel,138,,5-owl032-138,#004178,#ffffff,,pill,,,
+wt-mobiel,142,,5-owl032-142,#d75163,#ffffff,,pill,,,
+wt-mobiel,154,,5-owl032-154,#004178,#ffffff,,pill,,,
+wt-mobiel,155,,5-owl032-155,#39a9dc,#002650,,pill,,,
+wt-mobiel,228,,5-owl032-228,#41a62b,#ffffff,,pill,,,
+wt-mobiel,236,,5-owl032-236,#004178,#ffffff,,pill,,,
+wt-mobiel,352,,5-owl032-352,#e2001a,#ffffff,,pill,,,
+wt-mobiel,369,,5-owl032-369,#ad8dbc,#002650,,pill,,,
+wt-padersprinter,N2,,5-vph063-n2,#37ac47,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,N4,,5-vph063-n4,#00b9f2,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,1,,5-vph063-1,#f6c954,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,2,,5-vph063-2,#4eac91,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,3,,5-vph063-3,#9c69af,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,4,,5-vph063-4,#a16335,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,5,,5-vph063-5,#98273b,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,6,,5-vph063-6,#8ad7f4,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,7,,5-vph063-7,#e29042,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,8,,5-vph063-8,#95c65a,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,9,,5-vph063-9,#e98bbd,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,10,,5-vph063-10,#7fba91,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,11,,5-vph063-11,#5d201d,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,12,,5-vph063-12,#18367d,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,13,,5-vph063-13,#5fb458,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,14,,5-vph063-14,#7b4586,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,16,,5-vph063-16,#469cd8,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,20,,5-vph063-20,#7fba91,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,23,,5-vph063-23,#5fb458,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,42,,5-vph063-42,#9b9c9f,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,43,,5-vph063-43,#9b9c9f,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,44,,5-vph063-44,#9b9c9f,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,45,,5-vph063-45,#9b9c9f,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,ALF46,,9-vph063-46alf,#ffffff,#9b9c9f,#9b9c9f,rectangle,,9316,Padersprinter
+wt-padersprinter,47,,5-vph063-47,#9b9c9f,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,48,,5-vph063-48,#9b9c9f,#ffffff,,rectangle,,9316,Padersprinter
+wt-padersprinter,100,,5-vph063-100,#469cd8,#ffffff,,rectangle,,9316,Padersprinter
+wt-rvm,R51,,5-vgm023-r51,#006fb9,#ffffff,,rectangle-rounded-corner,,,
+wt-rvm,S50,,5-vgm020-s50,#c24636,#ffffff,,rectangle-rounded-corner,,,
+wt-twv,N19,,5-owl051-n19,#f7a600,#ffffff,,rectangle,,,
+wt-twv,48,,5-owl051-48,#39a9dc,#002650,,pill,,,
+wt-twv,59,,5-owl051-59,#e2001a,#ffffff,,pill,,,
+wt-twv,61,,5-owl051-61,#39a9dc,#002650,,pill,,,
+wt-twv,62,,5-owl051-62,#39a9dc,#002650,,pill,,,
+wt-twv,80.2,,5-owl050-80-2,#e2001a,#ffffff,,pill,,,
+wt-twv,88,,5-owl051-88,#e85b98,#002650,,pill,,,
+zvnl-bus,60,,5-naslvb-60,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,65,,5-naslvb-65,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,70,,5-naslvb-70,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,72,,5-naslvb-72,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,73,,5-naslvb-73,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,74,,5-naslvb-74,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,80,,5-naslvb-80,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,81,,5-naslvb-81,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,82,,5-naslvb-82,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,89,,5-naslvb-89,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,90,,5-naslvb-90,#a61580,#ffffff,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N1,,5-naslvb-n1,#f5a522,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N2,,5-naslvb-n2,#fee38e,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N3,,5-naslvb-n3,#fed92b,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N4,,5-naslvb-n4,#fed92b,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N5,,5-naslvb-n5,#f5a522,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N6,,5-naslvb-n6,#fed92b,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N7,,5-naslvb-n7,#fee38e,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N8,,5-naslvb-n8,#f5a522,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N9,,5-naslvb-n9,#fed92b,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-bus,N60,,5-naslvb-n60,#a61580,#000000,,pill,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,1,,8-naslvt-1,#67b337,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,2,,8-naslvt-2,#fecb29,#000000,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,3,,8-naslvt-3,#67b337,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,4,,8-naslvt-4,#233b8d,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,7,,8-naslvt-7,#233b8d,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,8,,8-naslvt-8,#fecb29,#000000,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,9,,8-naslvt-9,#fecb29,#000000,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,10,,8-naslvt-10,#e1001e,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,11,,8-naslvt-11,#e1001e,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,12,,8-naslvt-12,#233b8d,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,14,,8-naslvt-14,#18a0e1,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,15,,8-naslvt-15,#233b8d,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,16,,8-naslvt-16,#e1001e,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,50,,8-naslvt-50,#ffffff,#000000,#000000,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,56,,8-naslvt-56,#ffffff,#000000,#000000,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,N10,,8-naslvt-n10,#e1001e,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe
+zvnl-tram,N17,,8-naslvt-n17,#67b337,#ffffff,,rectangle,,8872,Leipziger Verkehrsbetriebe


### PR DESCRIPTION
Hey everyone,

so as you know, since DB HAFAS can't be used anymore since January, Träwelling and other services have started using Transitous. This uses the DELFI GTFS feeds. 

I have added almost all DELFI Agency ID/Nane mappings to the line colors csv. I'm not sure with every mapping, hence I left some blank. Especially non-German lines can't be used, obviously.
I'm not sure if this is something you want, or if it is useful in the longrun. I mostly created this mapping for my own project. 

In theory, you would compare the MOTIS DELFI output with the line number and agency ID/Name to the csv to find the correct line colors. Main issue: It can only be used if the Delfi feed is used, as GTFS IDs obviously aren't unique.

Please leave your feedback. I hope this is one step to establishing line colors for services again.