### PR TITLE
 (MERGE ON 2025-12-14) VVS/bwegt - New schedule from 14 December

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -232,8 +232,6 @@ db-regio-stuttgart,RE 18,,,#009c48,#ffffff,,rectangle,Q131583931,14172,SWEG Bahn
 db-regio-stuttgart,RE 71,,,#b6921d,#ffffff,,rectangle,Q131584454,14172,SWEG Bahn Stuttgart
 db-regio-stuttgart,MEX 12,,,#f27320,#ffffff,,rectangle,Q131584405,14172,SWEG Bahn Stuttgart
 db-regio-stuttgart,MEX 17,,,#561d6f,#ffffff,,rectangle,Q131584401,14172,SWEG Bahn Stuttgart
-db-regio-stuttgart,MEX 17a,,,#561d6f,#ffffff,,rectangle,Q131584401,14172,SWEG Bahn Stuttgart
-db-regio-stuttgart,MEX 17c,,,#ec2933,#ffffff,,rectangle,Q131584403,14172,SWEG Bahn Stuttgart
 db-regio-stuttgart,MEX 18,,,#009c48,#ffffff,,rectangle,Q131584398,14172,SWEG Bahn Stuttgart
 db-regio-stuttgart,RB 10a,,,#9f5a2c,#ffffff,,rectangle,Q131587496,14172,SWEG Bahn Stuttgart
 db-regio-stuttgart,RB 17,,,#561d6f,#ffffff,,rectangle,Q131584392,14172,SWEG Bahn Stuttgart


### PR DESCRIPTION
**VVS:**
- MEX 17a/c services will run as MEX 17
- MEX 17c/RB17c services will run as RB71
https://vpe.de/pdf/fahrplan/presse/VPE_PM_Doppelter%20Fahrplanwechsel_lang_.pdf