### PR TITLE
Update line colors and wikiData for Tram and S-Bahn Dresden

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -2254,11 +2254,11 @@ vvo-ferry,F17,,6-voe091-f17,#00a5df,#ffffff,,rectangle-rounded-corner,,,
 vvo-tram,1,,8-voe011-1,#e30018,#ffffff,,rectangle-rounded-corner,Q91659218,8190,DVB-Straßenbahn
 vvo-tram,2,,8-voe011-2,#eb5b2d,#ffffff,,rectangle-rounded-corner,Q91659698,8190,DVB-Straßenbahn
 vvo-tram,3,,8-voe011-3,#e5005a,#ffffff,,rectangle-rounded-corner,Q89494370,8190,DVB-Straßenbahn
-vvo-tram,4,,8-voe011-4,#92C255,#ffffff,,rectangle-rounded-corner,Q91660551,8190,DVB-Straßenbahn
+vvo-tram,4,,8-voe011-4,#92c255,#ffffff,,rectangle-rounded-corner,Q91660551,8190,DVB-Straßenbahn
 vvo-tram,6,,8-voe011-6,#ffdd00,#000000,,rectangle-rounded-corner,Q93766509,8190,DVB-Straßenbahn
 vvo-tram,7,,8-voe011-7,#9e0234,#ffffff,,rectangle-rounded-corner,Q91660996,8190,DVB-Straßenbahn
 vvo-tram,8,,8-voe011-8,#229133,#ffffff,,rectangle-rounded-corner,Q64022460,8190,DVB-Straßenbahn
-vvo-tram,9,,8-voe011-9,#C8061A,#ffffff,,rectangle-rounded-corner,Q93767104,8190,DVB-Straßenbahn
+vvo-tram,9,,8-voe011-9,#c8061a,#ffffff,,rectangle-rounded-corner,Q93767104,8190,DVB-Straßenbahn
 vvo-tram,10,,8-voe011-10,#f9b000,#ffffff,,rectangle-rounded-corner,Q93767517,8190,DVB-Straßenbahn
 vvo-tram,11,,8-voe011-11,#c2ddaf,#000000,,rectangle-rounded-corner,Q91034464,8190,DVB-Straßenbahn
 vvo-tram,12,,8-voe011-12,#006b42,#ffffff,,rectangle-rounded-corner,Q93767629,8190,DVB-Straßenbahn


### PR DESCRIPTION
Updated and appended the lines for Dresden tram and Dresden S-Bahn:

- Updated line colors for DVB lines 4 and 9
- Added WikiData QIDs for various tram and S-Bahn lines
- Added Delphi agency IDs and carrier information for various tram lines