### PR TITLE
added swiss routes (as a test)

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -55,6 +55,9 @@ ceske-drahy,RE 25,ceske-drahy,ex-362,#006666,#ffffff,,rectangle,,12634,Ceske Dra
 ceske-drahy,RE 25,ceske-drahy,ex-364,#006666,#ffffff,,rectangle,,12634,Ceske Drahy
 cfl,RE 11,cfl,re-11,#20b159,#ffffff,,rectangle,,10459,CFL1
 cfl,RB 83,cfl,rb-83,#20b159,#ffffff,,rectangle,,10459,CFL1
+ch-bernmobil,10,,,#00A65A,#ffffff,,rectangle,,827,Städtische Verkehrsbetriebe Bern
+ch-vbz-tram,2,,,#EC1F25,#ffffff,,rectangle,,849,Verkehrsbetriebe Zürich
+ch-vbz-tram,8,,,#A4CE3A,#ffffff,,rectangle,,849,Verkehrsbetriebe Zürich
 db-fernverkehr-ag,RE 87,db-fernverkehr-ag,re-87,#cc0066,#ffffff,,rectangle,,10918,DB Fernverkehr (Codesharing)
 db-regio-ag-baden-wurttemberg,RE 2,db-regio-ag-baden-wurttemberg,re-2,#0069b4,#ffffff,,rectangle,Q88627355,10443,DB Regio AG Baden-Württemberg
 db-regio-ag-baden-wurttemberg,RE 3,db-regio-ag-baden-wurttemberg,re-3,#e5007d,#ffffff,,rectangle,,10443,DB Regio AG Baden-Württemberg


### PR DESCRIPTION
I've added some Swiss tram and bus routes to the line-colors.csv file because of a [comment](https://github.com/Traewelling/line-colors/issues/273#issuecomment-3567820321) on PR #273 regarding that.

I've tested this with a Transitous branch in my own repos and the Python script to generate colours just doesn't care and adds the Swiss routes to the file.

As far as I can tell, there are no colliding agency IDs in the Swiss and German GTFS files, so just using one CSV for both countries seems to work just fine.

I'll let you discuss that (thus a PR draft) but there shouldn't be a reason why this shouldn't work.