### PR TITLE
New color for DB Regio Stuttgart RE17

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -501,7 +501,7 @@ db-regio-nordost,S3,db-regio-ag-nordost,4-800156-3,#a64c35,#ffffff,,rectangle,,1
 db-regio-stuttgart,RE 6,,,#ebaf2d,#ffffff,,rectangle,Q131584411,15252,DB Regio Stuttgart
 db-regio-stuttgart,RE 10a,,,#9f5a2c,#ffffff,,rectangle,Q131584412,15252,DB Regio Stuttgart
 db-regio-stuttgart,RE 10b,,,#9f5a2c,#ffffff,,rectangle,Q131584450,15252,DB Regio Stuttgart
-db-regio-stuttgart,RE 17,,,#561d6f,#ffffff,,rectangle,,15252,DB Regio Stuttgart
+db-regio-stuttgart,RE 17,,,#ec6d18,#ffffff,,rectangle,,15252,DB Regio Stuttgart
 db-regio-stuttgart,RE 18,,,#009c48,#ffffff,,rectangle,Q131583931,15252,DB Regio Stuttgart
 db-regio-stuttgart,RE 71,,,#b6921d,#ffffff,,rectangle,Q131584454,15252,DB Regio Stuttgart
 db-regio-stuttgart,MEX 12,,,#f27320,#ffffff,,rectangle,Q131584405,15252,DB Regio Stuttgart

--- a/sources.json
+++ b/sources.json
@@ -3925,7 +3925,7 @@
             },
             {
                 "name": "Liniennetzkarte Regionalverkehr 2026",
-                "source": "https://www.bwegt.de/fileadmin/media/PDF/Karten/Liniennetzkarte/bwegt_Karte_Liniennetzkarte_Regionalverkehr_14-12-2025_barrierefrei.pdf"
+                "source": "https://www.bwegt.de/fileadmin/media/PDF/Karten/Liniennetzkarte/bwegt_Karte_Liniennetzkarte_Regionalverkehr_16-06-2026_barrierefrei.pdf"
             }
         ]
     },


### PR DESCRIPTION
RE17 Pforzheim - Bad Wildbad (operated by DB Regio Stuttgart) now has an own official line color according to https://www.bwegt.de/fileadmin/media/PDF/Karten/Liniennetzkarte/bwegt_Karte_Liniennetzkarte_Regionalverkehr_16-06-2026_barrierefrei.pdf