### PR TITLE
fix the hexagon with border color

### DIFF
--- a/website/index.php
+++ b/website/index.php
@@ -167,8 +167,7 @@ include_once "../validation/common.php";
                             line-height: 1.2em;
 
                             padding: 0 0.75em;
-                            /* TODO: consider the edge case of border around a hexagon shape */
-                            clip-path: polygon(50% -100%, 100% 50%, 50% 200%, 0 50%);
+                            clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
                         }
 
                     </style>


### PR DESCRIPTION
Should fix this problem with the hexagon, if a border color is used too. ("should" fix that, because like with the circle, I had no way to check if this is working properly)

<img width="1005" height="174" alt="Screenshot 2025-12-22 at 12-59-30 line-colors Träwelling" src="https://github.com/user-attachments/assets/56cbcefa-2829-4674-a766-b0807697bf6f" />


Here some normal hexagons for comparison, so you see the difference:

<img width="975" height="160" alt="Screenshot 2025-12-22 at 13-02-46 line-colors Träwelling" src="https://github.com/user-attachments/assets/e3cb0245-0f9a-4c40-81f9-9903c2dfad03" />
