### PR TITLE
(MERGE ON 2025-12-14) Bus route gets withdrawn from service

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -2576,7 +2576,6 @@ vrs-bus,Berg. FahrradBus,,5-vrs016-bf,#000000,#ffffff,,rectangle,,,
 vrs-bus,SB33,,5-vrr076-sb33,#81c9ef,#ffffff,,rectangle,,,
 vrs-bus,SB42,,5-vrs003-sb25,#176438,#ffffff,,rectangle,,,
 vrs-bus,SB69,,5-vrs006-sb69,#df6a3c,#ffffff,,rectangle,,,
-vrs-bus,X24,,5-vrs003-x24,#243d98,#ffffff,,rectangle,,,
 vrs-kvb,106,,,#097cc1,#ffffff,,rectangle,,7969,Kölner VB
 vrs-kvb,118,,,#85d1f5,#ffffff,,rectangle,,7969,Kölner VB
 vrs-kvb,120,,,#e30a18,#ffffff,,rectangle,,7969,Kölner VB


### PR DESCRIPTION
Bus route 812 gets withdrawn from service, that's basically it

https://www.swb-busundbahn.de/aktuelle-meldungen/details/neuer-fahrplan-gilt-ab-14-dezember/