### PR TITLE
Bielefeld tram replacement buses

### DIFF
--- a/line-colors.csv
+++ b/line-colors.csv
@@ -6695,6 +6695,8 @@ wt-mobiel,N14,,5-owl032-n14,#c51931,#ffffff,,rectangle,,14366,GBN-moBiel-Stadtba
 wt-mobiel,N15,,5-owl032-n15,#af4b21,#ffffff,,rectangle,,14366,GBN-moBiel-Stadtbahn
 wt-mobiel,N18,,5-owl032-n18,#40c0f0,#ffffff,,rectangle,,14366,GBN-moBiel-Stadtbahn
 wt-mobiel,S15,,5-owl032-s15,#002650,#ffffff,,pill,Q131862834,14366,GBN-moBiel-Stadtbahn
+wt-mobiel,SEV,,,#002453,#fdfeff,,pill,,14366,GBN-moBiel-Stadtbahn
+wt-mobiel,SEV 3,,,#f5d300,#002453,,pill,,14366,GBN-moBiel-Stadtbahn
 wt-mobiel,21,,5-owl032-21,#d75162,#ffffff,,pill,,14366,GBN-moBiel-Stadtbahn
 wt-mobiel,22,,5-owl032-22,#d75162,#ffffff,,pill,,14366,GBN-moBiel-Stadtbahn
 wt-mobiel,23,,5-owl032-23,#e85a98,#002650,,pill,,14366,GBN-moBiel-Stadtbahn

--- a/sources.json
+++ b/sources.json
@@ -6927,6 +6927,10 @@
             {
                 "name": "NachtBus-Linie N14: Fahrplan & Linienweg",
                 "source": "https://www.mobiel.de/fileadmin/user_upload/Downloads/NachtBus/N14_Fahrplan_und_Linienweg.pdf"
+            },
+            {
+                "name": "Stadtbahn SEV Sommer 2026",
+                "source": "https://www.mobiel.de/fileadmin/user_upload/Allgemein/2026_News/SEV-Sommerferien/StadtBahn_SEV_Sommer_2026.pdf"
             }
         ]
     },


### PR DESCRIPTION
[Maintenance is being carried out in the Stadtbahn tunnel](https://www.mobiel.de/aktuelles/aktuelle-news/ersatzverkehr-mit-bussen-ab-207/) this summer. Thus, there are two new lines that will be operating until 2026-09-01, SEV and SEV 3.

Although line 3 has been fully replaced for this month, I do not think it is a good idea to remove the data set, as it will obviously return relatively soon.

Adds colours for SEV and SEV 3, as well as a source for both.