### PR TITLE
Improved readability of Rheinbahn bus routes

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -2361,8 +2361,6 @@ vrr-sr,671,,,#b43e75,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
 vrr-sr,672,,,#e20229,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
 vrr-sr,673,,,#ee7454,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
 vrr-sr,675,,,#004d9e,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
-vrr-sr,683,,,#ec6da6,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
-vrr-sr,687,,,#ec6da6,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
 vrr-sr,CE63,,,#cf0006,#ffffff,,rectangle,,7781,Stadtwerke Remscheid
 vrr-swk,041,,8-vrr001-041,#fb2513,#ffffff,,rectangle-rounded-corner,,7777,Städtische Werke Krefeld Strab
 vrr-swk,042,,8-vrr001-042,#fe8480,#ffffff,,rectangle-rounded-corner,,7777,Städtische Werke Krefeld Strab


### PR DESCRIPTION
Improved the readability by adjusting the text colour to black, which offers a way better contrast than the grey-ish black before.